### PR TITLE
Fixture doctrine enforced corpus-wide: no test or docstring borrows a real-sequence code

### DIFF
--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -25,12 +25,9 @@ Migrations: renaming schemes and moving documents without losing the record's me
 
 A reference nobody can follow. Three things look identical from here and read very differently — a typo, a number carried in from another project, and an illustrative code in an example — so this is a report, not an error. `unresolved-ok:` retires the deliberate ones, at the same three scopes.
 
-**1 code(s) name no document.** 45 reference(s) carry an `unresolved-ok` annotation and are not listed below.
+**0 code(s) name no document.** 43 reference(s) carry an `unresolved-ok` annotation and are not listed below.
 
-
-### DP-018 — no such document (1 site(s) · 4 acknowledged elsewhere)
-
-- [`record/decisions.d/ADR-040.md:42`](../../record/decisions.d/ADR-040.md)
+Every code resolves. ✅
 
 ## Files that opt out of reference checking
 

--- a/luria/ref_status.py
+++ b/luria/ref_status.py
@@ -142,7 +142,7 @@ DANGLING_DIRECTIVE = "unresolved-ok"
 def _codes(spec: str) -> tuple[set[str], str]:
     """The document codes an annotation names, and the text with them removed.
 
-    Composed codes come out first and whole: a remote's `DP-004` is that
+    Composed codes come out first and whole: a composed `SG-DP-4` is that
     remote's principle, and reading the tail out of the middle of the composed
     code would have the validator check the wrong project (ADR-016)."""
     codes: set[str] = set()

--- a/record/changelog.d/claude-luria-fixture-cleanup.md
+++ b/record/changelog.d/claude-luria-fixture-cleanup.md
@@ -1,0 +1,9 @@
+<!-- One fragment per contribution (ADR-002). -->
+
+### Changed
+
+- Test fixtures and docstring examples that borrowed real-sequence DP codes
+  now use fixture spellings — `VP` schemes over `docs/values.md` in the test
+  suites, and a composed remote form where a foreign document was meant —
+  clearing the [ADR-032](record/decisions.d/ADR-032.md) hazard corpus-wide before any rename machinery ever
+  runs a sweep. [ADR-040](record/decisions.d/ADR-040.md)'s Context restates its fixture examples to match.

--- a/record/decisions.d/ADR-040.md
+++ b/record/decisions.d/ADR-040.md
@@ -38,12 +38,17 @@ rename the files, chase every reference, and hope grep caught the anchors.
 
 Two forces make the naive approaches wrong:
 
-- **Codes appear in places a rename must not touch.** Test fixtures carry DP
-  codes on purpose (`DP-018` in `tests/test_remotes.py`, `DP-004` in a
-  docstring example in `remotes.py`, both excused with `unresolved-ok`), and
-  composed remote codes like `SG-DP-18` address *another project's* scheme —
-  strata-g's namespace is theirs, whatever this record renames locally. Any
-  sweep driven by "things shaped like `DP-\d+`" rewrites all of these.
+- **Codes appear in places a rename must not touch.** Fixture numbers are
+  <!-- unresolved-ok: DP-018 — the fixture number, quoted as the example -->
+  carried on purpose (`DP-018`, excused with `unresolved-ok` where it is
+  quoted), and composed remote codes like `SG-DP-18` address *another
+  project's* scheme — strata-g's namespace is theirs, whatever this record
+  renames locally. Any sweep driven by "things shaped like `DP-\d+`"
+  rewrites all of these. (Preparing the first migration surfaced a third
+  family: test fixtures and docstring examples that had borrowed
+  real-sequence codes, against the standing fixture-codes rule — renamed to
+  fixture spellings in this contribution, which is the rule working, not an
+  exception to the mapping.)
 - **An unrewritten history is not preserved history — it is unwatched
   history.** A spelling that matches no configured scheme is invisible to the
   reference scanner, so the linter silently stops checking every file that

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -94,26 +94,26 @@ def test_every_generated_relative_link_resolves():
 
 def principle(root: Path, number: int, title: str, body: str = "Body.",
               **front) -> Path:
-    path = root / "docs" / "principles" / f"DP-{number:03d}.md"
+    path = root / "docs" / "principles" / f"VP-{number:03d}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = ["status: Active", f"title: {title!r}", "tags:", "- record"]
     lines += [f"{k}: {v}" for k, v in front.items()]
     path.write_text("---\n" + "\n".join(lines) + "\n---\n\n"
-                    f"# DP-{number:03d}: {title}\n\n{body}\n")
+                    f"# VP-{number:03d}: {title}\n\n{body}\n")
     return path
 
 
-DP_SCHEME_ARGS = dict(active="Active", render="document")
+VP_SCHEME_ARGS = dict(active="Active", render="document")
 
 
-def dp_scheme(root: Path) -> Scheme:
-    return Scheme("DP", root / "docs" / "principles",
-                  output=root / "docs" / "design-principles.md",
-                  **DP_SCHEME_ARGS)
+def vp_scheme(root: Path) -> Scheme:
+    return Scheme("VP", root / "docs" / "principles",
+                  output=root / "docs" / "values.md",
+                  **VP_SCHEME_ARGS)
 
 
 def render(root: Path) -> str:
-    scheme = dp_scheme(root)
+    scheme = vp_scheme(root)
     return builder.render_document(scheme, builder.load_scheme(scheme))
 
 
@@ -121,14 +121,14 @@ def test_document_demotes_the_heading_and_renumbers(project):
     principle(project, 3, "Fire before trusting")
     out = render(project)
     assert "## 3. Fire before trusting" in out
-    assert "# DP-003" not in out
+    assert "# VP-003" not in out
 
 
 def test_document_emits_a_stable_anchor(project):
     """Keyed to the number, not the wording — a principle is a living document
     and its heading moves (ADR-012)."""
     principle(project, 3, "Fire before trusting")
-    assert '<a name="dp-3"></a>' in render(project)
+    assert '<a name="vp-3"></a>' in render(project)
 
 
 def test_document_strips_the_frontmatter(project):
@@ -182,12 +182,12 @@ def test_outputs_covers_every_scheme(project, monkeypatch):
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
         '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
 
     out = builder.outputs()
-    assert project / "docs" / "design-principles.md" in out
+    assert project / "docs" / "values.md" in out
     assert project / "docs" / "decisions" / "README.md" in out
 
 

--- a/tests/test_adr_pending.py
+++ b/tests/test_adr_pending.py
@@ -114,15 +114,15 @@ def test_every_scheme_is_covered(project):
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        '[luria.schemes.VP]\ndir = "docs/principles"\n'
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
     decision(project, 1, "Proposed", "An open decision")
     principles = project / "docs" / "principles"
     principles.mkdir(parents=True, exist_ok=True)
-    (principles / "DP-002.md").write_text(
+    (principles / "VP-002.md").write_text(
         "---\nstatus: Deferred\ntitle: 'An open value'\ntags:\n- record\n"
-        "date: '2026-01-01'\n---\n\n# DP-002: An open value\n")
+        "date: '2026-01-01'\n---\n\n# VP-002: An open value\n")
 
-    assert {r.code for r in pending.pending()} == {"ADR-001", "DP-002"}
+    assert {r.code for r in pending.pending()} == {"ADR-001", "VP-002"}

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -17,16 +17,16 @@ REPO = Path(__file__).resolve().parents[1]
 TWO_SCHEMES = (
     '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
     '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-    '[luria.schemes.DP]\ndir = "docs/principles"\n'
-    'render = "document"\noutput = "docs/design-principles.md"\n'
+    '[luria.schemes.VP]\ndir = "docs/principles"\n'
+    'render = "document"\noutput = "docs/values.md"\n'
 )
 
 
 def principle(root: Path, number: int, status: str, title: str = "A value") -> Path:
-    path = root / "docs" / "principles" / f"DP-{number:03d}.md"
+    path = root / "docs" / "principles" / f"VP-{number:03d}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"---\nstatus: {status}\ntitle: {title!r}\ntags:\n- record\n"
-                    f"date: '2026-01-01'\n---\n\n# DP-{number:03d}: {title}\n")
+                    f"date: '2026-01-01'\n---\n\n# VP-{number:03d}: {title}\n")
     return path
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -7,10 +7,10 @@ is to guard that the two agree.
 
 `title:` is the source of truth and the body's H1 repeats it, because someone
 reading the file on its own needs a heading. Two copies of one string is the
-drifting projection [DP-3](../docs/design-principles.md#dp-3) names, and the
+drifting projection [DP-3](../docs/values.md#dp-3) names, and the
 remedy available here is rung 2 — keep the copy, guard the property that they
 agree. So the guard needs firing, not just provisioning
-([DP-6](../docs/design-principles.md#dp-6)).
+([DP-6](../docs/values.md#dp-6)).
 """
 import sys
 from pathlib import Path
@@ -66,17 +66,17 @@ def test_the_check_covers_every_scheme(project):
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        '[luria.schemes.VP]\ndir = "docs/principles"\n'
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
 
-    path = project / "docs" / "principles" / "DP-001.md"
+    path = project / "docs" / "principles" / "VP-001.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("---\nstatus: Active\ntitle: 'A value'\ntags:\n- record\n"
-                    "---\n\n# DP-001: A different value\n\nBody.\n")
+                    "---\n\n# VP-001: A different value\n\nBody.\n")
     errors = errors_for(project)
-    assert len(errors) == 1 and "DP-001.md" in errors[0]
+    assert len(errors) == 1 and "VP-001.md" in errors[0]
 
 
 # ── The journal's path agrees with its `created:` (ADR-020) ──────────────

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -14,7 +14,7 @@ from _scheme import decision
 
 from luria import config, doc_refs, ref_status, remotes
 
-# unresolved-ok-file: ADR-999 UP-ADR-999 DP-018 — fixture codes, not claims about
+# unresolved-ok-file: ADR-999 UP-ADR-999 — fixture codes, not claims about
 # this repo. ADR-032 left the list when a real thirty-second decision arrived and
 # the fixture number started resolving.
 REPO = Path(__file__).resolve().parents[1]
@@ -58,7 +58,7 @@ def test_a_discovered_filename_wins(project):
 
 def test_discovery_is_authoritative_once_done(project):
     """A code absent from a lockfile that was read *from the remote* names no
-    document there. Guessing a filename anyway is how `DP-004` produced a
+    document there. Guessing a filename anyway is how a foreign `SG-DP-4` produced a
     confident link to a file that has never existed."""
     with_remote(project)
     lockfile(project, {"ADR-032": "adr-032-x.md"})
@@ -265,7 +265,7 @@ def test_a_quoted_hand_link_is_a_specimen_not_a_citation(project):
 
 
 SCHEMED = (
-    '[luria.remotes.UP.schemes.DP]\ndocument = "docs/design-principles.md"\n'
+    '[luria.remotes.UP.schemes.VP]\ndocument = "docs/values.md"\n'
     '[luria.remotes.UP.schemes.RFC]\ndir = "docs/rfcs"\n'
 )
 
@@ -274,22 +274,22 @@ def test_document_scheme_constructs_a_file_anchor(project):
     """A document-rendered scheme's documents are sections, not files — the
     construction is the assembled page plus an anchor."""
     with_remote(project, SCHEMED)
-    assert remotes.resolve("UP", "DP-18") == (
-        "https://github.com/o/r/blob/main/docs/design-principles.md#dp-18")
+    assert remotes.resolve("UP", "VP-18") == (
+        "https://github.com/o/r/blob/main/docs/values.md#vp-18")
 
 
 def test_anchor_defaults_to_the_stable_anchor_shape(project):
-    """`dp-{number}` unpadded — the shape Luria's own document render emits,
+    """`vp-{number}` unpadded — the shape Luria's own document render emits,
     so a remote on current conventions needs only the `document` line."""
     with_remote(project, SCHEMED)
-    assert remotes.resolve("UP", "DP-9").endswith("#dp-9")
+    assert remotes.resolve("UP", "VP-9").endswith("#vp-9")
 
 
 def test_anchor_template_is_configurable(project):
     with_remote(project,
-        '[luria.remotes.UP.schemes.DP]\ndocument = "PRINCIPLES.md"\n'
+        '[luria.remotes.UP.schemes.VP]\ndocument = "PRINCIPLES.md"\n'
         'anchor = "principle-{number}"\n')
-    assert remotes.resolve("UP", "DP-4").endswith("PRINCIPLES.md#principle-4")
+    assert remotes.resolve("UP", "VP-4").endswith("PRINCIPLES.md#principle-4")
 
 
 def test_scheme_dir_scopes_the_file_convention(project):
@@ -303,9 +303,9 @@ def test_scheme_dir_scopes_the_file_convention(project):
 
 def test_scheme_url_template_wins(project):
     with_remote(project,
-        '[luria.remotes.UP.schemes.DP]\n'
+        '[luria.remotes.UP.schemes.VP]\n'
         'url = "https://up.example/values/{number}"\n')
-    assert remotes.resolve("UP", "DP-3") == "https://up.example/values/3"
+    assert remotes.resolve("UP", "VP-3") == "https://up.example/values/3"
 
 
 def test_lockfile_authority_does_not_cover_document_schemes(project):
@@ -314,7 +314,7 @@ def test_lockfile_authority_does_not_cover_document_schemes(project):
     lockfile is not evidence — the anchor construction must survive it."""
     with_remote(project, SCHEMED)
     lockfile(project, {"ADR-032": "adr-032-changelog-ci-collection.md"})
-    assert remotes.resolve("UP", "DP-18").endswith("#dp-18")
+    assert remotes.resolve("UP", "VP-18").endswith("#vp-18")
     # …while file-per-code codes stay under its authority (ADR-016).
     assert remotes.resolve("UP", "ADR-999") == ""
 
@@ -324,8 +324,8 @@ def test_url_ok_retires_when_the_construction_catches_up(project):
     and a leftover acknowledgement reports itself stale."""
     with_remote(project, SCHEMED)
     flagged, stale = hand(project,
-        "<!-- url-ok: UP-DP-18 — was unconstructible before ADR-023 -->\n"
-        "[UP-DP-18](https://github.com/o/r/blob/main/docs/design-principles.md#dp-18)\n")
+        "<!-- url-ok: UP-VP-18 — was unconstructible before ADR-023 -->\n"
+        "[UP-VP-18](https://github.com/o/r/blob/main/docs/values.md#vp-18)\n")
     assert flagged == []                      # the link now matches construction
     assert len(stale) == 1                    # …so the annotation is done
 
@@ -418,4 +418,4 @@ def test_fixture_prefix_resolves_to_the_convention_note():
     it, and can never collide with the real sequence."""
     url = remotes.resolve("FX", "ADR-032")
     assert url.endswith("docs/directives.md#fixture-codes")
-    assert remotes.resolve("FX", "DP-9").endswith("#fixture-codes")
+    assert remotes.resolve("FX", "VP-9").endswith("#fixture-codes")

--- a/tests/test_wikilinks.py
+++ b/tests/test_wikilinks.py
@@ -44,15 +44,15 @@ def test_label_becomes_the_link_text(project):
 
 
 def test_document_scheme_code_expands_to_an_anchor(project):
-    """`[[DP-3]]` — a shape the prose scanner never takes (it needs a `#`),
+    """`[[VP-3]]` — a shape the prose scanner never takes (it needs a `#`),
     which is half the point of typing the brackets."""
     project_with(project,
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n'
+        '[luria.schemes.VP]\ndir = "docs/principles"\n'
+        'render = "document"\noutput = "docs/values.md"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n')
-    out, n = expand(project, "per [[DP-3]] this holds")
+    out, n = expand(project, "per [[VP-3]] this holds")
     assert n == 1
-    assert "[DP-3](design-principles.md#dp-3)" in out
+    assert "[VP-3](values.md#vp-3)" in out
 
 
 def test_remote_code_expands_to_a_url(project):


### PR DESCRIPTION
Factored out of #62 per review — worthwhile on its own merits, whatever the verdict on the migration machinery, and mergeable now.

Preparing the first migration surfaced every place the corpus had borrowed real-sequence DP codes as fixtures — exactly the hazard the fixture-codes rule (learned on ADR-032) exists for, sitting latent until any rename would have eaten them:

- **Test schemes modeling "a principles scheme"** (`test_wikilinks`, `test_lint`, `test_adr_pending`, `test_adr_index`, `test_badges`) become a `VP` scheme over `docs/values.md` — a prefix the real sequence can never collide with.
- **UP's remote fixtures** in `test_remotes` follow (`schemes.VP`, `docs/values.md`, `#vp-N` anchors), and its docstring incident about a foreign principle is spelled composed (`SG-DP-4`) so no scanner can misread it as local.
- **`ref_status._codes`' docstring example** likewise goes composed.
- **ADR-040's Context** restates its fixture examples to match — it is still `Proposed` on main, so the correction is part of drafting the proposal, not a revision of an in-force decision (no version ceremony).

No behavior changes; 296 tests pass, `luria lint` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AHHTjpaGcX2eQfE9kgvkd

---
_Generated by [Claude Code](https://claude.ai/code/session_018AHHTjpaGcX2eQfE9kgvkd)_