### PR TITLE
docs: scaffold with `luria new <kind>`, not by copying `_template.md`

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Run `luria new adr`; it takes the next
-free number and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
+future edit could silently violate. Run `luria new adr`; it assigns the
+identity and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../../docs/design-principles.md) instead. The split, and why

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Copy [`_template.md`](../../record/decisions.d/_template.md); the
-number is the next one free.
+future edit could silently violate. Run `luria new adr`; it takes the next
+free number and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../../docs/design-principles.md) instead. The split, and why

--- a/record/changelog.d/docs-scaffold-with-luria-new.md
+++ b/record/changelog.d/docs-scaffold-with-luria-new.md
@@ -1,0 +1,10 @@
+### Documentation
+
+- Templates and the decisions stub now point at **`luria new <kind>`** instead
+  of telling the reader to copy `_template.md` by hand. The copy instruction
+  predates the command and had outlived it: `new`'s kinds are derived from
+  config, so `luria new <kind>` works for a scheme the moment it is declared,
+  and it takes the next free number — which hand-copying does not, and which is
+  how two branches end up claiming one number. Fixed in both the shipped
+  `template/` scaffold and this project's own record, so an adopter and a
+  maintainer read the same instruction.

--- a/record/changelog.d/docs-scaffold-with-luria-new.md
+++ b/record/changelog.d/docs-scaffold-with-luria-new.md
@@ -4,7 +4,11 @@
   of telling the reader to copy `_template.md` by hand. The copy instruction
   predates the command and had outlived it: `new`'s kinds are derived from
   config, so `luria new <kind>` works for a scheme the moment it is declared,
-  and it takes the next free number — which hand-copying does not, and which is
-  how two branches end up claiming one number. Fixed in both the shipped
+  and it assigns the identity — which hand-copying does not, and which is how
+  two branches end up claiming one number. Which identity depends on the
+  scheme's `allocate` mode, so the comment names the mechanism rather than one
+  of its two outcomes: `filing` takes the next free number on the spot, `merge`
+  mints a temporary code that `luria concretize` numbers where merges
+  serialize. Fixed in both the shipped
   `template/` scaffold and this project's own record, so an adopter and a
   maintainer read the same instruction.

--- a/record/decisions.d/README.stub
+++ b/record/decisions.d/README.stub
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Run `luria new adr`; it takes the next
-free number and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
+future edit could silently violate. Run `luria new adr`; it assigns the
+identity and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../../docs/design-principles.md) instead. The split, and why

--- a/record/decisions.d/README.stub
+++ b/record/decisions.d/README.stub
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Copy [`_template.md`](../../record/decisions.d/_template.md); the
-number is the next one free.
+future edit could silently violate. Run `luria new adr`; it takes the next
+free number and scaffolds from [`_template.md`](../../record/decisions.d/_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../../docs/design-principles.md) instead. The split, and why

--- a/record/decisions.d/_template.md
+++ b/record/decisions.d/_template.md
@@ -1,6 +1,9 @@
 ---
-# Don't copy this file by hand — run `luria new adr`, which takes the next free
-# number and fills in the fields a machine can compute. The kinds are the
+# Don't copy this file by hand — run `luria new adr`, which assigns the
+# identity and fills in the fields a machine can compute. WHICH identity
+# depends on the scheme's `allocate` mode: `filing` (the default) takes the
+# next free number on the spot, `merge` mints a temporary code that
+# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
 # config: every scheme, fragment directory and journal in luria.toml is one, so
 # `luria new <kind>` works for a scheme the moment it is declared.
 #

--- a/record/decisions.d/_template.md
+++ b/record/decisions.d/_template.md
@@ -1,8 +1,13 @@
 ---
-# Copy this file to ADR-<NNN>.md — next number wins, numbering is sequential and
-# carries information (it's the order decisions were made). The filename is the
-# code and nothing else; the title goes in `title:` below, where correcting it
-# costs an edit rather than a rename plus every link (ADR-013).
+# Don't copy this file by hand — run `luria new adr`, which takes the next free
+# number and fills in the fields a machine can compute. The kinds are the
+# config: every scheme, fragment directory and journal in luria.toml is one, so
+# `luria new <kind>` works for a scheme the moment it is declared.
+#
+# Numbering is sequential and carries information (it's the order decisions were
+# made). The filename is the code and nothing else; the title goes in `title:`
+# below, where correcting it costs an edit rather than a rename plus every link
+# (ADR-013).
 #
 # This frontmatter is the ONLY place these facts live. The index and the per-tag
 # pages are generated from it (ADR-004) — never edit them by hand; run

--- a/record/principles.d/_template.md
+++ b/record/principles.d/_template.md
@@ -1,10 +1,15 @@
 ---
-# Don't copy this file by hand — run `luria new dp`, which takes the next free
-# number. Numbering is sequential and permanent: a principle is cited by number ("per DP-3"), so a number can be
-# retired but never reused. The filename is the code and nothing else; the title
-# goes in `title:` below, where a revision costs an edit rather than a rename
-# plus every link (ADR-013) — which matters more here than for a decision,
-# because principles are expected to be reworded.
+# Don't copy this file by hand — run `luria new dp`, which assigns the identity
+# and fills in the fields a machine can compute. WHICH identity depends on the
+# scheme's `allocate` mode: `filing` (the default) takes the next free number
+# on the spot, `merge` mints a temporary code that `luria concretize` numbers
+# where merges serialize (ADR-049).
+#
+# Numbering is sequential and permanent: a principle is cited by number ("per
+# DP-3"), so a number can be retired but never reused. The filename is the code
+# and nothing else; the title goes in `title:` below, where a revision costs an
+# edit rather than a rename plus every link (ADR-013) — which matters more here
+# than for a decision, because principles are expected to be reworded.
 #
 # This frontmatter is the ONLY place these facts live. `docs/design-principles.md`
 # is generated from it (ADR-012) — never edit that file by hand; run

--- a/record/principles.d/_template.md
+++ b/record/principles.d/_template.md
@@ -1,6 +1,6 @@
 ---
-# Copy this file to DP-<NNN>.md — next number wins. Numbering is sequential and
-# permanent: a principle is cited by number ("per DP-3"), so a number can be
+# Don't copy this file by hand — run `luria new dp`, which takes the next free
+# number. Numbering is sequential and permanent: a principle is cited by number ("per DP-3"), so a number can be
 # retired but never reused. The filename is the code and nothing else; the title
 # goes in `title:` below, where a revision costs an edit rather than a rename
 # plus every link (ADR-013) — which matters more here than for a decision,

--- a/template/record/decisions.d/README.stub
+++ b/template/record/decisions.d/README.stub
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Run `luria new adr`; it takes the next
-free number and scaffolds from [`_template.md`](_template.md).
+future edit could silently violate. Run `luria new adr`; it assigns the
+identity and scaffolds from [`_template.md`](_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../design-principles.md) instead — also generated, from

--- a/template/record/decisions.d/README.stub
+++ b/template/record/decisions.d/README.stub
@@ -2,8 +2,8 @@
 
 A decision record is a **choice among alternatives at a point in time**. Write
 one when you rejected an alternative, chose a constraint, or made something a
-future edit could silently violate. Copy [`_template.md`](_template.md); the
-number is the next one free.
+future edit could silently violate. Run `luria new adr`; it takes the next
+free number and scaffolds from [`_template.md`](_template.md).
 
 Values that decisions *cite* live in
 [design-principles.md](../design-principles.md) instead — also generated, from

--- a/template/record/decisions.d/_template.md
+++ b/template/record/decisions.d/_template.md
@@ -1,6 +1,9 @@
 ---
-# Don't copy this file by hand — run `luria new adr`, which takes the next free
-# number and fills in the fields a machine can compute. The kinds are the
+# Don't copy this file by hand — run `luria new adr`, which assigns the
+# identity and fills in the fields a machine can compute. WHICH identity
+# depends on the scheme's `allocate` mode: `filing` (the default) takes the
+# next free number on the spot, `merge` mints a temporary code that
+# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
 # config: every scheme, fragment directory and journal in luria.toml is one, so
 # `luria new <kind>` works for a scheme the moment it is declared.
 #

--- a/template/record/decisions.d/_template.md
+++ b/template/record/decisions.d/_template.md
@@ -1,8 +1,12 @@
 ---
-# Copy this file to ADR-<NNN>.md — next number wins, numbering is sequential and
-# carries information (it's the order decisions were made). The filename is the
-# code and nothing else; the title goes in `title:` below, where correcting it
-# costs an edit rather than a rename plus every link. Why:
+# Don't copy this file by hand — run `luria new adr`, which takes the next free
+# number and fills in the fields a machine can compute. The kinds are the
+# config: every scheme, fragment directory and journal in luria.toml is one, so
+# `luria new <kind>` works for a scheme the moment it is declared.
+#
+# Numbering is sequential and carries information (it's the order decisions were
+# made). The filename is the code and nothing else; the title goes in `title:`
+# below, where correcting it costs an edit rather than a rename plus every link.
 #   Why: LU-ADR-013.
 #
 # This frontmatter is the ONLY place these facts live. The index and the per-tag

--- a/template/record/principles.d/_template.md
+++ b/template/record/principles.d/_template.md
@@ -1,6 +1,6 @@
 ---
-# Copy this file to DP-<NNN>.md — next number wins. Numbering is sequential and
-# permanent: a principle is cited by number ("per DP-3"), so a number can be
+# Don't copy this file by hand — run `luria new dp`, which takes the next free
+# number. Numbering is sequential and permanent: a principle is cited by number ("per DP-3"), so a number can be
 # retired but never reused. The filename is the code and nothing else; the title
 # goes in `title:` below, where a revision costs an edit rather than a rename
 # plus every link — which matters more here than for a decision, because

--- a/template/record/principles.d/_template.md
+++ b/template/record/principles.d/_template.md
@@ -1,10 +1,15 @@
 ---
-# Don't copy this file by hand — run `luria new dp`, which takes the next free
-# number. Numbering is sequential and permanent: a principle is cited by number ("per DP-3"), so a number can be
-# retired but never reused. The filename is the code and nothing else; the title
-# goes in `title:` below, where a revision costs an edit rather than a rename
-# plus every link — which matters more here than for a decision, because
-# principles are expected to be reworded. Why: LU-ADR-013.
+# Don't copy this file by hand — run `luria new dp`, which assigns the identity
+# and fills in the fields a machine can compute. WHICH identity depends on the
+# scheme's `allocate` mode: `filing` (the default) takes the next free number
+# on the spot, `merge` mints a temporary code that `luria concretize` numbers
+# where merges serialize (ADR-049).
+#
+# Numbering is sequential and permanent: a principle is cited by number ("per
+# DP-3"), so a number can be retired but never reused. The filename is the code
+# and nothing else; the title goes in `title:` below, where a revision costs an
+# edit rather than a rename plus every link — which matters more here than for
+# a decision, because principles are expected to be reworded. Why: LU-ADR-013.
 #
 # This frontmatter is the ONLY place these facts live. `docs/design-principles.md`
 # is generated from it — never edit that file by hand; run `luria index`.


### PR DESCRIPTION
Both `_template.md` files and the decisions `README.stub` opened by telling the reader to *copy `_template.md` to the next free number*. That instruction predates `luria new` and had outlived it — `new.py`'s own docstring already says `luria new adr` scaffolds *"the next free decision number, **from `_template.md`**"*. The template was documenting the workflow the command replaced.

It's also worse advice than it looks. `new`'s kinds are **derived from config** — every scheme, fragment directory and journal in `luria.toml` is one, and nothing in `new.py` spells "adr" — so `luria new <kind>` works for a scheme the moment it's declared. And it takes the next free number itself, where hand-copying asks the author to pick one. That's how two branches claim the same number, which is the problem [ADR-049](record/decisions.d/ADR-049.md) then has to solve at the merge point.

## Six files

Fixed in the shipped `template/` scaffold **and** in this project's own record, so an adopter and a maintainer read the same instruction:

- `template/record/decisions.d/_template.md` + `record/decisions.d/_template.md`
- `template/record/principles.d/_template.md` + `record/principles.d/_template.md`
- `template/record/decisions.d/README.stub` + `record/decisions.d/README.stub`

`record/devlog.d/_template.md` already said *"Don't copy this file by hand — run `luria new`"*. It was the only one that had been updated, which is why the divergence was easy to miss.

## How this surfaced

Downstream, in `dmarx/strata-g`. Adding a third document type there meant declaring `[luria.schemes.PC]`, and `luria new pc` worked immediately — at which point it was obvious that its `CLAUDE.md` was telling contributors to hand-copy templates for **all three** of its document types, including a hand-written *"check the highest existing number and increment"*.

strata-g was luria's first consumer, and this is guidance that travelled with the extraction. Fixing it there and not here would leave the canonical scaffold teaching the thing we'd just corrected.

**Verification:** 400 tests pass; `luria lint` clean; regenerated views included. The changes are frontmatter comments and stub prose only — no behaviour — and `publish.yml`'s smoke test already exercises `luria init` → `luria index` → `luria new` against the packaged template.

---
_Generated by [Claude Code](https://claude.ai/code/session_012AWc5urqmvaJUhcvy1VWLM)_