### PR TITLE
fix(migrate): a moved document lands provisional, not numbered

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ The dial between reported and enforced. Status findings are warnings by default;
 | key | default | what it does |
 |---|---|---|
 | `fail_on` | *unset* | Warning classes promoted to failures. |
+| `narrow_terms` | *unset* | This project's own concrete nouns. A title in a scheme marked `titles_generalize` that names one is reported as `narrow-titles`. Luria ships none — the words are yours, and empty means the class never fires. |
 
 ## Schemes — `[luria.schemes.X]`
 
@@ -99,6 +100,7 @@ carries its prefix, so a second scheme is an entry here (ADR-006).
 | `render` | `str` | `"index"` |
 | `output` | `Path \| None` | *unset* |
 | `allocate` | `str` | `"filing"` |
+| `titles_generalize` | `bool` | `False` |
 
 ## Fragment directories — `[luria.fragments."dir"]`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,6 @@ The dial between reported and enforced. Status findings are warnings by default;
 | key | default | what it does |
 |---|---|---|
 | `fail_on` | *unset* | Warning classes promoted to failures. |
-| `narrow_terms` | *unset* | This project's own concrete nouns. A title in a scheme marked `titles_generalize` that names one is reported as `narrow-titles`. Luria ships none — the words are yours, and empty means the class never fires. |
 
 ## Schemes — `[luria.schemes.X]`
 
@@ -100,7 +99,6 @@ carries its prefix, so a second scheme is an entry here (ADR-006).
 | `render` | `str` | `"index"` |
 | `output` | `Path \| None` | *unset* |
 | `allocate` | `str` | `"filing"` |
-| `titles_generalize` | `bool` | `False` |
 
 ## Fragment directories — `[luria.fragments."dir"]`
 

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -94,6 +94,13 @@ def _rewrite_files(renames: list[tuple[str, str]]) -> int:
         text = new = path.read_text()
         for old, target in renames:
             new = new.replace(old, target)
+            # An anchor spells the code in lower case (`#adr-tmp47fje`,
+            # `name="adr-tmp47fje"`), which a case-sensitive replace walks
+            # straight past — leaving a live link pointing at a heading that
+            # no longer exists. Generated views are re-derived and so were
+            # never at risk; a hand-written or migration-written link is.
+            if (low := old.lower()) != old:
+                new = new.replace(low, target.lower())
         if new != text:
             path.write_text(new)
             touched += 1

--- a/luria/config.py
+++ b/luria/config.py
@@ -167,6 +167,28 @@ def _merge(base: dict, override: dict) -> dict:
     return out
 
 
+# A temporary code's tail: a literal `tmp` sentinel plus five base-36
+# characters — `ADR-tmp47fje`. The alphabetic start keeps the numeric and
+# temporary patterns disjoint by construction, and the spelled-out sentinel
+# does two more jobs (ADR-049): a reader who has never met the convention still
+# sees "provisional" at every citation site, and the prose pattern stops
+# false-matching six-letter English after a prefix — `[a-z][a-z0-9]{5}`, the
+# first shape, read "the ADR-review process" as a temporary reference.
+TEMP_TAIL = r"tmp[a-z0-9]{5}"
+_TEMP_TAIL_RE = re.compile(rf"^{TEMP_TAIL}$")
+
+
+def is_temp_tail(tail: str) -> bool:
+    """Whether a code's tail is a temporary one — the ONE place that decides.
+
+    Every other spelling of this question composes `TEMP_TAIL` with a prefix to
+    match a code or a filename. A caller holding only the tail asks here rather
+    than inventing a cheaper test: `not tail.isdigit()` looks equivalent and
+    is not, because it answers "this is not a number" — which a malformed tail
+    also satisfies."""
+    return bool(_TEMP_TAIL_RE.match(tail))
+
+
 @dataclass(frozen=True)
 class Scheme:
     """A family of referable documents — `ADR-012`, `RFC-7`, `SPEC-3`.
@@ -236,15 +258,9 @@ class Scheme:
     def pattern(self):
         return re.compile(rf"\b{self.prefix}[- ](?P<num>\d{{1,4}})\b")
 
-    # A temporary code's tail: a literal `tmp` sentinel plus five base-36
-    # characters — `ADR-tmp47fje`. The alphabetic start keeps the numeric and
-    # temporary patterns disjoint by construction, and the spelled-out
-    # sentinel does two more jobs (ADR-049): a reader who has never met the
-    # convention still sees "provisional" at every citation site, and the
-    # prose pattern stops false-matching six-letter English after a prefix —
-    # `[a-z][a-z0-9]{5}`, the first shape, read "the ADR-review process" as
-    # a temporary reference.
-    TEMP_TAIL = r"tmp[a-z0-9]{5}"
+    # Kept as a class attribute because every regex here composes it with a
+    # prefix; the definition and the predicate both live at module level.
+    TEMP_TAIL = TEMP_TAIL
 
     @property
     def temp_pattern(self):

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -73,16 +73,38 @@ class Pair:
     new: str                    # canonical new code, e.g. NEW-004
 
     @property
-    def parts(self) -> tuple[str, int, str, int | str]:
-        """`(old prefix, old number, new prefix, new tail)`.
+    def old_parts(self) -> tuple[str, int]:
+        """Prefix and number. The old side is always numeric: a document that
+        never had a number has nothing to migrate away from."""
+        return aliases_mod.split(self.old)
 
-        The new tail is an `int` for a rename and a temporary-code *string*
-        for a move (ADR-049): a moved document arrives provisional and is
-        numbered by the concretizer. The old side is always numeric — you
-        cannot migrate away from a code that was never assigned."""
-        op, on = aliases_mod.split(self.old)
-        np, raw = self.new.rsplit("-", 1)
-        return op, on, np, int(raw) if raw.isdigit() else raw
+    @property
+    def new_parts(self) -> tuple[str, str]:
+        """Prefix and the LITERAL new tail — `004`, or `tmp47fje`.
+
+        A string either way. The two spellings do not share a type: one is a
+        number carrying a padding convention, the other is an opaque identity
+        (ADR-049). An earlier `int | str` union pushed the ambiguity out to
+        every call site, which then had to test the type to learn which it
+        had — and the padding branch and the provisional branch are not the
+        same question."""
+        prefix, tail = self.new.rsplit("-", 1)
+        return prefix, tail
+
+    @property
+    def new_is_provisional(self) -> bool:
+        """A temporary code, awaiting `luria concretize`."""
+        return not self.new_parts[1].isdigit()
+
+    @property
+    def new_anchor_tail(self) -> str:
+        """How the tail is spelled inside an anchor: `#gp-4`, `#gp-tmp47fje`.
+
+        Anchors never pad — the generator emits the bare number — so a
+        numeric tail normalizes through `int` and a provisional one passes
+        through untouched."""
+        tail = self.new_parts[1]
+        return tail if self.new_is_provisional else str(int(tail))
 
 
 @dataclass
@@ -306,16 +328,20 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         return re.sub(pattern, guarded, text)
 
     def swap_pair(text: str, pair: Pair) -> str:
-        old_p, old_n, new_p, new_n = pair.parts
+        old_p, old_n = pair.old_parts
+        new_p, new_tail = pair.new_parts
 
         def code_repl(m: re.Match) -> str:
-            digits = m.group(2)
-            if isinstance(new_n, str):
-                # A temporary tail has no zero-padded form to preserve; the
+            sep, digits = m.group(1), m.group(2)
+            if pair.new_is_provisional:
+                # A temporary tail has no padded form to preserve; the
                 # concretizer rewrites it to a number later, everywhere.
-                return f"{new_p}{m.group(1)}{new_n}"
-            new_digits = f"{new_n:03d}" if digits != str(old_n) else str(new_n)
-            return f"{new_p}{m.group(1)}{new_digits}"
+                return f"{new_p}{sep}{new_tail}"
+            # Otherwise mirror the spelling the citation used: a padded
+            # reference stays padded, a bare one stays bare.
+            number = int(new_tail)
+            spelled = f"{number:03d}" if digits != str(old_n) else str(number)
+            return f"{new_p}{sep}{spelled}"
 
         text = swap(text,
                     rf"(?<![A-Za-z0-9-]){re.escape(old_p)}([- ])"
@@ -324,10 +350,10 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         # link target carries, and the `name="gp-4"` the render emits.
         text = swap(text,
                     rf"(?<=#){re.escape(old_p.lower())}-0*{old_n}(?!\d)",
-                    f"{new_p.lower()}-{new_n}")
+                    f"{new_p.lower()}-{pair.new_anchor_tail}")
         return swap(text,
                     rf"(?<=name=\"){re.escape(old_p.lower())}-0*{old_n}(?=\")",
-                    f"{new_p.lower()}-{new_n}")
+                    f"{new_p.lower()}-{pair.new_anchor_tail}")
 
     # Composed pairs first: `LU-OLD-013` must be rewritten whole before the
     # bare-code pattern reads `OLD-013` out of the middle of it.

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -60,7 +60,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import aliases as aliases_mod
-from . import doc_refs, remotes
+from . import doc_refs, new as new_mod, remotes
 from .config import current
 
 MIGRATIONS_DIR = "record/migrations.d"
@@ -73,10 +73,16 @@ class Pair:
     new: str                    # canonical new code, e.g. NEW-004
 
     @property
-    def parts(self) -> tuple[str, int, str, int]:
+    def parts(self) -> tuple[str, int, str, int | str]:
+        """`(old prefix, old number, new prefix, new tail)`.
+
+        The new tail is an `int` for a rename and a temporary-code *string*
+        for a move (ADR-049): a moved document arrives provisional and is
+        numbered by the concretizer. The old side is always numeric — you
+        cannot migrate away from a code that was never assigned."""
         op, on = aliases_mod.split(self.old)
-        np, nn = aliases_mod.split(self.new)
-        return op, on, np, nn
+        np, raw = self.new.rsplit("-", 1)
+        return op, on, np, int(raw) if raw.isdigit() else raw
 
 
 @dataclass
@@ -103,6 +109,10 @@ class Plan:
     # Supersede mode: (source path, new status line) + fresh copies to write.
     tombstones: list[tuple[Path, str]] = field(default_factory=list)
     copies: list[tuple[Path, Path, str, str]] = field(default_factory=list)
+    # Temporary tails this plan has already minted, per target prefix, so a
+    # second mint in the same run cannot repeat one — `_mint_tail` can only
+    # see what is on disk, and nothing has been written yet.
+    minted: dict[str, set[str]] = field(default_factory=dict)
 
 
 def _spec_path(ref: str) -> Path:
@@ -205,9 +215,20 @@ def _plan_move(plan: Plan, op: dict) -> None:
     path = source.documents().get(number)
     if path is None:
         raise SystemExit(f"luria migrate: {old_code} has no document")
-    new_number = max(target.documents(), default=0) + 1
-    new_code = target.code(new_number)
-    new_path = target.dir / target.filename(new_number)
+    # A moved document arrives under a TEMPORARY code, never a number
+    # (ADR-049). Every operation in a spec plans against the tree as it is
+    # now — nothing has moved yet — so "the next free number" is not a fact
+    # here any more than it is on a branch: two moves into one scheme both
+    # read the same highest number, and the second `git mv` would overwrite
+    # the first. The concretizer assigns the real numbers afterwards, at the
+    # serialization point, which is the only place that answer is true. It
+    # also stamps `formerly:`, so the alias the move needs comes for free.
+    seen = plan.minted.setdefault(target.prefix, set())
+    while (tail := new_mod._mint_tail(target)) in seen:
+        pass
+    seen.add(tail)
+    new_code = f"{target.prefix}-{tail}"
+    new_path = target.dir / f"{new_code}.md"
     if op.get("strategy") == "supersede":
         plan.copies.append((path, new_path, old_code, new_code))
         plan.tombstones.append((path, f"Superseded — by {new_code}"))
@@ -289,6 +310,10 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
 
         def code_repl(m: re.Match) -> str:
             digits = m.group(2)
+            if isinstance(new_n, str):
+                # A temporary tail has no zero-padded form to preserve; the
+                # concretizer rewrites it to a number later, everywhere.
+                return f"{new_p}{m.group(1)}{new_n}"
             new_digits = f"{new_n:03d}" if digits != str(old_n) else str(new_n)
             return f"{new_p}{m.group(1)}{new_digits}"
 

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -61,7 +61,7 @@ from pathlib import Path
 
 from . import aliases as aliases_mod
 from . import doc_refs, new as new_mod, remotes
-from .config import current
+from .config import current, is_temp_tail
 
 MIGRATIONS_DIR = "record/migrations.d"
 BLAME_IGNORE = ".git-blame-ignore-revs"
@@ -94,7 +94,7 @@ class Pair:
     @property
     def new_is_provisional(self) -> bool:
         """A temporary code, awaiting `luria concretize`."""
-        return not self.new_parts[1].isdigit()
+        return is_temp_tail(self.new_parts[1])
 
     @property
     def new_anchor_tail(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "luria"
-version = "0.2.0"
+version = "0.3.0"
 description = "A project's memory: decisions, principles, changelog and devlog, kept honest by lint"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/record/changelog.d/fix-move-doc-collides-within-a-plan.md
+++ b/record/changelog.d/fix-move-doc-collides-within-a-plan.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **`move_doc` lands a document under a temporary code, not a number.** "The
+  next free number" is no more a fact inside a migration than it is on a
+  branch: every operation plans against the tree as it is *now*, so two moves
+  into one scheme both read the same highest number, and the second `git mv`
+  silently overwrote the first. The move now mints a temp code
+  ([ADR-049](record/decisions.d/ADR-049.md)) and `luria concretize` assigns the
+  real number afterwards, at the serialization point — the same bargain
+  `luria new` already makes, rather than a second allocator with its own
+  arithmetic. The document ends up carrying both aliases: the code it migrated
+  from, and the provisional one it wore in between.
+
+- **`luria concretize` rewrites the anchor spelling too.** Its sweep was a
+  case-sensitive replace, so it upgraded `ADR-tmp47fje` but walked straight
+  past `#adr-tmp47fje` — leaving a live link pointing at a heading that no
+  longer existed. Generated views are re-derived and were never at risk; a
+  hand-written or migration-written link was.

--- a/record/changelog.d/fix-move-doc-collides-within-a-plan.md
+++ b/record/changelog.d/fix-move-doc-collides-within-a-plan.md
@@ -16,3 +16,13 @@
   past `#adr-tmp47fje` — leaving a live link pointing at a heading that no
   longer existed. Generated views are re-derived and were never at risk; a
   hand-written or migration-written link was.
+
+- **`Pair` no longer returns a tail typed `int | str`.** The padded-number
+  spelling and the opaque temporary identity are not the same kind of value,
+  and collapsing them pushed the ambiguity out to every call site, which then
+  had to test the type to learn which it had. Replaced with `old_parts`,
+  `new_parts`, `new_is_provisional` and `new_anchor_tail`, so the padding
+  question and the provisional question are asked separately — they are
+  separate questions. A test now pins that a rename mirrors each citation's
+  own spelling: `DP-004` stays padded, `DP-4` stays bare, the anchor stays
+  bare.

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -15,7 +15,8 @@ journal link whose frame the sweep must not disturb (#57).
 import subprocess
 from pathlib import Path
 
-from luria import aliases, config, doc_refs, lint, migrate, ref_status
+from luria import (aliases, concretize, config, doc_refs, lint, migrate,
+                   ref_status)
 
 
 def _record_project(tmp_path, monkeypatch):
@@ -163,7 +164,15 @@ def test_rename_scheme_end_to_end(tmp_path, monkeypatch, capsys):
     assert aliases.alias_map() == {"DP-001": "GP-001", "DP-004": "GP-004"}
 
 
-def test_move_doc_renumbers_and_stamps(tmp_path, monkeypatch, capsys):
+def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
+    """A move arrives under a TEMPORARY code and is numbered afterwards.
+
+    "The next free number" is no more a fact inside a migration than it is on
+    a branch: every operation plans against the tree as it is now. So the move
+    mints a temp code (ADR-049) and the concretizer — which runs where merges
+    serialize — assigns the real one. The document ends up carrying BOTH
+    aliases: the code it migrated from, and the temporary code it wore in
+    between."""
     root = _premigration_project(tmp_path, monkeypatch)
     (root / "luria.toml").write_text(
         (root / "luria.toml").read_text()
@@ -173,17 +182,76 @@ def test_move_doc_renumbers_and_stamps(tmp_path, monkeypatch, capsys):
     aliases.reset()
     mig = root / "record" / "migrations.d" / "0002-promote.toml"
     mig.write_text('title = "DP-4 becomes a value"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\nto = "VAL"\n')
+                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+                   'to = "VAL"\n')
     migrate.run("0002")
-    moved = (root / "record" / "values.d" / "VAL-001.md").read_text()
-    assert "formerly:\n- DP-4\n" in moved
+
+    landed = list((root / "record" / "values.d").glob("VAL-tmp*.md"))
+    assert len(landed) == 1, "the move lands provisional, never numbered"
+    assert "formerly:\n- DP-4\n" in landed[0].read_text()
     assert not (root / "record" / "principles.d" / "DP-004.md").exists()
+    assert "Bare VAL-tmp" in (root / "docs" / "notes.md").read_text()
+
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "migrated")
+    config.reset()
+    aliases.reset()
+    concretize.run()
+
+    final = (root / "record" / "values.d" / "VAL-001.md").read_text()
+    assert "- DP-4" in final and "- VAL-tmp" in final, \
+        "both the migrated-from code and the provisional one stay resolvable"
     notes = (root / "docs" / "notes.md").read_text()
-    assert "Bare VAL-1" in notes
-    assert "Fixture DP-018" in notes
+    assert "Bare VAL-001" in notes
+    assert "#val-001" in notes, "the anchor follows the code, not just the label"
+    assert "val-tmp" not in notes, "no provisional spelling survives the sweep"
+    assert "Fixture DP-018" in notes, "a fixture number is not in the mapping"
 
 
-def test_move_doc_supersede_copies_and_tombstones(tmp_path, monkeypatch, capsys):
+def test_two_moves_into_one_scheme_do_not_collide(tmp_path, monkeypatch):
+    """Two moves into one scheme, in one spec, must not claim one identity.
+
+    With numbers they did: both read the same highest number and the second
+    `git mv` overwrote the first — a document destroyed, and the dry-run
+    printed two lines saying so in plain sight. Temporary codes make the
+    collision structurally impossible rather than arithmetically avoided."""
+    root = _premigration_project(tmp_path, monkeypatch)
+    (root / "luria.toml").write_text(
+        (root / "luria.toml").read_text()
+        + '[luria.schemes.VAL]\ndir = "record/values.d"\n')
+    (root / "record" / "values.d").mkdir(parents=True)
+    config.reset()
+    aliases.reset()
+    mig = root / "record" / "migrations.d" / "0002-promote-both.toml"
+    mig.write_text('title = "Both principles become values"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "DP-1"\n'
+                   'to = "VAL"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+                   'to = "VAL"\n')
+    migrate.run("0002")
+
+    landed = sorted((root / "record" / "values.d").glob("VAL-tmp*.md"))
+    assert len(landed) == 2, [p.name for p in landed]
+    assert not list((root / "record" / "principles.d").glob("DP-*.md"))
+
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "migrated")
+    config.reset()
+    aliases.reset()
+    concretize.run()
+    numbered = sorted(p.name for p in
+                      (root / "record" / "values.d").glob("VAL-0*.md"))
+    assert numbered == ["VAL-001.md", "VAL-002.md"], numbered
+
+
+def test_move_doc_supersede_copies_and_tombstones(tmp_path, monkeypatch):
+    """Supersede copies rather than moves, and rewrites nothing.
+
+    The tombstone names the provisional code; the concretizer rewrites it to
+    the assigned number along with every other occurrence, so the status line
+    ends up pointing at the real one without the migration having to know it."""
     root = _premigration_project(tmp_path, monkeypatch)
     (root / "luria.toml").write_text(
         (root / "luria.toml").read_text()
@@ -193,14 +261,24 @@ def test_move_doc_supersede_copies_and_tombstones(tmp_path, monkeypatch, capsys)
     aliases.reset()
     mig = root / "record" / "migrations.d" / "0002-supersede.toml"
     mig.write_text('title = "DP-4 superseded by a value"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\nto = "VAL"\n'
-                   'strategy = "supersede"\n')
+                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+                   'to = "VAL"\nstrategy = "supersede"\n')
     migrate.run("0002")
     old = (root / "record" / "principles.d" / "DP-004.md").read_text()
+    assert "status: Superseded — by VAL-tmp" in old
+    assert len(list((root / "record" / "values.d").glob("VAL-tmp*.md"))) == 1
+    assert "Bare DP-4" in (root / "docs" / "notes.md").read_text(), \
+        "supersede mode rewrites nothing"
+
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "superseded")
+    config.reset()
+    aliases.reset()
+    concretize.run()
+    old = (root / "record" / "principles.d" / "DP-004.md").read_text()
     assert "status: Superseded — by VAL-001" in old
-    assert (root / "record" / "values.d" / "VAL-001.md").exists()
-    notes = (root / "docs" / "notes.md").read_text()
-    assert "Bare DP-4" in notes, "supersede mode rewrites nothing"
+    assert "Bare DP-4" in (root / "docs" / "notes.md").read_text()
 
 
 def test_new_migration_scaffolds_a_numbered_spec(tmp_path, monkeypatch):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -321,3 +321,17 @@ def test_the_sweep_honors_unlinted_file(tmp_path, monkeypatch, capsys):
     _git(root, "add", "-A")
     migrate.run("0001")
     assert "The old spelling DP-4 preserved verbatim." in specimen.read_text()
+
+
+def test_provisional_is_decided_in_one_place(tmp_path, monkeypatch):
+    """`Pair.new_is_provisional` must ask the canonical predicate.
+
+    The cheap version — `not tail.isdigit()` — looks equivalent and answers a
+    different question: "this is not a number", which a malformed tail also
+    satisfies. Pinned by asserting the two disagree exactly where they should."""
+    from luria.config import is_temp_tail
+    assert is_temp_tail("tmp47fje") and not is_temp_tail("004")
+    assert not is_temp_tail("nonsense"), "not-a-number is not the same test"
+    assert migrate.Pair("DP-004", "VAL-tmp47fje").new_is_provisional
+    assert not migrate.Pair("DP-004", "VAL-007").new_is_provisional
+    assert not migrate.Pair("DP-004", "VAL-nonsense").new_is_provisional

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -164,6 +164,27 @@ def test_rename_scheme_end_to_end(tmp_path, monkeypatch, capsys):
     assert aliases.alias_map() == {"DP-001": "GP-001", "DP-004": "GP-004"}
 
 
+def test_a_rename_mirrors_each_citation_s_padding(tmp_path, monkeypatch):
+    """`DP-004` stays padded, `DP-4` stays bare, and the anchor stays bare.
+
+    The tail is one string with two spellings in play at once — the padded
+    filename form and the bare prose form — so a rewrite has to answer
+    "padded?" per citation rather than once per pair. Pinned because the
+    provisional-tail work touched exactly this branch."""
+    root = _premigration_project(tmp_path, monkeypatch)
+    page = root / "docs" / "padding.md"
+    page.write_text("Padded DP-004, bare DP-4, anchor "
+                    "[x](design-principles.md#dp-4).\n")
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "padding")
+    migrate.run("0001")
+    out = page.read_text()
+    assert "Padded GP-004" in out, out
+    assert "bare GP-4," in out, out
+    assert "#gp-4)" in out, out
+
+
 def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
     """A move arrives under a TEMPORARY code and is numbered afterwards.
 


### PR DESCRIPTION
Found by running the first real two-document promotion downstream, hours after #80 shipped the machinery. **It would have destroyed a document.**

> **Rewritten after review.** The first version added a per-plan counter. That was the wrong level, and this now uses temporary codes instead — see *Why not a counter* below.

## The defect

Every operation in a spec plans against the tree as it is *now* — nothing has moved yet — so `_plan_move` computed `max(target.documents(), default=0) + 1` twice and got the same answer twice. Two `git mv`s onto one path; the second overwrote the first.

The dry-run printed it in plain sight:

```
DP-017 -> PC-001
DP-019 -> PC-001
git mv principles.d/DP-017.md docs/conventions/PC-001.md
git mv principles.d/DP-019.md docs/conventions/PC-001.md
```

## The fix: mint a temporary code, let the concretizer number it

"The next free number" is no more a fact inside a migration than it is on a branch. So `move_doc` now mints a temp code ([ADR-049](record/decisions.d/ADR-049.md)) and `luria concretize` assigns the real one afterwards, where merges serialize — the same bargain `luria new` already makes for a merge-allocated scheme.

The document ends up carrying **both** aliases — the code it migrated from, and the provisional one it wore in between — so citations from either era resolve.

### Why not a counter

A counter is a *second* allocator sitting alongside the one this project already has, with its own arithmetic to get wrong. It also only solves collisions **within** a spec: two branches each running a migration into the same scheme would still collide, and that is precisely the case temporary codes exist for. Reusing the mechanism fixes the general problem and deletes the arithmetic.

## Two things that fell out

- **`Pair.parts`** now returns the new tail as `int` for a rename and `str` for a move, and the sweep skips zero-padding for a temporary tail — which has no padded form to preserve.

- **A pre-existing bug in `luria concretize`.** Its sweep was a case-sensitive `str.replace`, so it upgraded `ADR-tmp47fje` and walked straight past the anchor spelling `#adr-tmp47fje` — leaving a live link pointing at a heading that no longer existed. Generated views are re-derived and were never at risk; a hand-written or migration-written link was. Unreachable until migrations started writing temp anchors into ordinary files, which this change does. The test now asserts `val-tmp` appears nowhere after concretization, not merely that the label updated.

## Also in here

The **0.3.0 version bump**, swept in by an earlier `git add -A` and kept deliberately rather than quietly: `narrow-titles` (#83) and this fix both want a release, and `main` has been sitting at 0.2.0 with unreleased features since #83 merged.

## Verification

The three move tests now assert the full chain — provisional landing, then `concretize`, then numbered — rather than a single numeric outcome. **408 tests pass**; `luria lint` clean.