### PR TITLE
feat: a scheme can require frontmatter fields beyond the standard set

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,7 @@ carries its prefix, so a second scheme is an entry here (ADR-006).
 | `output` | `Path \| None` | *unset* |
 | `allocate` | `str` | `"filing"` |
 | `titles_generalize` | `bool` | `False` |
+| `requires` | `tuple[str, ...]` | *unset* |
 
 ## Fragment directories — `[luria.fragments."dir"]`
 

--- a/luria/config.py
+++ b/luria/config.py
@@ -229,6 +229,12 @@ class Scheme:
     # scheme whose documents claim to transfer — principles, values — is where
     # this earns its keep.
     titles_generalize: bool = False
+    # Frontmatter fields this scheme demands beyond the standard set. What
+    # makes a CROSS-SCHEME move safe to automate (ADR-040): `luria migrate`
+    # moves the file, and the document then fails lint until a human supplies
+    # what the target scheme's template would have prompted for. The machinery
+    # relocates a document; only a person can vouch that it belongs.
+    requires: tuple[str, ...] = ()
 
     @property
     def view(self) -> Path:
@@ -725,6 +731,7 @@ def load(root: Path | None = None, text: str | None = None) -> Config:
                 root / spec["output"] if spec.get("output") else None,
                 spec.get("allocate", "filing"),
                 bool(spec.get("titles_generalize", False)),
+                tuple(spec.get("requires", ())),
             )
             for prefix, spec in raw["schemes"].items()
         },

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -113,6 +113,17 @@ def check_frontmatter(errors: list[str]) -> None:
             if not (meta.get("tags") or []):
                 errors.append(f"{rel}: no `tags:` in frontmatter (see ADR-003)")
 
+            # Per-scheme requirements (ADR-040): the fields a scheme demands
+            # beyond the standard set — what makes a cross-scheme move safe to
+            # automate, because the moved document fails here until a human
+            # supplies what the target scheme's template would have prompted
+            # for. The machinery relocates; only a person vouches.
+            for field in scheme.requires:
+                if not meta.get(field):
+                    errors.append(
+                        f"{rel}: no `{field}:` in frontmatter — the "
+                        f"{scheme.prefix} scheme requires it (luria.toml)")
+
 
 def check_title(errors: list[str], rel: str, meta: dict, body: str) -> None:
     """`title:` is the source of truth, and the body's H1 repeats it.

--- a/record/changelog.d/feat-scheme-requires.md
+++ b/record/changelog.d/feat-scheme-requires.md
@@ -1,0 +1,9 @@
+### Added
+
+- **`requires = [...]` on a scheme** — frontmatter fields it demands beyond the
+  standard set. This is what makes a cross-scheme `luria migrate` move safe to
+  automate ([ADR-040](record/decisions.d/ADR-040.md)): a document moved into a
+  scheme whose template asks for fields the source never had cannot have them
+  invented, so the move succeeds and the *lint* fails until a human supplies
+  them. The machinery relocates a document; only a person vouches that it
+  belongs.

--- a/tests/test_scheme_requires.py
+++ b/tests/test_scheme_requires.py
@@ -1,0 +1,66 @@
+"""Per-scheme required frontmatter — the cross-scheme move enabler (ADR-040).
+
+`luria migrate` can relocate a document into a scheme whose template asks for
+fields the source scheme never had. The machinery cannot invent them, and
+silently landing a document that is missing them is how a move degrades a
+record. So the move succeeds and the LINT fails, until a human supplies what
+the target's template would have prompted for: the machinery relocates, only a
+person vouches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from luria import config, lint
+
+
+def _project(root: Path, monkeypatch, requires: str = "") -> Path:
+    (root / "record" / "norms.d").mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.schemes.NRM]\ndir = "record/norms.d"\n'
+        + (f"requires = [{requires}]\n" if requires else ""))
+    doc = root / "record" / "norms.d" / "NRM-001.md"
+    doc.write_text("---\nstatus: Active\ntitle: 'A norm'\ntags:\n- record\n"
+                   "date: '2026-01-01'\n---\n\n# NRM-001: A norm\n\nBody.\n")
+    monkeypatch.setenv("LURIA_ROOT", str(root))
+    config.reset()
+    return doc
+
+
+def test_no_requires_demands_nothing(tmp_path, monkeypatch):
+    """The default: a scheme asks for the standard fields and no more."""
+    _project(tmp_path, monkeypatch)
+    errors: list[str] = []
+    lint.check_frontmatter(errors)
+    assert errors == []
+
+
+def test_a_required_field_is_demanded_by_name(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch, requires='"approvers"')
+    errors: list[str] = []
+    lint.check_frontmatter(errors)
+    assert any("no `approvers:`" in e and "NRM scheme requires it" in e
+               for e in errors), errors
+
+
+def test_supplying_the_field_clears_it(tmp_path, monkeypatch):
+    doc = _project(tmp_path, monkeypatch, requires='"approvers"')
+    doc.write_text(doc.read_text().replace(
+        "date: '2026-01-01'\n", "date: '2026-01-01'\napprovers:\n- someone\n"))
+    errors: list[str] = []
+    lint.check_frontmatter(errors)
+    assert errors == []
+
+
+def test_an_empty_value_does_not_satisfy_it(tmp_path, monkeypatch):
+    """A present-but-empty key is the shape a scaffold leaves behind, and it
+    vouches for nothing — the whole point is a human filling it in."""
+    doc = _project(tmp_path, monkeypatch, requires='"approvers"')
+    doc.write_text(doc.read_text().replace(
+        "date: '2026-01-01'\n", "date: '2026-01-01'\napprovers: []\n"))
+    errors: list[str] = []
+    lint.check_frontmatter(errors)
+    assert any("no `approvers:`" in e for e in errors), errors


### PR DESCRIPTION
Salvaged from #62, whose other content has since landed on `main` or gone stale. This is the one genuinely-missing feature in it.

## What it's for

`luria migrate` can relocate a document into a scheme whose template asks for fields the source scheme never had. The machinery cannot invent them, and silently landing a half-formed document is how a move quietly degrades a record.

`requires = [...]` puts the failure in the right place:

```toml
[luria.schemes.PC]
requires = ["scope"]
```

The **move succeeds**; the **lint fails** until a human supplies what the target template would have prompted for. The machinery relocates a document; only a person vouches that it belongs — which is [ADR-040](record/decisions.d/ADR-040.md)'s stated condition for automating a cross-scheme move at all.

Directly load-bearing for the promotion work downstream: a `DP` moved into a `PC` scheme lands under a template with different sections and different expectations, and this is what stops it arriving incomplete.

## One behaviour worth naming

**An empty value does not satisfy the requirement.** `approvers: []` is exactly the shape a scaffold leaves behind, and it vouches for nothing — the point is a human filling it in. Pinned by its own test.

## Verification

Four tests, fired before being trusted: deleting the check fails two of them (the other two assert the *absence* of demands, and correctly still pass — which is why the removal test matters). **417 tests pass**; `luria lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012AWc5urqmvaJUhcvy1VWLM)_