### PR TITLE
fix(migrate): rebuild a moved document's citations from the resolver

### DIFF
--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -33,7 +33,7 @@ Document status is reported, not enforced
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**3 codes unaccounted for.** Not listed: 49 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**4 codes unaccounted for.** Not listed: 49 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 
 ### ADR-123 — resolves to nothing (4 unmarked sites · 2 other mentions marked deliberate)
@@ -46,6 +46,10 @@ A reference the reader cannot follow: the code names no document in this record.
 ### ADR-000 — resolves to nothing (1 unmarked site)
 
 - [`tests/test_concretize.py:205`](../../tests/test_concretize.py)
+
+### DP-017 — resolves to nothing (1 unmarked site · 2 other mentions marked deliberate)
+
+- [`luria/migrate.py:152`](../../luria/migrate.py)
 
 ### DP-018 — resolves to nothing (1 unmarked site · 4 other mentions marked deliberate)
 

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -135,6 +135,23 @@ class Plan:
     # second mint in the same run cannot repeat one — `_mint_tail` can only
     # see what is on disk, and nothing has been written yet.
     minted: dict[str, set[str]] = field(default_factory=dict)
+    # New codes whose citations must be REBUILT rather than re-spelled. Every
+    # `move_doc` qualifies, because a move always crosses schemes and a
+    # scheme's address is more than its code:
+    #
+    #   same render mode  — the directory changes (`src.d/X.md` → `dst.d/Y.md`)
+    #   different modes   — the whole shape changes (`page.md#anchor` ↔ `dir/Y.md`)
+    #
+    # Swapping the code inside the old link fixes the label and leaves the
+    # target pointing at a file that does not exist. So the sweep strips these
+    # links back to bare references and the fixer rebuilds them from the
+    # resolver, which is the one place that knows how a scheme is addressed.
+    relocated: set[str] = field(default_factory=set)
+    # The address fragments a moved document USED to be reachable at — the
+    # anchor a document-rendered scheme gave it (`#dp-17`), or the filename an
+    # index-rendered one did (`DP-017.md`). Matched against link targets, so a
+    # citation is found by where it points rather than by how it is labelled.
+    old_addresses: set[str] = field(default_factory=set)
 
 
 def _spec_path(ref: str) -> Path:
@@ -255,6 +272,10 @@ def _plan_move(plan: Plan, op: dict) -> None:
         plan.copies.append((path, new_path, old_code, new_code))
         plan.tombstones.append((path, f"Superseded — by {new_code}"))
         return
+    plan.relocated.add(new_code)
+    plan.old_addresses.add(
+        f"#{old_prefix.lower()}-{number}" if source.render == "document"
+        else path.name)
     plan.mapping.append(Pair(old_code, new_code))
     plan.moves.append((path, new_path))
     plan.stamps[new_path] = f"{old_prefix}-{number}"
@@ -346,6 +367,11 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         text = swap(text,
                     rf"(?<![A-Za-z0-9-]){re.escape(old_p)}([- ])"
                     rf"(0*{old_n})(?!\d)", code_repl)
+        if pair.new in plan.relocated:
+            # The document MOVED, so its address is rebuilt below rather than
+            # re-spelled here. Rewriting the anchor now would bury the old
+            # address under the new code and leave nothing to match on.
+            return text
         # The two spellings of a machinery-authored anchor: the `#gp-4` a
         # link target carries, and the `name="gp-4"` the render emits.
         text = swap(text,
@@ -354,6 +380,30 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         return swap(text,
                     rf"(?<=name=\"){re.escape(old_p.lower())}-0*{old_n}(?=\")",
                     f"{new_p.lower()}-{pair.new_anchor_tail}")
+
+    def unlink_relocated(text: str) -> str:
+        """Any link AT a moved document's old address loses its target.
+
+        Matched on the ADDRESS, not the label: a citation may be worded
+        (`[design-principles #17](../design-principles.md#dp-17)`) rather than
+        spelled as the code, and those are exactly the ones a code-shaped
+        pattern walks past — leaving a live link to a document that moved.
+
+        The label is kept and the link dropped, so the fixer rebuilds a coded
+        citation from the resolver. A worded label is lost in the process,
+        which is the honest trade: the alternative is a link whose words point
+        somewhere the reader will not find them."""
+        for old_addr in sorted(plan.old_addresses):
+            text = swap(
+                text,
+                rf"\[([^\]]*)\]\([^)]*{re.escape(old_addr)}\)",
+                lambda m: m.group(1))
+        return text
+
+    # Before any swapping: a moved document's citations are matched by the
+    # address they point at, and the code swap rewrites codes inside link
+    # targets too — so running this later would leave nothing to match.
+    text = unlink_relocated(text)
 
     # Composed pairs first: `LU-OLD-013` must be rewritten whole before the
     # bare-code pattern reads `OLD-013` out of the middle of it.
@@ -473,6 +523,28 @@ def apply(plan: Plan) -> tuple[int, int]:
                 files += 1
                 swept += count
     aliases_mod.reset()
+
+    # Rebuild the links the sweep dropped to bare references. Deliberately
+    # AFTER the moves and the alias reset, so the resolver sees the tree as it
+    # now is: a cross-render move changes how a document is addressed, and the
+    # resolver is the one place that knows how. Doing it here rather than
+    # leaving it to a follow-up `luria link --fix` keeps the migration's
+    # output clean on its own terms — a run that ends with dangling bare refs
+    # is a run that half-finished.
+    if plan.relocated:
+        adrs, anchors = doc_refs.adr_paths(), doc_refs.dp_anchors()
+        for path in _tracked_files():
+            if not path.exists():
+                continue
+            try:
+                text = path.read_text()
+            except (UnicodeDecodeError, OSError):
+                continue
+            if doc_refs.unlinted(path, text):
+                continue
+            linked, n = doc_refs.linkify(text, path, adrs, anchors)
+            if n:
+                path.write_text(linked)
     return files, swept
 
 

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -147,11 +147,11 @@ class Plan:
     # links back to bare references and the fixer rebuilds them from the
     # resolver, which is the one place that knows how a scheme is addressed.
     relocated: set[str] = field(default_factory=set)
-    # The address fragments a moved document USED to be reachable at — the
-    # anchor a document-rendered scheme gave it (`#dp-17`), or the filename an
-    # index-rendered one did (`DP-017.md`). Matched against link targets, so a
-    # citation is found by where it points rather than by how it is labelled.
-    old_addresses: set[str] = field(default_factory=set)
+    # Old address fragment → the code that answers for it now. The address is
+    # the anchor a document-rendered scheme gave the document (`#dp-17`) or the
+    # filename an index-rendered one did (`DP-017.md`), so a citation is found
+    # by where it POINTS rather than by how it is labelled.
+    old_addresses: dict[str, str] = field(default_factory=dict)
 
 
 def _spec_path(ref: str) -> Path:
@@ -273,9 +273,9 @@ def _plan_move(plan: Plan, op: dict) -> None:
         plan.tombstones.append((path, f"Superseded — by {new_code}"))
         return
     plan.relocated.add(new_code)
-    plan.old_addresses.add(
+    plan.old_addresses[
         f"#{old_prefix.lower()}-{number}" if source.render == "document"
-        else path.name)
+        else path.name] = new_code
     plan.mapping.append(Pair(old_code, new_code))
     plan.moves.append((path, new_path))
     plan.stamps[new_path] = f"{old_prefix}-{number}"
@@ -389,15 +389,18 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         spelled as the code, and those are exactly the ones a code-shaped
         pattern walks past — leaving a live link to a document that moved.
 
-        The label is kept and the link dropped, so the fixer rebuilds a coded
-        citation from the resolver. A worded label is lost in the process,
-        which is the honest trade: the alternative is a link whose words point
-        somewhere the reader will not find them."""
-        for old_addr in sorted(plan.old_addresses):
+        The whole citation — label included — becomes the NEW CODE, bare, and
+        the fixer links it. Keeping the old label was the first attempt and it
+        undid itself: `[design-principles #17](…#dp-17)` stripped to
+        `design-principles #17`, whose bare `#17` the resolver reads as a
+        design-principle reference and re-linked straight back to the anchor
+        that had just been vacated. A stale label is not worth preserving at
+        the cost of resurrecting the address it names."""
+        for old_addr, new_code in sorted(plan.old_addresses.items()):
             text = swap(
                 text,
-                rf"\[([^\]]*)\]\([^)]*{re.escape(old_addr)}\)",
-                lambda m: m.group(1))
+                rf"\[[^\]]*\]\([^)]*{re.escape(old_addr)}\)",
+                new_code)
         return text
 
     # Before any swapping: a moved document's citations are matched by the

--- a/record/changelog.d/fix-cross-render-move-links.md
+++ b/record/changelog.d/fix-cross-render-move-links.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- `luria migrate`'s `move_doc` no longer leaves links pointing at a moved
+  document's old address. A move always crosses schemes, and a scheme's
+  address is more than its code — a same-render move changes the directory, a
+  cross-render move changes the whole shape (`page.md#anchor` ↔ `dir/CODE.md`).
+  Swapping the code inside the old link fixed the label and left the target
+  pointing at a file that does not exist, silently, with the lint clean.
+  Citations of a moved document are now matched by the ADDRESS they point at,
+  stripped to bare references, and rebuilt by the fixer from the resolver —
+  the one place that knows how each scheme is addressed.

--- a/record/changelog.d/fix-cross-render-move-links.md
+++ b/record/changelog.d/fix-cross-render-move-links.md
@@ -6,6 +6,10 @@
   cross-render move changes the whole shape (`page.md#anchor` ↔ `dir/CODE.md`).
   Swapping the code inside the old link fixed the label and left the target
   pointing at a file that does not exist, silently, with the lint clean.
-  Citations of a moved document are now matched by the ADDRESS they point at,
-  stripped to bare references, and rebuilt by the fixer from the resolver —
-  the one place that knows how each scheme is addressed.
+
+  Citations of a moved document are now found by the ADDRESS they point at
+  rather than by their label, replaced with the new code, and linked by the
+  fixer from the resolver — the one place that knows how each scheme is
+  addressed. A worded citation is rewritten too, label and all: keeping the
+  label resurrects the problem, because the `#17` left behind is itself a
+  reference the fixer re-links to the anchor the move just vacated.

--- a/record/migrations.d/0001-promote.toml
+++ b/record/migrations.d/0001-promote.toml
@@ -1,0 +1,10 @@
+title = "promote"
+[[operations]]
+op = "move_doc"
+doc = "DP-017"
+to = "PC"
+
+[[operations]]
+op = "move_doc"
+doc = "DP-019"
+to = "PC"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -373,3 +373,37 @@ def test_a_same_render_move_keeps_its_links_untouched(tmp_path, monkeypatch):
     out = page.read_text()
     assert "(../record/dst.d/DST-tmp" in out, out
     assert "src.d" not in out, "the path follows the move"
+
+
+def test_a_worded_citation_of_a_moved_document_is_rebuilt(tmp_path,
+                                                          monkeypatch):
+    """A citation labelled in prose, not spelled as the code, still follows.
+
+    `[design-principles #17](../design-principles.md#dp-17)` is a live link to
+    an anchor the move just vacated, and a code-shaped pattern walks straight
+    past it. Worse, stripping it to its LABEL resurrects the problem: the bare
+    `#17` left behind is itself a design-principle reference, which the fixer
+    re-links to the address that was just vacated. The whole citation has to
+    become the new code."""
+    root = _premigration_project(tmp_path, monkeypatch)
+    (root / "luria.toml").write_text(
+        (root / "luria.toml").read_text()
+        + '[luria.schemes.VAL]\ndir = "record/values.d"\n')
+    (root / "record" / "values.d").mkdir(parents=True)
+    page = root / "docs" / "worded.md"
+    page.write_text(
+        "The fix ([design-principles #4](design-principles.md#dp-4)) held.\n")
+    config.reset()
+    aliases.reset()
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "worded")
+    mig = root / "record" / "migrations.d" / "0002-worded.toml"
+    mig.write_text('title = "DP-4 becomes a value"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+                   'to = "VAL"\n')
+    migrate.run("0002")
+    out = page.read_text()
+    assert "design-principles.md#dp-4" not in out, out
+    assert "#dp-4" not in out, "the vacated anchor must not survive anywhere"
+    assert "VAL-tmp" in out, out

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -211,7 +211,12 @@ def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
     assert len(landed) == 1, "the move lands provisional, never numbered"
     assert "formerly:\n- DP-4\n" in landed[0].read_text()
     assert not (root / "record" / "principles.d" / "DP-004.md").exists()
-    assert "Bare VAL-tmp" in (root / "docs" / "notes.md").read_text()
+    # DP renders as a document and VAL as an index, so the citation's SHAPE
+    # changed: `page.md#anchor` → `dir/CODE.md`. The sweep drops the stale
+    # link and the fixer rebuilds it from the resolver.
+    notes = (root / "docs" / "notes.md").read_text()
+    assert "(../record/values.d/VAL-tmp" in notes, notes
+    assert "design-principles.md#val" not in notes, "no link to the old view"
 
     _git(root, "add", "-A")
     _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
@@ -224,8 +229,7 @@ def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
     assert "- DP-4" in final and "- VAL-tmp" in final, \
         "both the migrated-from code and the provisional one stay resolvable"
     notes = (root / "docs" / "notes.md").read_text()
-    assert "Bare VAL-001" in notes
-    assert "#val-001" in notes, "the anchor follows the code, not just the label"
+    assert "[VAL-001](../record/values.d/VAL-001.md)" in notes, notes
     assert "val-tmp" not in notes, "no provisional spelling survives the sweep"
     assert "Fixture DP-018" in notes, "a fixture number is not in the mapping"
 
@@ -335,3 +339,37 @@ def test_provisional_is_decided_in_one_place(tmp_path, monkeypatch):
     assert migrate.Pair("DP-004", "VAL-tmp47fje").new_is_provisional
     assert not migrate.Pair("DP-004", "VAL-007").new_is_provisional
     assert not migrate.Pair("DP-004", "VAL-nonsense").new_is_provisional
+
+
+def test_a_same_render_move_keeps_its_links_untouched(tmp_path, monkeypatch):
+    """The unlink pass must fire ONLY when the shape actually changes.
+
+    Two index-rendered schemes address a document the same way, so a move
+    between them is a pure spelling swap — dropping and rebuilding those links
+    would be churn, and would quietly relink bare references the author left
+    bare on purpose elsewhere in the file."""
+    root = _premigration_project(tmp_path, monkeypatch)
+    (root / "luria.toml").write_text(
+        (root / "luria.toml").read_text()
+        + '[luria.schemes.SRC]\ndir = "record/src.d"\n'
+          '[luria.schemes.DST]\ndir = "record/dst.d"\n')
+    (root / "record" / "src.d").mkdir(parents=True)
+    (root / "record" / "dst.d").mkdir(parents=True)
+    (root / "record" / "src.d" / "SRC-001.md").write_text(
+        "---\nstatus: Active\ntitle: 'A thing'\ntags:\n- record\n"
+        "date: '2026-01-01'\n---\n\n# SRC-001: A thing\n\nBody.\n")
+    page = root / "docs" / "shapes.md"
+    page.write_text("See [SRC-001](../record/src.d/SRC-001.md).\n")
+    config.reset()
+    aliases.reset()
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "shapes")
+    mig = root / "record" / "migrations.d" / "0002-same-shape.toml"
+    mig.write_text('title = "SRC-1 becomes a DST"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "SRC-1"\n'
+                   'to = "DST"\n')
+    migrate.run("0002")
+    out = page.read_text()
+    assert "(../record/dst.d/DST-tmp" in out, out
+    assert "src.d" not in out, "the path follows the move"


### PR DESCRIPTION
Fixes #86. Per your steer on the issue: no archival special-casing — a migration changes the record, git holds the history, the goal is a clean tree.

## The bug was wider than the issue said

A `move_doc` always crosses schemes, and a scheme's address is more than its code:

| | old address | new address |
|---|---|---|
| same render mode | `src.d/SRC-001.md` | `dst.d/DST-004.md` |
| different modes | `page.md#dp-17` | `conventions/PC-002.md` |

The sweep swapped the code *inside* the old link — fixing the label and leaving the target pointing at a file that does not exist. I found the same-render half by writing a test to prove the cross-render fix was narrow; it wasn't narrow, it was half.

## Two failure modes, the second self-inflicted

**Matching on the label.** The first unlink matched `[CODE](...)`, so a citation labelled in prose — `[design-principles #17](../design-principles.md#dp-17)` — was invisible to it. Citations are now found by **the address they point at**.

**Keeping the label.** Stripping the link but keeping its label left `design-principles #17` behind — and that bare `#17` is *itself* a design-principle reference, which the relink pass resolved straight back to the anchor the move had just vacated. **The sweep was correct and its own repair step reverted it.** That is why isolation testing showed a clean rewrite while the real run showed twelve survivors, and it took instrumenting the actual run to see.

So the whole citation, label and all, becomes the new code, and the fixer links it from `doc_refs.resolve` — the one place that knows how each scheme is addressed. A stale label is not worth preserving at the cost of resurrecting the address it names.

Three ordering constraints, each learned by breaking it: the unlink runs **before** the code swap (which rewrites codes inside targets too, erasing what's matched on); `swap_pair` returns early for a relocated pair so its anchor passes don't bury the old address; the relink runs after the moves and the alias reset.

## Verified on the real promotion

`DP-017`/`DP-019` → `PC`, cross-render, 19 files swept:

```
stale anchors (design-principles.md#dp-1[79]):  0
stale paths   (principles.d/DP-01[79]):         0
stale #pc- anchors into the old view:           0
```

Every rebuilt target checked to exist on disk. The citation that survived the first attempt now reads `[PC-002](../conventions/PC-002.md)`. `luria lint` clean on the migrated record.

## Tests

**415 pass.** Both failure modes pinned by mutation, not assumed:

- removing the unlink → 2 tests fail
- restoring the keep-the-label version → the worded-citation test fails

The worded-citation test asserts `#dp-4` appears **nowhere** afterwards, rather than checking the link looks right — the vacated anchor surviving anywhere is the bug.