### PR TITLE
fix(migrate): the relink pass stops where the hyperlink lint stops

### DIFF
--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -43,13 +43,14 @@ A reference the reader cannot follow: the code names no document in this record.
 - [`record/decisions.d/ADR-049.md:28`](../../record/decisions.d/ADR-049.md)
 - [`record/decisions.d/ADR-049.md:46`](../../record/decisions.d/ADR-049.md)
 
+### DP-017 — resolves to nothing (2 unmarked sites · 2 other mentions marked deliberate)
+
+- [`luria/migrate.py:152`](../../luria/migrate.py)
+- [`luria/migrate.py:408`](../../luria/migrate.py)
+
 ### ADR-000 — resolves to nothing (1 unmarked site)
 
 - [`tests/test_concretize.py:205`](../../tests/test_concretize.py)
-
-### DP-017 — resolves to nothing (1 unmarked site · 2 other mentions marked deliberate)
-
-- [`luria/migrate.py:152`](../../luria/migrate.py)
 
 ### DP-018 — resolves to nothing (1 unmarked site · 4 other mentions marked deliberate)
 

--- a/luria/doc_refs.py
+++ b/luria/doc_refs.py
@@ -173,6 +173,16 @@ def _frontmatter_span(text: str) -> tuple[int, int] | None:
 # is what makes it true.
 PROSE_KEYS = ("summary", "origin")
 
+# A `formerly:` list is the record's memory of an address a document used to
+# answer to. Naming an old code there is what the alias IS — a declaration,
+# not a citation — so every scan that reads codes out of a file has to skip
+# it, and for two different reasons: a sweep that rewrote the list would
+# destroy the very trail the next migration derives its aliases from, and a
+# reference scan that counted it would report every migration as having left
+# a dangling reference behind (the document it names is, by construction, the
+# one carrying the list). One definition because it is one exclusion.
+FORMERLY_RE = re.compile(r"^formerly:\n(?:- .*\n)*", re.MULTILINE)
+
 PROSE_KEY_RE = re.compile(
     r"^(?:" + "|".join(PROSE_KEYS) + r"):", re.MULTILINE)
 NEXT_KEY_RE = re.compile(r"^(?=[A-Za-z_][\w-]*:|---[ \t]*$)", re.MULTILINE)

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -313,7 +313,8 @@ def _tracked_files() -> list[Path]:
 URL_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s<>)\]\"']+", re.IGNORECASE)
 
 
-def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
+def sweep_text(text: str, plan: Plan, paths: bool = True,
+               source: Path = doc_refs.ANY_MD) -> tuple[str, int]:
     """Every mapped spelling in one text, rewritten. Masks only what the
     mapping doesn't own: composed remote codes (another project's namespace)
     that the spec didn't explicitly claim via `remotes = [...]`, URLs for
@@ -329,8 +330,7 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
         # they are the record's memory of this very operation, and of every
         # one before it. A later migration sweeping an earlier migration's
         # trail would corrupt exactly what makes aliases derivable.
-        spans += [m.span() for m in
-                  re.finditer(r"^formerly:\n(?:- .*\n)*", text, re.MULTILINE)]
+        spans += [m.span() for m in doc_refs.FORMERLY_RE.finditer(text)]
         if mask_urls:
             spans += [m.span() for m in URL_RE.finditer(text)]
         return spans
@@ -403,10 +403,47 @@ def sweep_text(text: str, plan: Plan, paths: bool = True) -> tuple[str, int]:
                 new_code)
         return text
 
+    def respell_relocated(text: str) -> str:
+        """A citation WORDED rather than spelled — `design-principles #17` in
+        a code comment — names a moved document as surely as `DP-017` does,
+        and both the code swap and the address swap walk straight past it: it
+        contains no code, and (unlinked) it points at no address.
+
+        The recognizer is the one the fixer already uses, so the two can't
+        disagree about what counts as a reference — `find_refs` is what turns
+        `design-principles #17` into a link in the first place. Only
+        *relocated* documents are respelled, and only the prose spellings: a
+        citation that already spells the code belongs to `swap_pair`, which
+        knows how to mirror padding."""
+        targets: dict[tuple[str, int], Pair] = {
+            (pair.old_parts[0].upper(), pair.old_parts[1]): pair
+            for pair in plan.mapping if pair.new in plan.relocated}
+        if not targets:
+            return text
+        out, cursor = [], 0
+        for ref in doc_refs.find_refs(text, source):
+            if ref.kind != "scheme" or ref.code:
+                continue
+            pair = targets.get((ref.prefix.upper(), ref.num))
+            if pair is None:
+                continue
+            prefix, number = pair.old_parts
+            if re.fullmatch(rf"{re.escape(prefix)}[- ]0*{number}",
+                            ref.text, re.IGNORECASE):
+                continue                 # a code spelling; swap_pair's job
+            out.append(text[cursor:ref.start])
+            out.append(pair.new)
+            cursor = ref.end
+            nonlocal count
+            count += 1
+        out.append(text[cursor:])
+        return "".join(out)
+
     # Before any swapping: a moved document's citations are matched by the
     # address they point at, and the code swap rewrites codes inside link
     # targets too — so running this later would leave nothing to match.
     text = unlink_relocated(text)
+    text = respell_relocated(text)
 
     # Composed pairs first: `LU-OLD-013` must be rewritten whole before the
     # bare-code pattern reads `OLD-013` out of the middle of it.
@@ -520,7 +557,8 @@ def apply(plan: Plan) -> tuple[int, int]:
             if doc_refs.unlinted(live, text):
                 continue
             new, count = sweep_text(text, plan,
-                                    paths=live not in plan.config_files)
+                                    paths=live not in plan.config_files,
+                                    source=live)
             if count:
                 live.write_text(new)
                 files += 1
@@ -534,9 +572,20 @@ def apply(plan: Plan) -> tuple[int, int]:
     # leaving it to a follow-up `luria link --fix` keeps the migration's
     # output clean on its own terms — a run that ends with dangling bare refs
     # is a run that half-finished.
+    #
+    # Over `doc_files()`, which is `luria link`'s own file set — NOT the
+    # tracked files the sweep walks. The two passes ask different questions.
+    # The sweep asks "does this text spell a code that moved?", which a source
+    # file answers as truthfully as a document does. Linking asks "should this
+    # reference be a hyperlink?", and for a `.ts` comment or a workflow YAML
+    # the answer is no: they are exempt from the hyperlink lint because code
+    # is quoted, not asserted. Running the fixer wider than the linter checks
+    # is how one migration rewrote 469 files nobody had asked it to touch,
+    # burying two moved documents in a diff of markdown links inside Python
+    # comments (#90).
     if plan.relocated:
         adrs, anchors = doc_refs.adr_paths(), doc_refs.dp_anchors()
-        for path in _tracked_files():
+        for path in doc_refs.doc_files():
             if not path.exists():
                 continue
             try:
@@ -592,7 +641,8 @@ def run(spec: str, dry_run: bool = False, commit: bool = False) -> None:
         would = 0
         for path in _tracked_files():
             try:
-                _, count = sweep_text(path.read_text(), plan)
+                _, count = sweep_text(path.read_text(), plan,
+                                      source=path)
             except (UnicodeDecodeError, OSError):
                 continue
             would += 1 if count else 0

--- a/luria/ref_status.py
+++ b/luria/ref_status.py
@@ -294,6 +294,13 @@ def scan(files: list[Path] | None = None, docs: dict[str, Doc] | None = None) ->
         # foreign document (ADR-009), and counting it as a local reference
         # would report every such link as dangling.
         text = _blank(text, [m.span() for m in URL_RE.finditer(text)])
+        # A `formerly:` entry names an address this document used to answer
+        # to — a code that resolves to nothing precisely BECAUSE the alias
+        # exists. Counting it made `luria migrate` hand back two fresh
+        # "resolves to no document" warnings for a two-document move, every
+        # time, pointing at the two files the migration had just written.
+        text = _blank(text, [m.span() for m in
+                             doc_refs.FORMERLY_RE.finditer(text)])
         # `LU-ADR-013` names the remote's decision 13, not this project's.
         # Blanking the composed span is what stops the local scheme pattern
         # reading a foreign code out of the middle of it (ADR-016) — but a

--- a/record/changelog.d/fix-migrate-sweep-scope.md
+++ b/record/changelog.d/fix-migrate-sweep-scope.md
@@ -1,0 +1,30 @@
+### Fixed
+
+- **`luria migrate`'s relink pass now stops where the hyperlink lint stops**
+  ([#90](https://github.com/dmarx/luria/issues/90)). It walked every tracked
+  file and linkified what it found there, while `luria link --fix` walks
+  `doc_files()` — the fixer running wider than the linter checks, which is the
+  disagreement `doc_refs` exists to prevent. The first real `move_doc`
+  migration turned two moved documents into a 499-file working tree, 469 of
+  them exactly `HEAD` plus markdown links written into Python comments,
+  TypeScript comments and workflow YAML. The *sweep* still walks every tracked
+  file, and should: "does this text spell a code that moved?" is a question a
+  `.py` comment answers as truthfully as a document does. Only the linking half
+  was scoped wrong.
+- **A worded citation in a source file follows the move too.**
+  [#89](https://github.com/dmarx/luria/pull/89) caught the prose-labelled form
+  by the *address* it points at — which works in a document, where the citation
+  is a link, and misses it entirely in code, where `(design-principles #17)` is
+  normally unlinked: no code for the code swap, no address for the address
+  swap. Eight of them survived the strata-g promotion, naming a document that
+  had moved. The sweep now respells them using `find_refs`, the same recognizer
+  that would have turned the phrase into a link in the first place, so the two
+  cannot disagree about what counts as a reference.
+- **A `formerly:` stamp is no longer reported as a dangling reference.** The
+  reference scan is deliberately unmasked, so it read the alias the move had
+  just written and reported `DP-017 resolves to no document` against the file
+  the migration had created — one warning per moved document, every time, for
+  the one construct whose entire purpose is to name a code that resolves to
+  nothing. `sweep_text` already excluded `formerly:` blocks for the mirror
+  reason (a later migration must not rewrite an earlier one's trail); the two
+  exclusions now share `doc_refs.FORMERLY_RE`, because they are one exclusion.

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -407,3 +407,81 @@ def test_a_worded_citation_of_a_moved_document_is_rebuilt(tmp_path,
     assert "design-principles.md#dp-4" not in out, out
     assert "#dp-4" not in out, "the vacated anchor must not survive anywhere"
     assert "VAL-tmp" in out, out
+
+
+def _worded_move_project(tmp_path, monkeypatch):
+    """The premigration project plus a SOURCE FILE that cites DP-4 two ways —
+    by code and in prose — and a spec that moves DP-4 into an index-rendered
+    scheme."""
+    root = _premigration_project(tmp_path, monkeypatch)
+    (root / "luria.toml").write_text(
+        (root / "luria.toml").read_text()
+        + '[luria.code]\nglobs = ["src/*.py"]\n'
+          '[luria.schemes.VAL]\ndir = "record/values.d"\n')
+    (root / "record" / "values.d").mkdir(parents=True)
+    (root / "src").mkdir()
+    (root / "src" / "engine.py").write_text(
+        "# Selection rides undo by decision (design-principles #4), not by\n"
+        "# accident. DP-4 is the claim; DP-1 is a different one.\n"
+        "SELECTION_RIDES_UNDO = True\n")
+    config.reset()
+    aliases.reset()
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-qm", "src")
+    (root / "record" / "migrations.d" / "0002-worded-code.toml").write_text(
+        'title = "DP-4 becomes a value"\n\n'
+        '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\nto = "VAL"\n')
+    return root
+
+
+def test_the_relink_pass_stops_where_the_hyperlink_lint_stops(tmp_path,
+                                                              monkeypatch):
+    """Rebuilding links must not reach files the linter never checks.
+
+    The sweep walks every tracked file, because "does this text spell a code
+    that moved?" is a question a `.py` comment answers as truthfully as a
+    document does. Linking is a different question — code is quoted, not
+    asserted, so a source file is exempt from the hyperlink lint — and running
+    the fixer wider than the linter checks turned one two-document move into a
+    469-file diff of markdown links inside Python comments."""
+    root = _worded_move_project(tmp_path, monkeypatch)
+    migrate.run("0002")
+    src = (root / "src" / "engine.py").read_text()
+    assert "](" not in src, f"no markdown links in a source file:\n{src}"
+    # DP-1 did not move, and stays exactly as the author left it.
+    assert "DP-1 is a different one" in src, src
+
+
+def test_a_worded_citation_in_code_follows_the_move(tmp_path, monkeypatch):
+    """A prose-spelled citation names the document as surely as the code does.
+
+    `design-principles #4` in a comment carries no code for the code swap to
+    catch and, unlinked, no address for the address swap to catch. It is
+    recognized by the same scanner that would have turned it into a link in a
+    document, so the sweep can respell it — and must, or the move leaves a
+    citation pointing at a document that is no longer there."""
+    root = _worded_move_project(tmp_path, monkeypatch)
+    migrate.run("0002")
+    src = (root / "src" / "engine.py").read_text()
+    assert "design-principles #4" not in src, src
+    assert "#4" not in src, "the vacated anchor number must not survive"
+    assert src.count("VAL-tmp") == 2, f"both spellings respelled:\n{src}"
+    assert "DP-1 is a different one" in src, "an unmoved code is left alone"
+
+
+def test_a_formerly_stamp_is_not_a_dangling_citation(tmp_path, monkeypatch):
+    """The alias a move writes must not be reported as a broken reference.
+
+    `formerly: DP-004` names a code that resolves to no document *because the
+    alias exists* — that is what the stamp is for. Counting it made every
+    migration hand back one fresh "resolves to no document" warning per moved
+    document, pointing at the files the migration had just written."""
+    root = _worded_move_project(tmp_path, monkeypatch)
+    migrate.run("0002")
+    config.reset()
+    aliases.reset()
+    moved = next((root / "record" / "values.d").glob("VAL-*.md"))
+    assert "formerly:" in moved.read_text(), moved.read_text()
+    assert "DP-004" not in ref_status.scan().dangling, \
+        "the stamp is a declaration, not a citation"


### PR DESCRIPTION
Closes [#90](https://github.com/dmarx/luria/issues/90). Three defects, all found by running the first real `move_doc` migration downstream in strata-g (two principles promoted to a new `PC` scheme).

### 1. The relink pass ran over every tracked file

`migrate.apply()` finished by rebuilding the links the sweep dropped to bare references, iterating `_tracked_files()`. `luria link --fix` iterates `doc_files()`. The gap is every source file in the repo, and the result was a **499-file working tree** for a two-document move — 469 of them exactly `HEAD` plus linkification:

```python
-# App version (semver, issue #256 / ADR-088) — read from the canonical root
+# App version (semver, issue [#256](…/issues/256) / [ADR-088](docs/decisions/ADR-088.md)) — …
```

Code is exempt from the hyperlink lint because code is quoted, not asserted. The fixer running wider than the linter checks is the two disagreeing, which is the thing `doc_refs` is a shared module to prevent — and it buried the actual migration in noise.

The **sweep** still walks every tracked file, deliberately: "does this text spell a code that moved?" is a question a `.py` comment answers as truthfully as a document does. Only the linking half was scoped wrong.

### 2. Worded citations in source files didn't follow a move

[#89](https://github.com/dmarx/luria/pull/89) caught the prose-labelled citation by matching the **address** it points at — which is how it appears in a document, where it's a link. In code the same citation is unlinked:

```typescript
// SELECTION semantics are NOT presentation (design-principles #17): the
```

No code for the code swap, no address for the address swap, so it survived the move pointing at a document that had gone. Eight of these were left behind across `mcp-server/src` and `web/src`.

`sweep_text` now respells them through `doc_refs.find_refs` — the same recognizer that turns the phrase into a link in a document — restricted to *relocated* documents, and skipping citations that already spell the code (those belong to `swap_pair`, which knows how to mirror padding).

### 3. Every migration reported its own `formerly:` stamps as dangling

`ref_status.scan()` is deliberately unmasked, so it read the alias the move had just written and reported `DP-017 resolves to no document, cited 1× in 1 file(s)` against a file the migration had created. One warning per moved document, every time, for the one construct whose purpose is to name a code that resolves to nothing.

`sweep_text` already masked `formerly:` blocks for the mirror reason — a later migration must not rewrite an earlier one's trail. Both now share `doc_refs.FORMERLY_RE`, because they are one exclusion.

### Tests

Three added to `tests/test_migrations.py`, each verified to fail with its fix reverted and pass with it:

| test | mutation reverted | result |
|---|---|---|
| `test_the_relink_pass_stops_where_the_hyperlink_lint_stops` | `doc_files()` → `_tracked_files()` | fails |
| `test_a_worded_citation_in_code_follows_the_move` | drop `respell_relocated` | fails |
| `test_a_formerly_stamp_is_not_a_dangling_citation` | drop the `FORMERLY_RE` blank | fails |

Full suite: 418 passed. `luria lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012AWc5urqmvaJUhcvy1VWLM)_