### PR TITLE
fix(index): a gitignored view is not stale, and one rule set decides

### DIFF
--- a/luria/adr_index.py
+++ b/luria/adr_index.py
@@ -41,7 +41,9 @@ from __future__ import annotations
 import os.path
 import posixpath
 import re
+import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -391,6 +393,38 @@ def orphans(rendered: dict[Path, str]) -> list[Path]:
             for p in sorted(d.glob("*.md")) if p not in rendered]
 
 
+def ignored(paths: list[Path]) -> set[Path]:
+    """The subset of `paths` that git is configured to ignore.
+
+    A generated view the project has gitignored is one it has decided not to
+    keep — `[luria.paths] reports = "build/doc-reports"` behind a CI artifact
+    upload is the shape that exists in the wild. The staleness check has
+    nothing to compare against there: a fresh clone never has the file, so
+    *missing* reads as *stale*, and the remedy the failure prints — regenerate
+    and commit the result — is the one thing `.gitignore` forbids. A check
+    that cannot be satisfied is not a check; it is a permanently red job that
+    teaches people to stop reading it, which is DP-1 wearing a green hat.
+
+    Only `--check` consults this. Writing is unaffected: `luria index` still
+    renders an ignored view, because *not committed* is not *not wanted* —
+    that report is precisely what the artifact upload publishes.
+
+    One `git check-ignore` for the whole set. Exit 1 means "nothing matched",
+    the ordinary answer; anything else (not a repo, no git on PATH) means we
+    cannot tell, and not-ignored is the answer that keeps checking."""
+    if not paths:
+        return set()
+    try:
+        out = subprocess.run(
+            ["git", "check-ignore", "--", *(str(p) for p in paths)],
+            cwd=current().root, capture_output=True, text=True)
+    except OSError:
+        return set()
+    if out.returncode not in (0, 1):
+        return set()
+    return {Path(line).resolve() for line in out.stdout.splitlines() if line}
+
+
 def _render_scheme(scheme) -> dict[Path, str]:
     docs = load_scheme(scheme)
     if scheme.render == "document":
@@ -428,6 +462,53 @@ def outputs() -> dict[Path, str]:
     return out
 
 
+@dataclass(frozen=True)
+class Staleness:
+    """Everything the staleness check has to say about the tree.
+
+    Three kinds, kept apart because each wants a different sentence: a view
+    that differs from what the generator would write, a file sitting in a view
+    directory the generator never wrote, and a README whose badge counts have
+    drifted."""
+    stale: list[Path]
+    orphaned: list[Path]
+    badges: Path | None
+
+    @property
+    def all(self) -> list[Path]:
+        return self.stale + self.orphaned + ([self.badges] if self.badges else [])
+
+    @property
+    def any(self) -> bool:
+        return bool(self.all)
+
+
+def staleness(rendered: dict[Path, str] | None = None) -> Staleness:
+    """The one answer `luria index --check` and `luria lint` both consume.
+
+    They used to compute it twice, in two files, from the same three rules —
+    which is the arrangement where a fix lands in one of them and the other
+    keeps failing. It did: the gitignore exemption below was written in
+    `--check` first, and `lint` went on rejecting the same tree.
+
+    A view the project gitignores is excluded from all three kinds. There is
+    no committed copy to compare against — see `ignored`."""
+    from . import badges as badges_mod
+    rendered = outputs() if rendered is None else rendered
+    loose = orphans(rendered)
+    skip = ignored(list(rendered) + loose)
+    readme = badges_mod.readme()
+    drifted = (readme.exists() and readme not in skip
+               and badges_mod.OPEN in (text := readme.read_text())
+               and badges_mod.rewrite(text) != text)
+    return Staleness(
+        stale=[p for p, text in rendered.items()
+               if p not in skip and (not p.exists() or p.read_text() != text)],
+        orphaned=[p for p in loose if p not in skip],
+        badges=readme if drifted else None,
+    )
+
+
 def run(check: bool = False) -> None:
     """Regenerate every view — the decision index and tag pages, the
     principles document, the devlog books, the status reports, the README
@@ -441,27 +522,18 @@ def run(check: bool = False) -> None:
             for p in journal.populate_created(j):
                 print(f"populated `created:` from the path in {current().rel(p)}")
 
-    rendered = outputs()
     if check:
-        stale = [p for p, text in rendered.items()
-                 if not p.exists() or p.read_text() != text]
-        # Anything in a view directory the generator didn't render is stale
-        # too — a tag page whose tag is gone, a book from an old granularity.
-        stale += orphans(rendered)
-        from . import badges
-        readme = badges.readme()
-        if readme.exists() and badges.OPEN in (text := readme.read_text()) \
-                and badges.rewrite(text) != text:
-            stale.append(readme)
-        if stale:
+        report = staleness()
+        if report.any:
             from . import ci
             print(f"stale ({ci.regenerate_remedy()}):", file=sys.stderr)
-            for p in sorted(stale):
+            for p in sorted(report.all):
                 print(f"  {current().rel(p)}", file=sys.stderr)
             raise SystemExit(1)
         print("luria index: current")
         return
 
+    rendered = outputs()
     cfg = current()
     for stale_file in orphans(rendered):
         stale_file.unlink()

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -197,26 +197,27 @@ def check_generated_index(errors: list[str]) -> None:
     """The index is generated (ADR-004) — verify it's current, rather than
     checking each document is mentioned, which a generated file can't fail."""
     cfg = current()
-    rendered = builder.outputs()
+    # Computed by the generator, not recomputed here: the rules for what
+    # counts as stale live in one place, so this check and `luria index
+    # --check` cannot answer differently. Only the wording is this file's.
+    report = builder.staleness()
     # This lint is usually read in a build log, where "run `luria index`" names
     # the one action that must not be taken here — putting the generator ahead
     # of this check makes it compare the generator's output against itself, and
     # it stops being able to fail (ADR-029). The remedy says so when it is
     # being read in CI.
     remedy = ci.regenerate_remedy()
-    for path, text in rendered.items():
-        if not path.exists() or path.read_text() != text:
-            errors.append(f"{cfg.rel(path)}: stale — {remedy}")
-    for path in builder.orphans(rendered):
+    for path in report.stale:
+        errors.append(f"{cfg.rel(path)}: stale — {remedy}")
+    for path in report.orphaned:
         errors.append(f"{cfg.rel(path)}: not something the generator wrote — "
                       "a view directory holds only generated files (ADR-021); "
                       f"{remedy}, or file the content as a source")
     # The README's badge counts are derived from the same frontmatter, so a
     # stale one is the same class of failure as a stale index (ADR-018).
-    readme = badges.readme()
-    if readme.exists() and badges.OPEN in (text := readme.read_text()) \
-            and badges.rewrite(text) != text:
-        errors.append(f"{cfg.rel(readme)}: badge counts are stale — {remedy}")
+    if report.badges:
+        errors.append(
+            f"{cfg.rel(report.badges)}: badge counts are stale — {remedy}")
 
 
 def check_wikilinks(errors: list[str]) -> None:

--- a/record/changelog.d/fix-ignored-views-are-not-stale.md
+++ b/record/changelog.d/fix-ignored-views-are-not-stale.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **A generated view the project gitignores is no longer reported stale.** A
+  project can point `[luria.paths] reports` at a build directory and publish
+  the result as a CI artifact instead of committing it. A fresh clone then
+  never has the file, so *missing* read as *stale* — and the remedy the
+  failure printed, "regenerate and commit the result", is the one thing
+  `.gitignore` forbids. Downstream that meant a docs job red on every commit
+  for a day, on a check nothing could satisfy, which is
+  [DP-1](docs/design-principles.md#dp-1) wearing a green hat: the tool refused
+  and its explanation was impossible to act on. `--check` now excludes
+  gitignored outputs from all three staleness kinds. Writing is unchanged —
+  `luria index` still renders an ignored view, because *not committed* is not
+  *not wanted*; that report is exactly what the artifact upload publishes.
+- **`luria lint` and `luria index --check` share one staleness rule set.** They
+  each had their own copy of the same three rules — stale view, orphan in a
+  view directory, drifted README badges — and the fix above landed in one of
+  them, so `lint` went on rejecting the identical tree the generator had just
+  called current. That is the fixer/linter split this package exists to
+  prevent, reproduced inside the package. `adr_index.staleness()` is now the
+  single answer both consume; only the wording stayed with the linter, because
+  a build log and a `--check` want different sentences. A test pins the
+  invariant from outside: whatever one command says about a tree, the other
+  says too.

--- a/tests/test_doc_reports.py
+++ b/tests/test_doc_reports.py
@@ -17,11 +17,14 @@ column — not by "today's date appears nowhere": a decision filed and still
 `Proposed` today legitimately puts today's date in the report, so that
 blunter assertion fails on a correct report exactly once per decision.
 """
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 from _scheme import decision
 
-from luria import adr_pending, ref_status, reports
+from luria import adr_index, adr_pending, config, lint, ref_status, reports
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -139,3 +142,114 @@ def test_reports_are_deterministic():
     a = reports.reference_status(), reports.pending_decisions()
     b = reports.reference_status(), reports.pending_decisions()
     assert a == b
+
+
+def _git(root, *args):
+    subprocess.run(["git", *args], cwd=root, check=True,
+                   capture_output=True, text=True)
+
+
+def test_a_gitignored_report_dir_is_not_stale(tmp_path, monkeypatch):
+    """`luria index --check` must not fail over a view the project ignores.
+
+    A project can point `[luria.paths] reports` at a build directory and
+    publish the result as a CI artifact instead of committing it — which is
+    the shape downstream had. A fresh clone then never has the file, so
+    *missing* read as *stale*, and the remedy the failure printed ("regenerate
+    and commit the result") is the one thing `.gitignore` forbids: the docs
+    job went red on every commit and stayed there.
+    """
+    (tmp_path / "docs" / "decisions").mkdir(parents=True)
+    (tmp_path / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.paths]\nreports = "build/doc-reports"\n')
+    (tmp_path / "docs" / "design-principles.md").write_text(
+        "# Design principles\n\n## 1. First value\n\nBody.\n")
+    (tmp_path / ".gitignore").write_text("build/\n")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-qm", "before")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+
+    adr_index.run()                            # writes every view, ignored ones too
+    assert (tmp_path / "build" / "doc-reports" /
+            "reference-status.md").exists(), "an ignored view is still written"
+    adr_index.run(check=True)                  # …and does not gate on them
+
+    shutil.rmtree(tmp_path / "build")          # the state of every fresh clone
+    adr_index.run(check=True)
+
+
+def test_a_tracked_report_dir_still_gates(tmp_path, monkeypatch):
+    """The exemption is `.gitignore`, not the reports directory.
+
+    A project that commits its reports — which is this repo's own layout —
+    must keep failing on a stale one, or the fix would have turned a real
+    check off for everybody to unstick one project.
+    """
+    (tmp_path / "docs" / "decisions").mkdir(parents=True)
+    (tmp_path / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.paths]\nreports = "docs/reports"\n')
+    (tmp_path / "docs" / "design-principles.md").write_text(
+        "# Design principles\n\n## 1. First value\n\nBody.\n")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-qm", "before")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+
+    adr_index.run()
+    adr_index.run(check=True)
+    (tmp_path / "docs" / "reports" / "reference-status.md").write_text("stale\n")
+    with pytest.raises(SystemExit):
+        adr_index.run(check=True)
+
+
+def test_lint_and_index_check_agree_about_staleness(tmp_path, monkeypatch):
+    """One rule set, two commands. They used to be two rule sets.
+
+    `luria index --check` and `luria lint`'s `check_generated_index` both
+    decided what "stale" means, from the same three rules written twice. The
+    gitignore exemption above went into the first one and `lint` went on
+    rejecting the identical tree — the fixer/linter split this package exists
+    to prevent, reproduced inside the package. They share `staleness()` now,
+    and this pins it from the outside: whatever one says about a tree, the
+    other says too.
+    """
+    (tmp_path / "docs" / "decisions").mkdir(parents=True)
+    (tmp_path / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.paths]\nreports = "build/doc-reports"\n')
+    (tmp_path / "docs" / "design-principles.md").write_text(
+        "# Design principles\n\n## 1. First value\n\nBody.\n")
+    (tmp_path / ".gitignore").write_text("build/\n")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-qm", "before")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+
+    def verdicts() -> tuple[bool, list[str]]:
+        try:
+            adr_index.run(check=True)
+            index_stale = False
+        except SystemExit:
+            index_stale = True
+        errors: list[str] = []
+        lint.check_generated_index(errors)
+        return index_stale, errors
+
+    adr_index.run()
+    shutil.rmtree(tmp_path / "build")
+    index_stale, errors = verdicts()
+    assert not index_stale and not errors, errors
+
+    # …and they agree the other way too, on a view that IS tracked.
+    (tmp_path / "docs" / "decisions" / "README.md").write_text("hand-edited\n")
+    index_stale, errors = verdicts()
+    assert index_stale and errors, "both must fail on a genuinely stale view"


### PR DESCRIPTION
Independent of [#91](https://github.com/dmarx/luria/pull/91) — branched from `main`, merges in either order.

## The failure

strata-g points `[luria.paths] reports` at `build/doc-reports/` and publishes the result as a CI artifact rather than committing it. `build/` is in `.gitignore`. Its docs job checks out clean, `git clean -ffdx` removes `build/`, and:

```
luria: 2 violation(s)
  build/doc-reports/reference-status.md: stale — regenerate and commit the result …
  build/doc-reports/pending-decisions.md: stale — regenerate and commit the result …
```

A fresh clone never has the file, so **missing reads as stale**, and the remedy the failure prints is the one thing `.gitignore` forbids. That job has been red on every commit since 2026-08-15T06:42Z on a check nothing can satisfy — [DP-1](docs/design-principles.md#dp-1) wearing a green hat: the tool refused and its explanation was impossible to act on.

`--check` now excludes gitignored outputs from all three staleness kinds. **Writing is unchanged** — `luria index` still renders an ignored view, because *not committed* is not *not wanted*; that report is precisely what the artifact upload publishes.

## Fixing it once wasn't enough, and that's the more interesting half

The exemption went into `adr_index.run(check=True)`. `luria index --check` then said *current* on the tree — and `luria lint` went on rejecting the identical tree.

`lint.check_generated_index` had its own copy of the same three rules (stale view / orphan in a view directory / drifted README badges). Two code paths asking one question, so a fix reaches one of them. That is **the fixer-linter split this package exists to prevent, reproduced inside the package** — `doc_refs` is a shared module for exactly this reason, and the staleness rules never got the same treatment.

`adr_index.staleness()` is now the single answer both consume. Only the wording stayed with the linter, because a build log and a `--check` want different sentences.

## Tests

Three, in `tests/test_doc_reports.py`:

| test | what it pins | mutation |
|---|---|---|
| `test_a_gitignored_report_dir_is_not_stale` | an ignored view is written but never gated | `skip = set()` → fails |
| `test_a_tracked_report_dir_still_gates` | the exemption is `.gitignore`, not the reports dir | guard — passes either way, by design |
| `test_lint_and_index_check_agree_about_staleness` | both commands, one verdict, both directions | re-inline lint's own rules → fails |

418 pass. `luria lint` clean on this repo.

Verified against the real downstream tree: `rm -rf build && luria lint` in strata-g goes from **exit 1 with 2 violations** to **exit 0**.

---
_Generated by [Claude Code](https://claude.ai/code/session_012AWc5urqmvaJUhcvy1VWLM)_