### PR TITLE
fix(template): a scaffolded project starts with no dangling references

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,6 @@ carries its prefix, so a second scheme is an entry here (ADR-006).
 | `output` | `Path \| None` | *unset* |
 | `allocate` | `str` | `"filing"` |
 | `titles_generalize` | `bool` | `False` |
-| `requires` | `tuple[str, ...]` | *unset* |
 
 ## Fragment directories — `[luria.fragments."dir"]`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,7 @@ carries its prefix, so a second scheme is an entry here (ADR-006).
 | `output` | `Path \| None` | *unset* |
 | `allocate` | `str` | `"filing"` |
 | `titles_generalize` | `bool` | `False` |
+| `requires` | `tuple[str, ...]` | *unset* |
 
 ## Fragment directories — `[luria.fragments."dir"]`
 

--- a/record/changelog.d/claude-template-fixture-codes.md
+++ b/record/changelog.d/claude-template-fixture-codes.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A scaffolded project no longer starts with dangling references.** Three
+  illustrative codes in shipped templates came from the real sequence and
+  resolved to nothing in a fresh scaffold (`ADR-049` in two `_template.md`
+  files, `ADR-001` in `CLAUDE.md`); they now use the `FX-` fixture prefix.
+  Three more in the scaffolded workflows cited Luria's own decisions bare, so
+  they read as the adopting project's decisions — they now compose as `LU-`.
+  A fresh `init` + `index` + `lint` went from 5 unresolved codes to none.

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# The record's own CI, in the recommended shape (ADR-029). Three jobs:
+# The record's own CI, in the recommended shape (LU-ADR-029). Three jobs:
 #
 #   docs-generate  regenerates the derived views (index, tag pages, books,
 #                  README badges, reference links) and commits them back as
@@ -12,7 +12,7 @@
 #                  workflows, so a lint anywhere else would keep a red earned
 #                  from the pre-regeneration commit and never clear it.
 #   collect        assembles changelog fragments on a cadence, never
-#                  per-merge (ADR-002 — a per-merge bot commit races
+#                  per-merge (LU-ADR-002 — a per-merge bot commit races
 #                  in-flight rebases, reintroducing the conflict fragments
 #                  exist to remove).
 #

--- a/template/.github/workflows/pages.yml
+++ b/template/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-# Publish the record as a browsable site on GitHub Pages (ADR-042).
+# Publish the record as a browsable site on GitHub Pages (LU-ADR-042).
 #
 # `luria site` stages every page the record publishes — the decisions, the
 # principles document, the devlog books, the reports — with paths preserved,

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -43,7 +43,7 @@ Four ground rules, terse enough to restate:
   link --fix` spell the target: record prose is rendered into views in
   *other directories*, so a target has to resolve from where the text
   lands, not where it lives — only the fixer knows that frame. Want prose
-  as the label? That's `[[ADR-001|a labeled wikilink]]`, still the fixer's
+  as the label? That's `[[FX-ADR-001|a labeled wikilink]]`, still the fixer's
   job. A hand-written target that looks right here is wrong somewhere.
 - **A guard that keeps catching you is a bug report about the workflow.**
   One catch is the net working; the same catch again means the hazard is

--- a/template/record/decisions.d/_template.md
+++ b/template/record/decisions.d/_template.md
@@ -3,7 +3,7 @@
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the
 # next free number on the spot, `merge` mints a temporary code that
-# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
+# `luria concretize` numbers where merges serialize (FX-ADR-049). The kinds are the
 # config: every scheme, fragment directory and journal in luria.toml is one, so
 # `luria new <kind>` works for a scheme the moment it is declared.
 #

--- a/template/record/principles.d/_template.md
+++ b/template/record/principles.d/_template.md
@@ -3,7 +3,7 @@
 # and fills in the fields a machine can compute. WHICH identity depends on the
 # scheme's `allocate` mode: `filing` (the default) takes the next free number
 # on the spot, `merge` mints a temporary code that `luria concretize` numbers
-# where merges serialize (ADR-049).
+# where merges serialize (FX-ADR-049).
 #
 # Numbering is sequential and permanent: a principle is cited by number ("per
 # DP-3"), so a number can be retired but never reused. The filename is the code


### PR DESCRIPTION
A fresh `luria init` → `index` → `lint` reports **five codes resolving to no document**, all shipped by the templates themselves:

```
luria: 5 code(s) resolve to no document
  ADR-049 resolves to no document, cited 2× in 2 file(s)
  ADR-001 resolves to no document, cited 1× in 1 file(s)
  ADR-002 resolves to no document, cited 1× in 1 file(s)
  ADR-029 resolves to no document, cited 1× in 1 file(s)
  ADR-042 resolves to no document, cited 1× in 1 file(s)
```

Two kinds, with different fixes.

## Illustrative codes → `FX-`

`ADR-049` in `record/decisions.d/_template.md` and `record/principles.d/_template.md`, and `ADR-001` as the wikilink syntax example in `CLAUDE.md`.

These are *examples*, not citations, and they come from the real sequence — [ADR-032](record/decisions.d/ADR-032.md)'s hazard exactly. The day a project's own sequence reaches 049, the specimen starts resolving to an unrelated decision and silently reads as a citation of it.

I hit this from the other side downstream: an ADR illustrated supersession with a plausible `CLM-014`, extraction later minted a real CLM-014, and the `unresolved-ok` excusing it went stale the same day. `FX-` resolves always, cannot collide, and needs no directive.

## Real citations written bare → `LU-`

`ADR-042` in `pages.yml`, `ADR-029` and `ADR-002` in `docs.yml`. These genuinely cite *Luria's* decisions, but written bare they read as the **adopting project's** decisions and resolve to nothing. They now compose as `LU-`, for which the scaffolded config already declares a remote.

This kind is invisible by default: the scaffolded config ships `globs = []`, so the workflows aren't scanned until a project adds them — at which point three dangling codes appear in files it never wrote.

## Verification

Fresh scaffold, with `.github/workflows/*.yml` in globs:

| | unresolved codes |
|---|---|
| before | **5** |
| after | **0** |

426 tests pass, `luria lint` clean.

## One thing worth a second opinion

The shipped config comments out `fail_on = ["retired-citations", "pending-documents"]`, so a default scaffold reports these as warnings and exits **0**. That's why this has been invisible — it only becomes a failure once a project opts into `unresolved-codes`, which is the natural thing to do when the citation graph is the point.

I also checked and can rule out a related suspicion: the scaffolded `luria.toml` **does** declare the `LU` and `FX` remotes. An adoption guide I was following claimed otherwise, but that was a defect in its own hand-written config, not upstream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpK3k2WhH9Pnc3i6TjLMVv)_