### PR TITLE
fix(record): ADR-053 is a real decision now, not a specimen

### DIFF
--- a/docs/reports/pending-decisions.md
+++ b/docs/reports/pending-decisions.md
@@ -12,7 +12,7 @@
 | 2026-08-08 | Proposed | [ADR-041](../../record/decisions.d/ADR-041.md) | 0 | 0 | Bugs enter the record characterized: the minimal working example protocol |
 | 2026-08-08 | Proposed | [ADR-052](../../record/decisions.d/ADR-052.md) | 0 | 0 | The draft signal: a contribution that asks for a verdict, not a review |
 | 2026-08-08 | Proposed | [DP-010](../../record/principles.d/DP-010.md) | 0 | 0 | Defaults follow the failure mode: guards opt out, disclosures opt in |
-| 2026-08-16 | Proposed | [ADR-053](../../record/decisions.d/ADR-053.md) | 4 | 4 | The published version is derived from the release tag |
+| 2026-08-16 | Proposed | [ADR-053](../../record/decisions.d/ADR-053.md) | 2 | 2 | The published version is derived from the release tag |
 | 2026-08-16 | Proposed | [ADR-tmpl1j8m](../../record/decisions.d/ADR-tmpl1j8m.md) | 0 | 0 | A scheme can constrain which of its tags combine |
 
 The citation count is the second axis, and it flips the priority: an old proposal nothing references is a stalled idea worth closing, while an old proposal many files cite is a decision the codebase has already made and hasn't written down.

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -33,33 +33,24 @@ Document status is reported, not enforced
 
 The published version is derived from the release tag
 
-4 citations in 2 files await a look.
+2 citations in 1 file await a look.
 
-- [`record/decisions.d/ADR-014.md:89`](../../record/decisions.d/ADR-014.md)
-- [`tests/test_adr_index.py:28`](../../tests/test_adr_index.py)
-- [`tests/test_adr_index.py:29`](../../tests/test_adr_index.py)
-- [`tests/test_adr_index.py:46`](../../tests/test_adr_index.py)
+- [`record/decisions.d/ADR-014.md:28`](../../record/decisions.d/ADR-014.md)
+- [`record/decisions.d/ADR-014.md:138`](../../record/decisions.d/ADR-014.md)
 
 ## Codes that resolve to no document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**9 codes unaccounted for.** Not listed: 37 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**4 codes unaccounted for.** Not listed: 49 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 
-### ADR-123 — resolves to nothing (6 unmarked sites)
+### ADR-123 — resolves to nothing (4 unmarked sites · 2 other mentions marked deliberate)
 
 - [`docs/adopting.md:189`](../adopting.md)
 - [`luria/concretize.py:19`](../../luria/concretize.py)
-- [`record/decisions.d/ADR-014.md:49`](../../record/decisions.d/ADR-014.md)
-- [`record/decisions.d/ADR-014.md:51`](../../record/decisions.d/ADR-014.md)
 - [`record/decisions.d/ADR-049.md:28`](../../record/decisions.d/ADR-049.md)
 - [`record/decisions.d/ADR-049.md:46`](../../record/decisions.d/ADR-049.md)
-
-### ADR-404 — resolves to nothing (2 unmarked sites)
-
-- [`tests/test_adr_index.py:170`](../../tests/test_adr_index.py)
-- [`tests/test_adr_index.py:172`](../../tests/test_adr_index.py)
 
 ### DP-017 — resolves to nothing (2 unmarked sites · 2 other mentions marked deliberate)
 
@@ -69,22 +60,6 @@ A reference the reader cannot follow: the code names no document in this record.
 ### ADR-000 — resolves to nothing (1 unmarked site)
 
 - [`tests/test_concretize.py:205`](../../tests/test_concretize.py)
-
-### ADR-099 — resolves to nothing (1 unmarked site · 1 other mention marked deliberate)
-
-- [`record/decisions.d/ADR-014.md:42`](../../record/decisions.d/ADR-014.md)
-
-### ADR-158 — resolves to nothing (1 unmarked site)
-
-- [`record/decisions.d/ADR-014.md:49`](../../record/decisions.d/ADR-014.md)
-
-### ADR-187 — resolves to nothing (1 unmarked site)
-
-- [`record/decisions.d/ADR-014.md:49`](../../record/decisions.d/ADR-014.md)
-
-### ADR-188 — resolves to nothing (1 unmarked site · 1 other mention marked deliberate)
-
-- [`record/decisions.d/ADR-014.md:49`](../../record/decisions.d/ADR-014.md)
 
 ### DP-018 — resolves to nothing (1 unmarked site · 4 other mentions marked deliberate)
 
@@ -98,5 +73,4 @@ A reference the reader cannot follow: the code names no document in this record.
 
 ## Directives that no longer apply
 
-- record/decisions.d/ADR-014.md:26: annotation names ADR-053, which does resolve here
-- tests/test_adr_index.py:17: annotation names ADR-053, which does resolve here
+None. Every annotation still governs something. ✅

--- a/record/changelog.d/claude-fixture-code-collision.md
+++ b/record/changelog.d/claude-fixture-code-collision.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Two acknowledgements stopped applying when the sequence reached ADR-053.**
+  The specimen lists in `ADR-014` and `tests/test_adr_index.py` borrowed a code
+  from the real sequence, and a real fifty-third decision made it resolve. This
+  is the second time — `ADR-032` went the same way — so `ADR-014` now records
+  that trimming the list is the symptom fix and the `FX-` prefix is the cause
+  fix.

--- a/record/changelog.d/claude-fixture-code-collision.md
+++ b/record/changelog.d/claude-fixture-code-collision.md
@@ -1,6 +1,6 @@
 ### Fixed
 
-- **Two acknowledgements stopped applying when the sequence reached ADR-053.**
+- **Two acknowledgements stopped applying when the sequence reached [ADR-053](record/decisions.d/ADR-053.md).**
   The specimen lists in `ADR-014` and `tests/test_adr_index.py` borrowed a code
   from the real sequence, and a real fifty-third decision made it resolve. This
   is the second time — `ADR-032` went the same way — so `ADR-014` now records

--- a/record/decisions.d/ADR-014.md
+++ b/record/decisions.d/ADR-014.md
@@ -23,9 +23,10 @@ summary: >-
 ---
 
 <!-- inactive-ok-file: ADR-007 — cited while in force; ADR-035 is the successor -->
-<!-- unresolved-ok-file: ADR-053 ADR-099 ADR-123 ADR-158 ADR-187 ADR-188 — this page quotes them as the
-     specimens it is about. ADR-032 left the list when a real thirty-second decision arrived and that
-     specimen began to resolve. -->
+<!-- unresolved-ok-file: ADR-099 ADR-123 ADR-158 ADR-187 ADR-188 — this page quotes them as the
+     specimens it is about. ADR-032 left this list when a real thirty-second decision arrived and its
+     specimen began to resolve; ADR-053 left it the same way, which is twice, and says the list itself
+     is the defect — see the note at the end of Consequences. -->
 
 # ADR-014: A code that resolves to nothing is reported, not dropped
 
@@ -77,7 +78,6 @@ was, in the same vocabulary at the same three scopes
 ([ADR-008](ADR-008.md)):
 
 ```
-<!-- unresolved-ok: ADR-053 — a strata-g code, quoted as the worked example -->
 # unresolved-ok-file: ADR-019, ADR-163 — fixture codes, deliberately not real
 ```
 
@@ -86,7 +86,7 @@ One rule is inverted rather than shared, and it is the interesting part.
 would excuse nothing. `unresolved-ok` is malformed when it names one that
 *does* — there is nothing to excuse. Same check, opposite sign, so an
 acknowledgement that stops applying gets reported either way: the day someone
-adds a real `ADR-053`, the annotation quoting it says so.
+adds a real fifty-third decision, `FX-ADR-053` here becomes a citation of it.
 
 ### Codes inside URLs are not citations
 
@@ -133,3 +133,12 @@ pointed a new project at Luria's own decisions.
 - `Scan` now carries two pools and `annotations()` takes a directive name, which
   is the shape a third acknowledgement would use. The parser was already
   generic; this is the first evidence that it is.
+
+<!-- The specimen list above has now been trimmed twice for the same reason —
+     ADR-032, then ADR-053 — each time because the project's own sequence
+     reached a code this page was borrowing. Trimming is the symptom fix. The
+     cause is that specimens come from the real sequence at all, and the
+     remedy already exists: the `FX-` prefix resolves always and cannot
+     collide. Applying it here is not a one-line change, because several
+     specimens sit inside hand-written link targets that the FX remote would
+     want to construct, so it wants its own pass. -->

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -14,7 +14,8 @@ import re
 import sys
 from pathlib import Path
 
-# unresolved-ok-file: ADR-053, ADR-404 — fixture codes, deliberately not real
+# unresolved-ok-file: ADR-404 — fixture code, deliberately not real. ADR-404 was
+# here until the project's own sequence reached it; see ADR-014's closing note.
 REPO = Path(__file__).resolve().parents[1]
 
 from luria import adr_index as builder  # noqa: E402
@@ -25,8 +26,8 @@ rebase = builder.rebase_links
 
 
 def test_relative_targets_are_rebased():
-    assert rebase("see [ADR-053](adr-053-x.md)", "../") == \
-        "see [ADR-053](../adr-053-x.md)"
+    assert rebase("see [ADR-404](adr-404-x.md)", "../") == \
+        "see [ADR-404](../adr-404-x.md)"
     assert rebase("see [dp](../design-principles.md#13-a)", "../") == \
         "see [dp](../../design-principles.md#13-a)"
 
@@ -43,7 +44,7 @@ def test_absolute_and_anchor_targets_are_left_alone():
 def test_no_prefix_is_a_no_op():
     """README.md renders from the ADRs' own directory, so its rows are the
     unmodified text — that's what kept the ADR-004 migration byte-identical."""
-    text = "see [ADR-053](adr-053-x.md) and [#1](https://example.com/1)"
+    text = "see [ADR-404](adr-404-x.md) and [#1](https://example.com/1)"
     assert rebase(text, "") == text
 
 


### PR DESCRIPTION
**Self-inflicted.** Merging #94 minted the fifty-third decision, and two acknowledgements that had been quoting `ADR-053` as a fixture immediately stopped applying:

```
record/decisions.d/ADR-014.md:26: annotation names ADR-053, which does resolve here
tests/test_adr_index.py:17:      annotation names ADR-053, which does resolve here
```

## Why this is worth more than a trim

ADR-014's own comment already records that this happened once:

> *ADR-032 left the list when a real thirty-second decision arrived and that specimen began to resolve.*

And line 89 anticipated exactly this case, treating the annotation as the mitigation:

> *adds a real `ADR-053`, the annotation quoting it says so.*

The annotation is the thing that rots. Twice now, for the same reason: **specimens come from the real sequence at all**, and the sequence keeps arriving. Trimming the list is the symptom fix — it just nominates the next code to break.

So the list is trimmed (there's nothing else to do about `053` today), and ADR-014 now carries a closing note saying that trimming is the symptom and `FX-` is the cause fix.

## What's deliberately not bundled

Applying `FX-` to the remaining specimens. I tried it, and several sit inside hand-written link targets:

```python
rebase("see [ADR-053](adr-053-x.md)", "../")
```

The `FX` remote wants to *construct* that URL, so `FX-ADR-053` there produces a new warning class (`links to a hand-written URL`). That's a real design question about how fixture codes and link construction interact, and it wants its own pass rather than being smuggled into a regression fix.

`ADR-123` is also a specimen in three further files, so the sweep is wider than these two sites.

This overlaps what **#65** was reaching for. My read there was close-and-redo, and this strengthens it: the cause fix is still wanted, it's larger than #65's diff, and it needs a guard or it recurs a third time.

## The test fixture

Moved to `ADR-404`, which is outside any plausible sequence, with a comment recording why `053` left.

## Verification

428 tests pass, `luria lint` clean, **no stale directives**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpK3k2WhH9Pnc3i6TjLMVv)_