### PR TITLE
feat: warn when a commit message suppresses its own build

### DIFF
--- a/actions/lint/action.yml
+++ b/actions/lint/action.yml
@@ -25,6 +25,14 @@ inputs:
   reports-path:
     description: Where `luria reports` writes — your luria.toml's `reports` path.
     default: docs/reports
+  skip-marker-range:
+    description: >-
+      Commit range scanned for skip markers written as prose — a message
+      *describing* the convention carries the marker and so suppresses its own
+      build. Empty string turns the check off. It needs history to read:
+      `actions/checkout` fetches depth 1 by default, so give the checkout a
+      `fetch-depth` that covers this range or the check has nothing to see.
+    default: HEAD~20..HEAD
 runs:
   using: composite
   steps:
@@ -40,6 +48,13 @@ runs:
     - if: ${{ always() }}
       shell: bash
       run: luria reports
+    # Independent of the lint's verdict, so `always()`: a suppressed build is
+    # worth reporting on the run that failed as much as on the one that
+    # passed. Warns and does not fail — the marker is legitimate on the
+    # commits that mean it, and only position distinguishes them.
+    - if: ${{ always() && inputs.skip-marker-range != '' }}
+      shell: bash
+      run: luria skip-markers --rev-range "${{ inputs.skip-marker-range }}"
     - if: ${{ always() && inputs.reports-artifact != '' }}
       uses: actions/upload-artifact@v4
       with:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,6 +116,32 @@ Assemble fragment directories into their documents — a changelog from
 Fragments exist so the assembled file is not a lock every branch must touch.
 Collect on a cadence, not on every merge.
 
+## `luria skip-markers [--rev-range R] [--strict]`
+
+Report commits whose message carries a CI skip marker **in its body** — a
+message *describing* the convention contains the marker, and so tells the forge
+not to build the commit that describes it.
+
+Position is the whole rule, and it is what keeps this quiet enough to be worth
+running. A deliberate skip goes in the subject line or a trailer, which is where
+every tool that generates one puts it — the `generate` action's own
+`docs: regenerate views [skip ci]` included, which is why no author check is
+needed. A marker anywhere else was almost certainly prose.
+
+Prints nothing when there is nothing to say, warns rather than fails, and says
+nothing at all when it cannot read history — a depth-1 checkout is the ordinary
+case, and a build should not break on a checkout setting. `--strict` exits 1 for
+a project that wants it enforced.
+
+This is a backstop, not a fix: the run it warns on is a **later** one, because
+the suppressed commit's own run is precisely what did not happen. What it
+converts is silence into a message — and silence is the reason the failure is
+hard to spot, since a suppressed build is not a red check but *no* check, with
+the previous commit's green still on display.
+
+The `lint` action runs it; give that job's checkout a `fetch-depth` covering the
+range, or it has nothing to read.
+
 ## `luria init [--config PATH] [--dry-run] [--issue-url URL]`
 
 Scaffold the record a config declares. Never overwrites, so it is safe in a repo

--- a/docs/devlog/2026-08.md
+++ b/docs/devlog/2026-08.md
@@ -2,7 +2,7 @@
 
 # Development log — August 2026
 
-39 entries. [All books](README.md).
+40 entries. [All books](README.md).
 
 ## Contents
 
@@ -45,6 +45,7 @@
 - [16 Aug 19:02 — The field was green because nobody was judging](#20260816190210)
 - [16 Aug 19:30 — Four descriptions and no name](#20260816193000)
 - [22 Aug 06:34 — The schema reference was somebody else's file in everybody else's repo](#20260822063442)
+- [24 Aug 20:51 — A guard for the one convention that has no escape](#20260824205117)
 
 ---
 
@@ -2662,3 +2663,81 @@ page, and `luria lint` then asked for the `docs/README.md` row — and, usefully
 caught a link in that project's own devlog citing the page that had just been
 retired. The upgrade note in the changelog fragment is written from that run
 rather than from what the code looks like it should do.
+
+---
+
+<a name="20260824205117"></a>
+
+## A guard for the one convention that has no escape
+
+*2026-08-24 20:51:17 · ci*
+
+**A project adopting the recommended workflow wrote a commit message
+explaining what the skip marker does, and thereby did it.** Every workflow on
+that commit was skipped. The author had read the caution in `docs.yml`'s
+header — the one that says to name the marker in prose — before making the
+mistake, which is the strongest available evidence that a comment was not
+enough.
+
+The convention has no escape sequence. There is no way to mention the marker
+in a commit message without invoking it, so any project that documents its own
+CI in its own commit messages is one sentence away from a silent skip.
+
+**What makes it expensive is the shape of the failure.** A suppressed run is
+not a red build. It is *no* build, and the pull request goes on displaying the
+previous commit's green checks, because those are the most recent checks that
+exist. Silence is indistinguishable from success unless someone thinks to ask
+which commit the green belongs to — and nobody asks that question on a PR that
+looks passing. In the reported case it was noticed only because a script that
+polled for run results returned stale SHAs.
+
+## The rule is position, not authorship
+
+The first design put an author check on it: warn when a *human* commit carries
+a marker. That is wrong in both directions. It fires on someone deliberately
+skipping a docs-only build, which is correct use of the convention, and it
+needs a list of bot identities to stay quiet.
+
+Position does the whole job. Somebody instructing the forge puts the marker
+where the convention puts it — the subject line, or a trailer at the end — and
+so does every tool that generates one, this package's `generate` action
+included. Somebody *writing about* it lands the marker mid-paragraph. So a
+marker in the first or last line passes silently and one in the body is
+reported, and the bot's own `docs: regenerate views [skip ci]` never fires
+because a one-line message is first and last at once. No author list, no
+configuration.
+
+Worth being precise about what the position means here. GitHub documents the
+marker as honoured in the first or last line; measured, it is broader than
+that — the reported case had it on line nine of a body and every workflow was
+still skipped. So the rule above is not a claim about what the forge honours.
+It is a claim about what the author meant, which is the only thing worth
+guessing at.
+
+## What it cannot do
+
+It cannot catch the commit it is about. The suppressed run is the one that did
+not happen, so nothing inside it can speak; the warning necessarily arrives on
+a later run, once history has moved past the offending commit. That makes this
+a backstop rather than a fix, and the docs say so rather than implying a
+guarantee.
+
+The honest fix is client-side — a `commit-msg` hook that refuses the marker in
+a body — and that is a bigger conversation, because scaffolding git hooks into
+somebody's repository is intrusive in a way writing files is not. Not doing it
+here.
+
+## Kept quiet on purpose
+
+`ci.py` already carried the lesson this needed, in a comment about a helper
+that was built and removed before merge: a warning that fires on correct runs
+trains readers to skip warnings. So this prints nothing when there is nothing
+to say, warns rather than fails, and stays silent when it cannot read history
+at all — a depth-1 checkout is the default and the ordinary case, and a build
+should not break over a checkout setting. `--strict` is there for a project
+that wants it enforced, and is off.
+
+The silent-on-shallow-history behaviour is itself a small trap: a guard that
+sees nothing looks exactly like a guard that found nothing. That is why the
+scaffolded workflow sets `fetch-depth` on the lint job rather than leaving it
+to be discovered.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [August 2026](2026-08.md)
 
+- [24 Aug 20:51 — A guard for the one convention that has no escape](2026-08.md#20260824205117)
 - [22 Aug 06:34 — The schema reference was somebody else's file in everybody else's repo](2026-08.md#20260822063442)
 - [16 Aug 19:30 — Four descriptions and no name](2026-08.md#20260816193000)
 - [16 Aug 19:02 — The field was green because nobody was judging](2026-08.md#20260816190210)
@@ -48,8 +49,8 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-39 entries across 1 book, newest first.
+40 entries across 1 book, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-08](2026-08.md) | 39 | 2026-08-03 | 2026-08-22 |
+| [2026-08](2026-08.md) | 40 | 2026-08-03 | 2026-08-24 |

--- a/luria/ci.py
+++ b/luria/ci.py
@@ -17,6 +17,10 @@ Detection is deliberately crude — every CI sets `CI` — and it only ever
 changes what is *said*, never what is done: a false positive costs a sentence
 of advice, a false negative leaves today's behaviour. Nothing here gates a
 write or an exit code.
+
+The second question this module answers is the inverse: whether a commit
+message has accidentally told the forge **not to build**. See
+`prose_skip_marker` — same posture, nothing gated, only something said.
 """
 
 from __future__ import annotations
@@ -65,3 +69,114 @@ def regenerate_remedy(command: str = "luria index") -> str:
 # warning that is usually noise trains readers to skip warnings, the flaky-
 # guard dynamic this record already documents. The remedy above is the whole
 # surface: it fires only when a check has actually failed (ADR-029).
+
+
+# ── Skip markers written as prose ────────────────────────────────────────
+#
+# The forge skips a workflow run when the head commit's message carries one
+# of these. That is a useful convention and this package depends on it: the
+# generate action marks its own commits so a bot push opens no run.
+#
+# The hazard is that the convention has no escape: a message *describing* the
+# marker contains the marker, so writing about it suppresses the build for the
+# commit that writes about it. Observed in the wild, in a commit adopting this
+# very workflow, by an author who had read the warning first — which is the
+# evidence that a comment was not enough.
+#
+# GitHub documents the marker as honoured in the first or last line. Measured,
+# it is broader than that: a marker in the middle of a body suppressed every
+# workflow on the commit. So the position below is not a claim about what the
+# forge honours; it is a claim about what the AUTHOR meant.
+SKIP_MARKERS = ("[skip ci]", "[ci skip]", "[no ci]",
+                "[skip actions]", "[actions skip]")
+
+
+def prose_skip_marker(message: str) -> str | None:
+    """The skip marker this message carries in a *prose* position, or None.
+
+    The whole design is the position, and it is what keeps this quiet enough
+    to be worth having. Someone deliberately skipping a build puts the marker
+    where the convention puts it — the subject line, or a trailer at the end —
+    and every tool that generates one does the same, this package's own
+    generate action included. Someone *writing about* the convention lands it
+    in the middle of a paragraph.
+
+    So a marker in the first or last line is read as an instruction and passes
+    silently; one in the body is read as prose and is reported. That single
+    rule is why no author check is needed: the bot's `docs: regenerate views
+    [skip ci]` is one line, which is first and last at once, and never fires.
+
+    The failure being caught is unusually easy to miss, which is the argument
+    for catching it at all. A suppressed run is not a red build — it is *no*
+    build, and the pull request goes on displaying the previous commit's green
+    checks. Silence is indistinguishable from success unless someone thinks to
+    ask which commit the green belongs to.
+    """
+    lines = message.strip().splitlines()
+    # Two lines or fewer is all instruction position and no body.
+    for line in lines[1:-1]:
+        lowered = line.lower()
+        for marker in SKIP_MARKERS:
+            if marker in lowered:
+                return marker
+    return None
+
+
+def commits(rev_range: str) -> list[tuple[str, str]]:
+    """`(sha, message)` for each commit in the range, newest first.
+
+    Returns nothing when git cannot answer — a shallow checkout is the
+    ordinary case (`actions/checkout` fetches depth 1 by default), and a
+    guard that cannot see history has nothing to say. It must not turn that
+    into a failure: the build would break on a checkout setting rather than
+    on anything about the code.
+    """
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "log", "--format=%H%n%B%x00", rev_range],
+            capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    found = []
+    for chunk in out.split("\0"):
+        chunk = chunk.strip("\n")
+        if not chunk:
+            continue
+        sha, _, message = chunk.partition("\n")
+        found.append((sha.strip(), message))
+    return found
+
+
+def run(rev_range: str = "HEAD~20..HEAD", strict: bool = False) -> None:
+    """Report commits that tell the forge not to build while meaning to talk
+    about it — a skip marker sitting in prose rather than in the subject or a
+    trailer (`prose_skip_marker`).
+
+    Prints nothing when there is nothing to say. That is deliberate and it is
+    the lesson this module already learned once: a warning printed on correct
+    runs trains readers to skip warnings, and the check that fires on every
+    green build is the one nobody reads on the red one.
+
+    Warns rather than fails by default, matching the record's posture
+    everywhere else; `--strict` promotes it for a project that wants the
+    build to stop.
+    """
+    import sys
+    hits = [(sha, marker)
+            for sha, message in commits(rev_range)
+            if (marker := prose_skip_marker(message))]
+    if not hits:
+        return
+    annotate = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
+    for sha, marker in hits:
+        text = (f"{sha[:8]} carries `{marker}` in its message body. If this "
+                f"commit was ever the tip of a push, its checks did not run "
+                f"— a suppressed run is not a red build, it is no build, and "
+                f"the previous commit's green stays on display. Write about "
+                f"the marker in prose, or move it to the subject line if the "
+                f"skip was meant.")
+        print(f"::warning::{text}" if annotate else f"luria: {text}",
+              file=sys.stderr)
+    if strict:
+        raise SystemExit(1)

--- a/luria/cli.py
+++ b/luria/cli.py
@@ -17,6 +17,7 @@ Two more exist for CI, which is their only regular caller:
 
     luria reports       write the status reports as markdown, for an artifact
     luria collect       assemble fragment directories into their views
+    luria skip-markers  commits whose message told the forge not to build
 
 Each command is a plain typed function (`<module>.run`), and Fire derives the
 flags and help from the signatures and docstrings — there is no argparse
@@ -31,8 +32,8 @@ the package.
 
 import fire
 
-from . import (adr_index, collect, concretize, init, link_refs, lint, migrate,
-               new, remotes, reports, site)
+from . import (adr_index, ci, collect, concretize, init, link_refs, lint,
+               migrate, new, remotes, reports, site)
 
 COMMANDS = {
     "lint": lint.run,
@@ -46,6 +47,7 @@ COMMANDS = {
     "init": init.run,
     "reports": reports.run,
     "collect": collect.run,
+    "skip-markers": ci.run,
 }
 
 # Run by CI on every push; runnable by hand, but nothing in the contributor
@@ -54,6 +56,7 @@ COMMANDS = {
 CI_COMMANDS = {
     "reports": ("luria.reports", "write the status reports as markdown"),
     "collect": ("luria.collect", "assemble fragments into their views"),
+    "skip-markers": ("luria.ci", "commits that suppressed their own build"),
 }
 
 

--- a/record/changelog.d/20260824-205117.md
+++ b/record/changelog.d/20260824-205117.md
@@ -1,0 +1,12 @@
+### Added
+
+- `luria skip-markers` — reports commits carrying a CI skip marker in their
+  message body, where it is almost certainly prose rather than an
+  instruction. The `lint` action runs it and warns; the scaffolded workflow
+  gives that job enough history to read.
+
+### Changed
+
+- The scaffolded `docs.yml` checks out the lint job with `fetch-depth: 25`,
+  so the new check has history to see. Depth 1 would have left it silent,
+  which looks exactly like a clean result.

--- a/record/devlog.d/2026/08/24/205117.md
+++ b/record/devlog.d/2026/08/24/205117.md
@@ -1,0 +1,76 @@
+---
+title: 'A guard for the one convention that has no escape'
+created: '2026-08-24T20:51:17'
+tags:
+- ci
+---
+
+**A project adopting the recommended workflow wrote a commit message
+explaining what the skip marker does, and thereby did it.** Every workflow on
+that commit was skipped. The author had read the caution in `docs.yml`'s
+header — the one that says to name the marker in prose — before making the
+mistake, which is the strongest available evidence that a comment was not
+enough.
+
+The convention has no escape sequence. There is no way to mention the marker
+in a commit message without invoking it, so any project that documents its own
+CI in its own commit messages is one sentence away from a silent skip.
+
+**What makes it expensive is the shape of the failure.** A suppressed run is
+not a red build. It is *no* build, and the pull request goes on displaying the
+previous commit's green checks, because those are the most recent checks that
+exist. Silence is indistinguishable from success unless someone thinks to ask
+which commit the green belongs to — and nobody asks that question on a PR that
+looks passing. In the reported case it was noticed only because a script that
+polled for run results returned stale SHAs.
+
+## The rule is position, not authorship
+
+The first design put an author check on it: warn when a *human* commit carries
+a marker. That is wrong in both directions. It fires on someone deliberately
+skipping a docs-only build, which is correct use of the convention, and it
+needs a list of bot identities to stay quiet.
+
+Position does the whole job. Somebody instructing the forge puts the marker
+where the convention puts it — the subject line, or a trailer at the end — and
+so does every tool that generates one, this package's `generate` action
+included. Somebody *writing about* it lands the marker mid-paragraph. So a
+marker in the first or last line passes silently and one in the body is
+reported, and the bot's own `docs: regenerate views [skip ci]` never fires
+because a one-line message is first and last at once. No author list, no
+configuration.
+
+Worth being precise about what the position means here. GitHub documents the
+marker as honoured in the first or last line; measured, it is broader than
+that — the reported case had it on line nine of a body and every workflow was
+still skipped. So the rule above is not a claim about what the forge honours.
+It is a claim about what the author meant, which is the only thing worth
+guessing at.
+
+## What it cannot do
+
+It cannot catch the commit it is about. The suppressed run is the one that did
+not happen, so nothing inside it can speak; the warning necessarily arrives on
+a later run, once history has moved past the offending commit. That makes this
+a backstop rather than a fix, and the docs say so rather than implying a
+guarantee.
+
+The honest fix is client-side — a `commit-msg` hook that refuses the marker in
+a body — and that is a bigger conversation, because scaffolding git hooks into
+somebody's repository is intrusive in a way writing files is not. Not doing it
+here.
+
+## Kept quiet on purpose
+
+`ci.py` already carried the lesson this needed, in a comment about a helper
+that was built and removed before merge: a warning that fires on correct runs
+trains readers to skip warnings. So this prints nothing when there is nothing
+to say, warns rather than fails, and stays silent when it cannot read history
+at all — a depth-1 checkout is the default and the ordinary case, and a build
+should not break over a checkout setting. `--strict` is there for a project
+that wants it enforced, and is off.
+
+The silent-on-shallow-history behaviour is itself a small trap: a guard that
+sees nothing looks exactly like a guard that found nothing. That is why the
+scaffolded workflow sets `fetch-depth` on the lint job rather than leaving it
+to be discovered.

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -23,10 +23,12 @@
 # generate job dying on a 403.
 #
 # One caution for maintainers: GitHub skips a workflow run when the head
-# commit message carries its skip marker, in the first or last line, in any
-# of its five spellings — so a commit message *describing* the bot's commit
-# format can suppress its own CI run. Name the marker in prose; file contents
-# like this one are unaffected.
+# commit message carries its skip marker, in any of its five spellings — so a
+# commit message *describing* the bot's commit format can suppress its own CI
+# run. Name the marker in prose; file contents like this one are unaffected.
+# The lint action checks for this and warns, which is a backstop rather than a
+# fix: the run it warns on is a LATER one, because the suppressed commit's own
+# run is exactly what did not happen.
 name: Docs
 
 on:
@@ -75,6 +77,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.docs-generate.outputs.sha }}
+          # Enough history for the skip-marker check inside the lint action.
+          # Depth 1 is the default and would leave it nothing to read — a
+          # silent guard, which is worse than no guard, because silence is
+          # what a clean result looks like.
+          fetch-depth: 25
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import subprocess
 import sys
 
-from luria import (adr_index, cli, collect, concretize, init, link_refs,
+from luria import (adr_index, ci, cli, collect, concretize, init, link_refs,
                    lint, migrate, new, remotes, reports, site)
 
 
@@ -22,7 +22,7 @@ def test_every_command_is_registered():
         "new": new.run, "concretize": concretize.run,
         "migrate": migrate.run, "remotes": remotes.run,
         "site": site.run, "init": init.run, "reports": reports.run,
-        "collect": collect.run,
+        "collect": collect.run, "skip-markers": ci.run,
     }
 
 

--- a/tests/test_skip_markers.py
+++ b/tests/test_skip_markers.py
@@ -1,0 +1,151 @@
+"""The guard for a convention that has no escape.
+
+A forge skips a build when the head commit's message carries a skip marker.
+Nothing distinguishes an instruction from a mention, so a commit message
+*about* the convention suppresses the build for the commit that writes about
+it — which happened to a project adopting this package's own workflow, to an
+author who had read the warning comment first.
+
+The position rule is the whole design: subject line or trailer is an
+instruction, anywhere else is prose. Everything below pins one half of that.
+"""
+
+import subprocess
+
+import pytest
+
+from luria import ci
+
+
+# --- what passes silently -----------------------------------------------
+
+def test_the_bots_own_commit_never_fires():
+    """The generate action's default message, which is the reason no author
+    check is needed: one line is first and last at once."""
+    assert ci.prose_skip_marker("docs: regenerate views [skip ci]") is None
+
+
+def test_a_deliberate_trailer_is_an_instruction():
+    """Someone skipping a build on purpose puts the marker where the
+    convention puts it. Reporting that would be reporting correct use."""
+    assert ci.prose_skip_marker("fix a typo in the README\n\n[skip ci]") is None
+
+
+def test_a_subject_line_skip_is_an_instruction():
+    assert ci.prose_skip_marker("[skip ci] bump the pinned runner") is None
+
+
+def test_an_ordinary_message_is_quiet():
+    assert ci.prose_skip_marker("refactor the collector\n\nNo behaviour "
+                                "change; the fragments are unaffected.") is None
+
+
+# --- what it catches -----------------------------------------------------
+
+def test_a_marker_described_in_the_body_fires():
+    """The observed failure, reduced: a commit explaining what the marker
+    does, and thereby doing it."""
+    message = ("consolidate the build\n"
+               "\n"
+               "the generate action already marks its commits [skip ci];\n"
+               "nothing else did.\n"
+               "\n"
+               "Co-Authored-By: someone <s@example.com>")
+    assert ci.prose_skip_marker(message) == "[skip ci]"
+
+
+@pytest.mark.parametrize("marker", ci.SKIP_MARKERS)
+def test_every_spelling_is_caught(marker):
+    """Five spellings, and a guard that knows one of them is a guard that
+    misses four."""
+    assert ci.prose_skip_marker(f"subject\n\nprose {marker} prose\n\ntrailer") \
+        == marker
+
+
+def test_the_match_is_case_insensitive():
+    assert ci.prose_skip_marker("subject\n\nprose [SKIP CI] prose\n\nend") \
+        == "[skip ci]"
+
+
+# --- reading real history ------------------------------------------------
+
+@pytest.fixture
+def repo(tmp_path):
+    def git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True,
+                       capture_output=True)
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    (tmp_path / "f").write_text("1")
+    git("add", "-A")
+    git("commit", "-q", "-m", "first")
+    return tmp_path, git
+
+
+def test_scanning_history_finds_the_prose_commit(repo, monkeypatch):
+    path, git = repo
+    (path / "f").write_text("2")
+    git("add", "-A")
+    git("commit", "-q", "-m",
+        "subject\n\nexplaining [ci skip] here\n\ntrailer")
+    monkeypatch.chdir(path)
+
+    found = [m for _, msg in ci.commits("HEAD~1..HEAD")
+             if (m := ci.prose_skip_marker(msg))]
+    assert found == ["[ci skip]"]
+
+
+def test_a_shallow_or_missing_history_says_nothing(tmp_path, monkeypatch):
+    """`actions/checkout` fetches depth 1 by default, so an unreadable range
+    is the ordinary case. A guard that cannot see history has nothing to
+    say, and must not turn a checkout setting into a failed build."""
+    monkeypatch.chdir(tmp_path)
+    assert ci.commits("HEAD~50..HEAD") == []
+
+
+def test_run_is_silent_when_there_is_nothing_to_say(repo, monkeypatch, capsys):
+    """The lesson this module already learned once: a warning printed on
+    correct runs trains readers to skip warnings."""
+    path, _ = repo
+    monkeypatch.chdir(path)
+    ci.run("HEAD~1..HEAD")
+    assert capsys.readouterr().err == ""
+
+
+def test_run_warns_without_failing(repo, monkeypatch, capsys):
+    path, git = repo
+    (path / "f").write_text("2")
+    git("add", "-A")
+    git("commit", "-q", "-m", "subject\n\nabout [skip ci] again\n\ntrailer")
+    monkeypatch.chdir(path)
+
+    ci.run("HEAD~1..HEAD")                      # no SystemExit
+    assert "[skip ci]" in capsys.readouterr().err
+
+
+def test_strict_promotes_the_warning(repo, monkeypatch):
+    path, git = repo
+    (path / "f").write_text("2")
+    git("add", "-A")
+    git("commit", "-q", "-m", "subject\n\nabout [skip ci] again\n\ntrailer")
+    monkeypatch.chdir(path)
+
+    with pytest.raises(SystemExit):
+        ci.run("HEAD~1..HEAD", strict=True)
+
+
+def test_annotations_only_inside_the_forge(repo, monkeypatch, capsys):
+    path, git = repo
+    (path / "f").write_text("2")
+    git("add", "-A")
+    git("commit", "-q", "-m", "subject\n\nabout [no ci] again\n\ntrailer")
+    monkeypatch.chdir(path)
+
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    ci.run("HEAD~1..HEAD")
+    assert capsys.readouterr().err.startswith("luria:")
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    ci.run("HEAD~1..HEAD")
+    assert capsys.readouterr().err.startswith("::warning::")


### PR DESCRIPTION
Independent of #119 — based on `main`, no overlap.

## The convention has no escape sequence

There is no way to mention a CI skip marker in a commit message without invoking it. So a message *explaining* what the marker does tells the forge not to build the commit that explains it.

That happened this week to a project adopting the recommended workflow — in the commit that adopted it, written by an author who had read the caution in the scaffolded `docs.yml` header **first**. A warning that is read and then tripped anyway is weak evidence for documentation as the remedy.

## Why it is expensive out of proportion to its silliness

A suppressed run is not a red build. It is *no* build, and the pull request goes on displaying the previous commit's green checks — because those are the most recent checks that exist. Silence is indistinguishable from success unless somebody thinks to ask which commit the green belongs to, and nobody asks that on a PR that looks passing.

In the reported case it surfaced only because a polling script kept returning stale SHAs.

## `luria skip-markers`

Reports commits carrying a marker in the message **body**.

**Position is the entire rule**, and it is what keeps this quiet enough to be worth running. Someone instructing the forge puts the marker where the convention puts it — subject line, or a trailer — and so does every tool that generates one, including this package's own `generate` action. Someone writing *about* it lands the marker mid-paragraph.

So `docs: regenerate views [skip ci]` never fires: a one-line message is first and last at once. No author list, no bot identities to maintain, no configuration.

A note on what the position claim actually is: GitHub documents the marker as honoured in the first or last line. Measured, it is broader — the reported case had it on line nine of a body and every workflow was still skipped. The rule here is therefore not a claim about what the forge honours; it is a claim about **what the author meant**, which is the only thing worth guessing at.

## Kept quiet on purpose

`ci.py` already carried the lesson this needed, in a comment about a helper built and removed before merge: *a warning that fires on correct runs trains readers to skip warnings.* So this:

- prints nothing when there is nothing to say
- warns rather than fails (`--strict` exists, and is off)
- stays silent when it cannot read history — `actions/checkout` fetches depth 1 by default, and a build must not break over a checkout setting

That last one is itself a small trap: a guard that sees nothing looks exactly like a guard that found nothing. Which is why the scaffolded workflow now sets `fetch-depth: 25` on the lint job rather than leaving it to be discovered.

## What it cannot do

**It cannot catch the commit it is about.** The suppressed run is the one that did not happen, so nothing inside it can speak — the warning necessarily arrives on a *later* run, once history has moved past the offending commit. This is a backstop, not a fix, and the docs say so rather than implying a guarantee.

The honest fix is client-side: a `commit-msg` hook that refuses a marker in a body. That is a bigger conversation, because scaffolding git hooks into someone's repository is intrusive in a way writing files is not. Not doing it here; noted in the devlog as the better shape if you want it.

## Changes

- `luria/ci.py` — `SKIP_MARKERS`, `prose_skip_marker()`, `commits()`, `run()`
- `luria/cli.py` — registered, and listed under the CI-only commands
- `actions/lint/action.yml` — new `skip-marker-range` input; empty string turns it off
- `template/.github/workflows/docs.yml` — `fetch-depth: 25` on the lint checkout, and the header caution now says a check exists and what it cannot do
- `docs/cli.md` — the command
- `tests/test_skip_markers.py` — 17 tests

498 pass, `luria lint` clean. Filed with a changelog fragment and a devlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj6mizbanCFTbTPEjZZD7c
