### PR TITLE
fix: acknowledge every demonstration code in the corpus

### DIFF
--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -70,19 +70,13 @@ A scheme's template is a form, not a document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**4 codes unaccounted for.** Not listed: 51 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**3 codes unaccounted for.** Not listed: 51 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 
-### ADR-123 — resolves to nothing (3 unmarked sites · 2 other mentions marked deliberate)
+### ADR-123 — resolves to nothing (2 unmarked sites · 2 other mentions marked deliberate)
 
-- [`luria/concretize.py:19`](../../luria/concretize.py)
 - [`record/decisions.d/ADR-049.md:28`](../../record/decisions.d/ADR-049.md)
 - [`record/decisions.d/ADR-049.md:46`](../../record/decisions.d/ADR-049.md)
-
-### DP-017 — resolves to nothing (2 unmarked sites · 2 other mentions marked deliberate)
-
-- [`luria/migrate.py:152`](../../luria/migrate.py)
-- [`luria/migrate.py:408`](../../luria/migrate.py)
 
 ### ADR-000 — resolves to nothing (1 unmarked site)
 

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -70,17 +70,13 @@ A scheme's template is a form, not a document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**3 codes unaccounted for.** Not listed: 51 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**2 codes unaccounted for.** Not listed: 56 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 
-### ADR-123 — resolves to nothing (2 unmarked sites · 2 other mentions marked deliberate)
+### ADR-123 — resolves to nothing (2 unmarked sites · 3 other mentions marked deliberate)
 
 - [`record/decisions.d/ADR-049.md:28`](../../record/decisions.d/ADR-049.md)
 - [`record/decisions.d/ADR-049.md:46`](../../record/decisions.d/ADR-049.md)
-
-### ADR-000 — resolves to nothing (1 unmarked site)
-
-- [`tests/test_concretize.py:205`](../../tests/test_concretize.py)
 
 ### DP-018 — resolves to nothing (1 unmarked site · 4 other mentions marked deliberate)
 

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -70,17 +70,9 @@ A scheme's template is a form, not a document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**2 codes unaccounted for.** Not listed: 56 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**0 codes unaccounted for.** Not listed: 59 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
-
-### ADR-123 — resolves to nothing (2 unmarked sites · 3 other mentions marked deliberate)
-
-- [`record/decisions.d/ADR-049.md:28`](../../record/decisions.d/ADR-049.md)
-- [`record/decisions.d/ADR-049.md:46`](../../record/decisions.d/ADR-049.md)
-
-### DP-018 — resolves to nothing (1 unmarked site · 4 other mentions marked deliberate)
-
-- [`record/decisions.d/ADR-040.md:42`](../../record/decisions.d/ADR-040.md)
+Every code resolves. ✅
 
 ## Files that opt out of reference checking
 

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -16,7 +16,7 @@ committed (the same ordering the changelog collector trusts, for the same
 reason: a filename is not required to sort chronologically):
 
 1. the next free number is assigned and the file renamed to the numeric
-   shape (`FX-ADR-123.md`);
+   shape (`ADR-123.md`);
 2. every occurrence of the temporary code in current files is rewritten —
    which covers link labels and link targets in one pass, since the target
    is the code plus `.md`;
@@ -39,6 +39,9 @@ is git's guarantee, not the working tree's job.
 always wrong and mechanically fixable — run this command — so it fails
 outright, which is ADR-035's bar for a check that may fail a build.
 """
+
+# unresolved-ok-file: ADR-123 — a demonstration code in the docstring above,
+# standing in for the number a temporary code concretizes onto
 
 from __future__ import annotations
 

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -16,7 +16,7 @@ committed (the same ordering the changelog collector trusts, for the same
 reason: a filename is not required to sort chronologically):
 
 1. the next free number is assigned and the file renamed to the numeric
-   shape (`ADR-123.md`);
+   shape (`FX-ADR-123.md`);
 2. every occurrence of the temporary code in current files is rewritten —
    which covers link labels and link targets in one pass, since the target
    is the code plus `.md`;

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -50,6 +50,9 @@ never swept: the spec's mapping is written in old spellings *on purpose* —
 it is the one artifact whose job is to remember them.
 """
 
+# unresolved-ok-file: DP-017 — a demonstration code in the comments below,
+# standing in for a moved document's old address
+
 from __future__ import annotations
 
 import re
@@ -149,7 +152,7 @@ class Plan:
     relocated: set[str] = field(default_factory=set)
     # Old address fragment → the code that answers for it now. The address is
     # the anchor a document-rendered scheme gave the document (`#dp-17`) or the
-    # filename an index-rendered one did (`FX-DP-017.md`), so a citation is found
+    # filename an index-rendered one did (`DP-017.md`), so a citation is found
     # by where it POINTS rather than by how it is labelled.
     old_addresses: dict[str, str] = field(default_factory=dict)
 
@@ -405,7 +408,7 @@ def sweep_text(text: str, plan: Plan, paths: bool = True,
 
     def respell_relocated(text: str) -> str:
         """A citation WORDED rather than spelled — `design-principles #17` in
-        a code comment — names a moved document as surely as `FX-DP-017` does,
+        a code comment — names a moved document as surely as `DP-017` does,
         and both the code swap and the address swap walk straight past it: it
         contains no code, and (unlinked) it points at no address.
 

--- a/luria/migrate.py
+++ b/luria/migrate.py
@@ -149,7 +149,7 @@ class Plan:
     relocated: set[str] = field(default_factory=set)
     # Old address fragment → the code that answers for it now. The address is
     # the anchor a document-rendered scheme gave the document (`#dp-17`) or the
-    # filename an index-rendered one did (`DP-017.md`), so a citation is found
+    # filename an index-rendered one did (`FX-DP-017.md`), so a citation is found
     # by where it POINTS rather than by how it is labelled.
     old_addresses: dict[str, str] = field(default_factory=dict)
 
@@ -405,7 +405,7 @@ def sweep_text(text: str, plan: Plan, paths: bool = True,
 
     def respell_relocated(text: str) -> str:
         """A citation WORDED rather than spelled — `design-principles #17` in
-        a code comment — names a moved document as surely as `DP-017` does,
+        a code comment — names a moved document as surely as `FX-DP-017` does,
         and both the code swap and the address swap walk straight past it: it
         contains no code, and (unlinked) it points at no address.
 

--- a/record/changelog.d/20260824-223929.md
+++ b/record/changelog.d/20260824-223929.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Three illustrative codes in source comments were drawn from the live
+  sequence and now use the `FX` prefix ADR-034 registered for exactly this:
+  `DP-017` in `migrate.py` (twice) and `ADR-123` in `concretize.py`. The DP
+  sequence stands at 12, so those two specimens were five numbers from
+  becoming real citations to unrelated documents.

--- a/record/changelog.d/20260824-223929.md
+++ b/record/changelog.d/20260824-223929.md
@@ -1,7 +1,8 @@
 ### Fixed
 
-- Three illustrative codes in source comments were drawn from the live
-  sequence and now use the `FX` prefix [ADR-034](record/decisions.d/ADR-034.md) registered for exactly this:
-  `DP-017` in `migrate.py` (twice) and `ADR-123` in `concretize.py`. The DP
-  sequence stands at 12, so those two specimens were five numbers from
-  becoming real citations to unrelated documents.
+- Three demonstration codes in source comments carried no acknowledgement, so
+  they sat in the unresolved-codes report as if they were mistakes: `DP-017`
+  in `migrate.py`, `ADR-123` in `concretize.py`, and the `[ADR-0` string
+  literal in `test_concretize.py` that the scanner reads as a code. Each file
+  now carries an `unresolved-ok-file:` directive under its module docstring,
+  next to the reason.

--- a/record/changelog.d/20260824-223929.md
+++ b/record/changelog.d/20260824-223929.md
@@ -1,7 +1,7 @@
 ### Fixed
 
 - Three illustrative codes in source comments were drawn from the live
-  sequence and now use the `FX` prefix ADR-034 registered for exactly this:
+  sequence and now use the `FX` prefix [ADR-034](record/decisions.d/ADR-034.md) registered for exactly this:
   `DP-017` in `migrate.py` (twice) and `ADR-123` in `concretize.py`. The DP
   sequence stands at 12, so those two specimens were five numbers from
   becoming real citations to unrelated documents.

--- a/record/changelog.d/20260824-223929.md
+++ b/record/changelog.d/20260824-223929.md
@@ -2,8 +2,8 @@
 
 - Five demonstration codes carried no acknowledgement, so they sat in the
   unresolved-codes report indistinguishable from typos: `DP-017` in
-  `migrate.py`, `ADR-123` in `concretize.py` and again in ADR-049's worked
-  collision example, `DP-018` in ADR-040, and the `[ADR-0` string literal in
+  `migrate.py`, `ADR-123` in `concretize.py` and again in [ADR-049](record/decisions.d/ADR-049.md)'s worked
+  collision example, `DP-018` in [ADR-040](record/decisions.d/ADR-040.md), and the `[ADR-0` string literal in
   `test_concretize.py` that the scanner reads as a code. Each file now
   carries an `unresolved-ok-file:` directive next to the reason. The report
   reads "every code resolves" for the first time.

--- a/record/changelog.d/20260824-223929.md
+++ b/record/changelog.d/20260824-223929.md
@@ -1,8 +1,9 @@
 ### Fixed
 
-- Three demonstration codes in source comments carried no acknowledgement, so
-  they sat in the unresolved-codes report as if they were mistakes: `DP-017`
-  in `migrate.py`, `ADR-123` in `concretize.py`, and the `[ADR-0` string
-  literal in `test_concretize.py` that the scanner reads as a code. Each file
-  now carries an `unresolved-ok-file:` directive under its module docstring,
-  next to the reason.
+- Five demonstration codes carried no acknowledgement, so they sat in the
+  unresolved-codes report indistinguishable from typos: `DP-017` in
+  `migrate.py`, `ADR-123` in `concretize.py` and again in ADR-049's worked
+  collision example, `DP-018` in ADR-040, and the `[ADR-0` string literal in
+  `test_concretize.py` that the scanner reads as a code. Each file now
+  carries an `unresolved-ok-file:` directive next to the reason. The report
+  reads "every code resolves" for the first time.

--- a/record/decisions.d/ADR-040.md
+++ b/record/decisions.d/ADR-040.md
@@ -23,6 +23,8 @@ summary: >-
   unwatched).
 ---
 
+<!-- unresolved-ok-file: DP-018 — named while describing the fixture codes tests/test_remotes.py carries on purpose -->
+
 # ADR-040: Migrations: renaming schemes and moving documents without losing the record's memory
 
 ## Context

--- a/record/decisions.d/ADR-049.md
+++ b/record/decisions.d/ADR-049.md
@@ -37,6 +37,8 @@ summary: >-
   question is separable).
 ---
 
+<!-- unresolved-ok-file: ADR-123 — the number in this decision's worked collision example, where 122 being the last one is the point -->
+
 # ADR-049: Temporary codes at filing; concretized and aliased at the serialization point
 
 ## Context

--- a/tests/test_concretize.py
+++ b/tests/test_concretize.py
@@ -7,6 +7,9 @@ commands — the pattern ADR-045 established, because the first hand-fired run
 of this machinery found a crash (`render_categories` formatting a number that
 temp docs don't have) that no unit test of the minter would have seen.
 """
+
+# unresolved-ok-file: ADR-000 — the assertion below matches on the string
+# `[ADR-0`, which the reference scanner reads as a code
 import re
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
Three demonstration codes in source comments carried no acknowledgement, so they sat in the unresolved-codes report indistinguishable from typos.

- `migrate.py` uses `DP-017` twice as a moved document's old address.
- `concretize.py` uses `ADR-123` for the number a temporary code lands on.
- `test_concretize.py` asserts on the literal `"[ADR-0"`, which the scanner reads as a code — an assertion about link text rather than a reference, and the clearest case for annotating rather than editing.

Two more sit in decision bodies:

- `ADR-049` uses `ADR-123` twice in its worked collision example, where two branches both read 122 as the last number — the arithmetic is the point of the passage.
- `ADR-040` names `DP-018` while describing the fixture codes `tests/test_remotes.py` carries on purpose.

Each file now carries an `unresolved-ok-file:` directive next to the reason — under the module docstring for the source files, where `directives.py` already keeps its own, and between the frontmatter and the H1 for the decisions, where `ADR-034` keeps its own.

**The unresolved-codes report now reads "every code resolves", with 59 mentions marked deliberate.** It has not read that before.

Adding an acknowledgement is an annotation rather than a revision — it makes no claim the decision did not already make — so neither Active document takes a version bump or a history entry.

## What changed from the first version of this branch

It rewrote these three sites onto the `FX` prefix. That was the wrong end of the problem.

ADR-034 registered `FX` so that fixtures *could not collide* with the real sequence, and separately allows a demonstration code to stand where it is acknowledged — the acknowledgement is what tells a reader the code is an example. Rewriting prose to satisfy a rule an annotation already satisfies is churn, and here it read worse: `FX-DP-017.md` is not a filename anything would ever produce, and the passage is specifically about what a filename looks like.

## On #65

Closed as stale. It was written in August against a 296-test tree and conflicts with main. Its prose half is settled by the rule above; its other half — tests that build a principles scheme from real `DP` codes, which it proposed solving with a `VP` fixture *scheme* — is a distinct problem, since `FX` is a remote and cannot back a scheme directory. Worth a fresh issue against current main if it still bites.

## Checks

504 tests pass; `luria lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj6mizbanCFTbTPEjZZD7c
