### PR TITLE
test: fixture principles schemes use a VP prefix, not DP

### DIFF
--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -70,7 +70,7 @@ A scheme's template is a form, not a document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**0 codes unaccounted for.** Not listed: 59 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**0 codes unaccounted for.** Not listed: 56 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 Every code resolves. ✅
 

--- a/record/changelog.d/20260824-230848.md
+++ b/record/changelog.d/20260824-230848.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Test fixtures that model a principles scheme now use a `VP` prefix over
+  `docs/values.md` rather than borrowing `DP`. A rename of the real scheme
+  would have swept them: `luria migrate` walks tracked source files on the
+  grounds that "a source file answers as truthfully as a document does", and
+  a fixture's codes are not claims about this record. Six test files, and the
+  `UP` remote's document-scheme fixtures with them.

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -93,60 +93,60 @@ def test_every_generated_relative_link_resolves():
 # ── render = "document" (ADR-012) ────────────────────────────────────────
 
 
-def principle(root: Path, number: int, title: str, body: str = "Body.",
+def value(root: Path, number: int, title: str, body: str = "Body.",
               **front) -> Path:
-    path = root / "docs" / "principles" / f"DP-{number:03d}.md"
+    path = root / "docs" / "values" / f"VP-{number:03d}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = ["status: Active", f"title: {title!r}", "tags:", "- record"]
     lines += [f"{k}: {v}" for k, v in front.items()]
     path.write_text("---\n" + "\n".join(lines) + "\n---\n\n"
-                    f"# DP-{number:03d}: {title}\n\n{body}\n")
+                    f"# VP-{number:03d}: {title}\n\n{body}\n")
     return path
 
 
-DP_SCHEME_ARGS = dict(active="Active", render="document")
+VP_SCHEME_ARGS = dict(active="Active", render="document")
 
 
-def dp_scheme(root: Path) -> Scheme:
-    return Scheme("DP", root / "docs" / "principles",
-                  output=root / "docs" / "design-principles.md",
-                  **DP_SCHEME_ARGS)
+def vp_scheme(root: Path) -> Scheme:
+    return Scheme("VP", root / "docs" / "values",
+                  output=root / "docs" / "values.md",
+                  **VP_SCHEME_ARGS)
 
 
 def render(root: Path) -> str:
-    scheme = dp_scheme(root)
+    scheme = vp_scheme(root)
     return builder.render_document(scheme, builder.load_scheme(scheme))
 
 
 def test_document_demotes_the_heading_and_renumbers(project):
-    principle(project, 3, "Fire before trusting")
+    value(project, 3, "Fire before trusting")
     out = render(project)
     assert "## 3. Fire before trusting" in out
-    assert "# DP-003" not in out
+    assert "# VP-003" not in out
 
 
 def test_document_emits_a_stable_anchor(project):
     """Keyed to the number, not the wording — a principle is a living document
     and its heading moves (ADR-012)."""
-    principle(project, 3, "Fire before trusting")
-    assert '<a name="dp-3"></a>' in render(project)
+    value(project, 3, "Fire before trusting")
+    assert '<a name="vp-3"></a>' in render(project)
 
 
 def test_document_strips_the_frontmatter(project):
-    principle(project, 1, "A value", **{"version": 2})
+    value(project, 1, "A value", **{"version": 2})
     out = render(project)
     assert "status: Active" not in out and "tags:" not in out
 
 
 def test_metadata_line_carries_version_and_origin(project):
-    principle(project, 1, "A value", **{"version": 2, "origin": "'An incident.'"})
+    value(project, 1, "A value", **{"version": 2, "origin": "'An incident.'"})
     assert "*v2 · origin: An incident*" in render(project)
 
 
 def test_a_retired_principle_says_so(project):
     """`Active` is the silent default; anything else is stated, because a
     principle nobody believes any more is exactly what a reader needs told."""
-    path = principle(project, 1, "A value")
+    path = value(project, 1, "A value")
     path.write_text(path.read_text().replace("status: Active", "status: Rejected"))
     assert "**Rejected**" in render(project)
 
@@ -160,15 +160,15 @@ def test_influenced_by_renders_as_a_followable_backlink(project):
     from luria.config import current
     from tests import _scheme
     _scheme.decision(project, 4, "Active")
-    principle(project, 1, "A value", influenced_by="[ADR-004]")
+    value(project, 1, "A value", influenced_by="[ADR-004]")
     target = os.path.relpath(current().schemes["ADR"].dir / "ADR-004.md",
-                             current().design_principles.parent)
+                             vp_scheme(project).output.parent)
     assert f"[ADR-004]({target})" in render(project)
 
 
 def test_an_unresolvable_backlink_stays_a_bare_code(project):
     """DP-1: say what can be said, rather than linking to nothing."""
-    principle(project, 1, "A value", influenced_by="[ADR-404]")
+    value(project, 1, "A value", influenced_by="[ADR-404]")
     out = render(project)
     assert "shaped by ADR-404" in out and "](" not in out.split("shaped by")[1]
 
@@ -178,17 +178,17 @@ def test_outputs_covers_every_scheme(project, monkeypatch):
     scheme the moment it is configured, with no second command to remember."""
     from tests import _scheme
     _scheme.decision(project, 1, "Active")
-    principle(project, 1, "A value")
+    value(project, 1, "A value")
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        '[luria.schemes.VP]\ndir = "docs/values"\n'
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
 
     out = builder.outputs()
-    assert project / "docs" / "design-principles.md" in out
+    assert project / "docs" / "values.md" in out
     assert project / "docs" / "decisions" / "README.md" in out
 
 

--- a/tests/test_adr_pending.py
+++ b/tests/test_adr_pending.py
@@ -114,15 +114,15 @@ def test_every_scheme_is_covered(project):
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        '[luria.schemes.VP]\ndir = "docs/values"\n'
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
     decision(project, 1, "Proposed", "An open decision")
-    principles = project / "docs" / "principles"
-    principles.mkdir(parents=True, exist_ok=True)
-    (principles / "DP-002.md").write_text(
+    values = project / "docs" / "values"
+    values.mkdir(parents=True, exist_ok=True)
+    (values / "VP-002.md").write_text(
         "---\nstatus: Deferred\ntitle: 'An open value'\ntags:\n- record\n"
-        "date: '2026-01-01'\n---\n\n# DP-002: An open value\n")
+        "date: '2026-01-01'\n---\n\n# VP-002: An open value\n")
 
-    assert {r.code for r in pending.pending()} == {"ADR-001", "DP-002"}
+    assert {r.code for r in pending.pending()} == {"ADR-001", "VP-002"}

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -17,16 +17,16 @@ REPO = Path(__file__).resolve().parents[1]
 TWO_SCHEMES = (
     '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
     '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-    '[luria.schemes.DP]\ndir = "docs/principles"\n'
-    'render = "document"\noutput = "docs/design-principles.md"\n'
+    '[luria.schemes.VP]\ndir = "docs/values"\n'
+    'render = "document"\noutput = "docs/values.md"\n'
 )
 
 
 def principle(root: Path, number: int, status: str, title: str = "A value") -> Path:
-    path = root / "docs" / "principles" / f"DP-{number:03d}.md"
+    path = root / "docs" / "values" / f"VP-{number:03d}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"---\nstatus: {status}\ntitle: {title!r}\ntags:\n- record\n"
-                    f"date: '2026-01-01'\n---\n\n# DP-{number:03d}: {title}\n")
+                    f"date: '2026-01-01'\n---\n\n# VP-{number:03d}: {title}\n")
     return path
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -66,17 +66,17 @@ def test_the_check_covers_every_scheme(project):
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n'
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n')
+        '[luria.schemes.VP]\ndir = "docs/values"\n'
+        'render = "document"\noutput = "docs/values.md"\n')
     from luria import config
     config.reset()
 
-    path = project / "docs" / "principles" / "DP-001.md"
+    path = project / "docs" / "values" / "VP-001.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("---\nstatus: Active\ntitle: 'A value'\ntags:\n- record\n"
-                    "---\n\n# DP-001: A different value\n\nBody.\n")
+                    "---\n\n# VP-001: A different value\n\nBody.\n")
     errors = errors_for(project)
-    assert len(errors) == 1 and "DP-001.md" in errors[0]
+    assert len(errors) == 1 and "VP-001.md" in errors[0]
 
 
 # ── The journal's path agrees with its `created:` (ADR-020) ──────────────

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -14,7 +14,7 @@ from _scheme import decision
 
 from luria import config, doc_refs, ref_status, remotes
 
-# unresolved-ok-file: ADR-999 UP-ADR-999 DP-018 — fixture codes, not claims about
+# unresolved-ok-file: ADR-999 UP-ADR-999 VP-018 — fixture codes, not claims about
 # this repo. ADR-032 left the list when a real thirty-second decision arrived and
 # the fixture number started resolving.
 REPO = Path(__file__).resolve().parents[1]
@@ -266,7 +266,7 @@ def test_a_quoted_hand_link_is_a_specimen_not_a_citation(project):
 
 
 SCHEMED = (
-    '[luria.remotes.UP.schemes.DP]\ndocument = "docs/design-principles.md"\n'
+    '[luria.remotes.UP.schemes.VP]\ndocument = "docs/values.md"\n'
     '[luria.remotes.UP.schemes.RFC]\ndir = "docs/rfcs"\n'
 )
 
@@ -275,22 +275,23 @@ def test_document_scheme_constructs_a_file_anchor(project):
     """A document-rendered scheme's documents are sections, not files — the
     construction is the assembled page plus an anchor."""
     with_remote(project, SCHEMED)
-    assert remotes.resolve("UP", "DP-18") == (
-        "https://github.com/o/r/blob/main/docs/design-principles.md#dp-18")
+    assert remotes.resolve("UP", "VP-18") == (
+        "https://github.com/o/r/blob/main/docs/values.md#vp-18")
 
 
 def test_anchor_defaults_to_the_stable_anchor_shape(project):
-    """`dp-{number}` unpadded — the shape Luria's own document render emits,
-    so a remote on current conventions needs only the `document` line."""
+    """The prefix lowercased plus the number, unpadded — the shape Luria's
+    own document render emits, so a remote on current conventions needs only
+    the `document` line."""
     with_remote(project, SCHEMED)
-    assert remotes.resolve("UP", "DP-9").endswith("#dp-9")
+    assert remotes.resolve("UP", "VP-9").endswith("#vp-9")
 
 
 def test_anchor_template_is_configurable(project):
     with_remote(project,
-        '[luria.remotes.UP.schemes.DP]\ndocument = "PRINCIPLES.md"\n'
-        'anchor = "principle-{number}"\n')
-    assert remotes.resolve("UP", "DP-4").endswith("PRINCIPLES.md#principle-4")
+        '[luria.remotes.UP.schemes.VP]\ndocument = "VALUES.md"\n'
+        'anchor = "value-{number}"\n')
+    assert remotes.resolve("UP", "VP-4").endswith("VALUES.md#value-4")
 
 
 def test_scheme_dir_scopes_the_file_convention(project):
@@ -304,9 +305,9 @@ def test_scheme_dir_scopes_the_file_convention(project):
 
 def test_scheme_url_template_wins(project):
     with_remote(project,
-        '[luria.remotes.UP.schemes.DP]\n'
+        '[luria.remotes.UP.schemes.VP]\n'
         'url = "https://up.example/values/{number}"\n')
-    assert remotes.resolve("UP", "DP-3") == "https://up.example/values/3"
+    assert remotes.resolve("UP", "VP-3") == "https://up.example/values/3"
 
 
 def test_lockfile_authority_does_not_cover_document_schemes(project):
@@ -315,7 +316,7 @@ def test_lockfile_authority_does_not_cover_document_schemes(project):
     lockfile is not evidence — the anchor construction must survive it."""
     with_remote(project, SCHEMED)
     lockfile(project, {"ADR-032": "adr-032-changelog-ci-collection.md"})
-    assert remotes.resolve("UP", "DP-18").endswith("#dp-18")
+    assert remotes.resolve("UP", "VP-18").endswith("#vp-18")
     # …while file-per-code codes stay under its authority (ADR-016).
     assert remotes.resolve("UP", "ADR-999") == ""
 
@@ -325,8 +326,8 @@ def test_url_ok_retires_when_the_construction_catches_up(project):
     and a leftover acknowledgement reports itself stale."""
     with_remote(project, SCHEMED)
     flagged, stale = hand(project,
-        "<!-- url-ok: UP-DP-18 — was unconstructible before ADR-023 -->\n"
-        "[UP-DP-18](https://github.com/o/r/blob/main/docs/design-principles.md#dp-18)\n")
+        "<!-- url-ok: UP-VP-18 — was unconstructible before ADR-023 -->\n"
+        "[UP-VP-18](https://github.com/o/r/blob/main/docs/values.md#vp-18)\n")
     assert flagged == []                      # the link now matches construction
     assert len(stale) == 1                    # …so the annotation is done
 

--- a/tests/test_wikilinks.py
+++ b/tests/test_wikilinks.py
@@ -44,15 +44,15 @@ def test_label_becomes_the_link_text(project):
 
 
 def test_document_scheme_code_expands_to_an_anchor(project):
-    """`[[DP-3]]` — a shape the prose scanner never takes (it needs a `#`),
+    """`[[VP-3]]` — a shape the prose scanner never takes (it needs a `#`),
     which is half the point of typing the brackets."""
     project_with(project,
-        '[luria.schemes.DP]\ndir = "docs/principles"\n'
-        'render = "document"\noutput = "docs/design-principles.md"\n'
+        '[luria.schemes.VP]\ndir = "docs/values"\n'
+        'render = "document"\noutput = "docs/values.md"\n'
         '[luria.schemes.ADR]\ndir = "docs/decisions"\n')
-    out, n = expand(project, "per [[DP-3]] this holds")
+    out, n = expand(project, "per [[VP-3]] this holds")
     assert n == 1
-    assert "[DP-3](design-principles.md#dp-3)" in out
+    assert "[VP-3](values.md#vp-3)" in out
 
 
 def test_remote_code_expands_to_a_url(project):


### PR DESCRIPTION
The half of #65 that the acknowledgement rule does not cover. #122 settled the reporting side; this is the rename side.

## Why an acknowledgement is not enough here

An `unresolved-ok` directive settles the unresolved-codes report. It does nothing about a rename, and `migrate.py` says so itself:

> The sweep asks "does this text spell a code that moved?", **which a source file answers as truthfully as a document does.**

`[luria.code] globs` includes `tests/*.py`. So renaming the real `DP` scheme would have rewritten `DP-002` and friends *inside test fixtures* — codes that were never claims about this record, only scaffolding for a test that needed *a* document-rendered scheme. That is the latent breakage #65 found while preparing the first migration, and it is still latent.

## What changed

Six files. Five build a principles-shaped scheme, now `VP` over `docs/values.md`:

`test_wikilinks` · `test_adr_index` · `test_badges` · `test_adr_pending` · `test_lint`

And `test_remotes`' `UP` remote gets the same treatment for its document-scheme construction tests.

## The part that needed care

**These files carry both kinds of DP reference.** Alongside the fixtures, `DP-1`, `DP-3` and `DP-6` appear in docstrings and comments explaining *why a test is written the way it is* — live citations of this project's own principles. A blanket rename would have turned them into fixtures, quietly. They stay `DP`.

**One docstring changed meaning rather than spelling.** The anchor-default test described `dp-{number}` as "the shape Luria's own document render emits", which reads as a fact about DP. The default is `prefix.lower() + "-" + number`, derived from the prefix — so the docstring now says that instead. The test is stronger for it: it was always checking the generic rule, and its wording had narrowed the claim.

## Not changed

- `test_migrations` — its subject *is* renaming DP, so it needs the real prefix.
- `test_prose_frontmatter` — models the real record layout.

## Checks

504 tests pass; `luria lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj6mizbanCFTbTPEjZZD7c
