### PR TITLE
docs: one badge block, and a header that is not arguing with anyone

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ generated and linted by the CLI it ships.
 [![cited, not in force: 1](https://img.shields.io/badge/cited,%20not%20in%20force-1-orange)](docs/reports/reference-status.md)
 <!-- /luria:badges -->
 
-## It is not only for decisions
+## Kinds of record
 
 `ADR` is not in the code. It is a table in a config file, and so is
 everything else: schemes (documents with codes), journals (dated entries
@@ -63,11 +63,6 @@ have a different record on the same engine.
 
 [Designing a record](docs/modeling.md) is how to work out which of these
 your material is.
-
-<!-- luria:badges -->
-[![needs decision: 9](https://img.shields.io/badge/needs%20decision-9-orange)](docs/reports/pending-decisions.md)
-[![cited, not in force: 3](https://img.shields.io/badge/cited,%20not%20in%20force-3-orange)](docs/reports/reference-status.md)
-<!-- /luria:badges -->
 
 ## Install
 

--- a/record/changelog.d/20260825-001857.md
+++ b/record/changelog.d/20260825-001857.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- The README carried two badge blocks. The generator updates the first, so
+  the second had frozen at numbers three weeks stale. It was left behind when
+  the pitch rewrite inserted a new block above it.
+
+### Changed
+
+- The section introducing the four families is `## Kinds of record` rather
+  than `## It is not only for decisions`, which argued against an impression
+  the reader has no way to have formed.


### PR DESCRIPTION
Two fixes to the README, both introduced by my own pitch rewrite in #119.

## The duplicated badge block

The rewrite inserted a badge block with the new pitch and left the original in place further down. The generator updates the **first** occurrence, so the second froze:

| | first block (live) | second block (frozen) |
|---|---|---|
| needs decision | 0 | 9 |
| cited, not in force | 1 | 3 |

Three weeks stale, and sitting between the shapes list and Install where it read as a second, contradictory status. A stale badge is worse than no badge — it is the one thing on the page a reader takes as current by construction.

Removed the second. Verified the generator still updates the remaining one.

## The defensive header

`## It is not only for decisions` argued against an impression the reader has no way to have formed. It made sense while the old README defined the tool by its default furniture; that README is gone. The section now follows an opening about what a record *is*, so nobody arrives at it holding a decisions-only assumption to correct.

`## Kinds of record` says what is below it instead — the four families, and four shapes a record can take.

## Checks

508 tests pass; `luria lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj6mizbanCFTbTPEjZZD7c