### PR TITLE
test: acknowledge the ADR-007 fixture, clearing the reference-status report

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ generated and linted by the CLI it ships.
 
 <!-- luria:badges -->
 [![needs decision: 0](https://img.shields.io/badge/needs%20decision-0-brightgreen)](docs/reports/pending-decisions.md)
-[![cited, not in force: 1](https://img.shields.io/badge/cited,%20not%20in%20force-1-orange)](docs/reports/reference-status.md)
+[![cited, not in force: 0](https://img.shields.io/badge/cited,%20not%20in%20force-0-brightgreen)](docs/reports/reference-status.md)
 <!-- /luria:badges -->
 
 ## Kinds of record

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -9,7 +9,7 @@ Every reference in the record is a claim — "this is why things are the way the
 
 Only an `Active` document is in force. `Proposed` and `Deferred` mean *not in force yet* — an open question, being cited as if it were settled — while `Superseded` and `Rejected` mean *no longer in force*, which is often a perfectly good thing to cite: history, or a rejection worth pointing at. Either way the citation should be deliberate, and this section lists the ones nobody has vouched for yet.
 
-**1 document cited without acknowledgement.** Not listed: 34 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
+**0 documents cited without acknowledgement.** Not listed: 41 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
 
 To vouch for one, put the reason where the citation is — `inactive-ok:` covers its own line and the line below it, `inactive-ok-block:` its paragraph, `inactive-ok-file:` the whole page:
 
@@ -17,18 +17,7 @@ To vouch for one, put the reason where the citation is — `inactive-ok:` covers
 <!-- inactive-ok: ADR-012 — why this citation is right -->
 ```
 
-### [ADR-007](../../record/decisions.d/ADR-007.md) — Superseded
-
-Document status is reported, not enforced
-
-5 citations in 1 file await a look; 23 other citations of it are acknowledged.
-
-- [`tests/test_prose_frontmatter.py:15`](../../tests/test_prose_frontmatter.py)
-- [`tests/test_prose_frontmatter.py:17`](../../tests/test_prose_frontmatter.py)
-- [`tests/test_prose_frontmatter.py:27`](../../tests/test_prose_frontmatter.py)
-- [`tests/test_prose_frontmatter.py:31`](../../tests/test_prose_frontmatter.py)
-- [`tests/test_prose_frontmatter.py:41`](../../tests/test_prose_frontmatter.py)
-
+Nothing unacknowledged. ✅
 ## Codes that resolve to no document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.

--- a/record/changelog.d/20260825-013040.md
+++ b/record/changelog.d/20260825-013040.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `tests/test_prose_frontmatter.py` writes an `ADR-007.md` into a temporary
+  project as fixture data, and the number collides with this repository's own
+  [ADR-007](record/decisions.d/ADR-007.md), which is `Superseded` — so the scanner read five lines of fixture
+  data as citations of a retired decision. Acknowledged at file level with
+  what they actually are.
+
+  The reference-status report now reads clean in every section: nothing
+  cited unacknowledged, every code resolving, no stale annotations.

--- a/tests/test_prose_frontmatter.py
+++ b/tests/test_prose_frontmatter.py
@@ -1,4 +1,10 @@
 """`origin:` is prose: references in it are linked and lint-checked."""
+
+# inactive-ok-file: ADR-007 — a fixture code, not a citation. The tests
+# below write an ADR-007.md into a temporary project and check that a bare
+# reference to it is linkified; the number collides with this repository's
+# own ADR-007, which is Superseded, so the scanner reads fixture data as a
+# citation of a retired decision.
 from pathlib import Path
 from luria import config, doc_refs
 


### PR DESCRIPTION
The report had exactly one finding, and it was fixture data rather than a citation.

`tests/test_prose_frontmatter.py` writes an `ADR-007.md` into a temporary project and checks that a bare reference to it gets linkified. The number collides with this repository's own `ADR-007`, which is **Superseded** — so five lines of fixture data read as citations of a retired decision.

Acknowledged at file level, saying what they actually are.

**The report now reads clean in every section:**

| | |
|---|---|
| cited while not in force | 0 unacknowledged (41 vouched for) |
| codes resolving to nothing | 0 (56 marked deliberate) |
| stale annotations | none |

## What this is an instance of

Worth recording rather than treating as a one-off. Test fixtures across the suite are drawn from the live ADR sequence — **37 distinct numbers over 15 files** — and I checked where they stand:

- 4 real ADRs are not in force today; only `ADR-007` was borrowed, which is why there was exactly one finding.
- **35 fixture codes name decisions that are currently `Active`.** Each becomes a report finding on the day its decision is retired. That is precisely how this one arrived: `ADR-007` was fine until it was superseded.

ADR-034 named the shape — *"any specimen drawn from the sequence is a collision waiting for the sequence to arrive"* — and #123 fixed it for the principles schemes, where a rename would have swept the fixtures too.

The decision fixtures are the larger half, and I left them alone. Converting them means fifteen files with assertions on `ADR-` strings throughout, which is its own piece of work rather than a line in a report cleanup. Worth an issue if you want it done; the cost of not doing it is one acknowledgement each time a decision retires.

## Checks

541 tests pass; `luria lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dj6mizbanCFTbTPEjZZD7c