### PR TITLE
A temporary code in a workflow file is a lint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,12 @@ on:
 jobs:
   # Where merges serialize, the sources are repaired, the views regenerated,
   # and both committed and pushed as the bot; the lint then reads that
-  # commit (ADR-029). Generated views are committed on main only
-  # (ADR-tmphzwg9): a pull request pushes its source repairs onto the
-  # branch, regenerates the views in the working tree, checks in the same
-  # job, and commits no view — so branches never carry the decision index or
-  # the devlog book, and two branches cannot conflict on them.
+  # commit (ADR-029). Generated views are committed on main only (the
+  # amendment to ADR-029 on where views land): a pull request pushes its
+  # source repairs onto the branch, regenerates the views in the working
+  # tree, checks in the same job, and commits no view — so branches never
+  # carry the decision index or the devlog book, and two branches cannot
+  # conflict on them.
   docs-generate:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -355,6 +355,32 @@ def check_generated_index(errors: list[str]) -> None:
             f"{remedy}")
 
 
+def check_workflow_temp_codes(errors: list[str]) -> None:
+    """A temporary code (ADR-049) in a workflow file is one the generation
+    job can never number: `luria concretize` rewrites it with everything
+    else, and GitHub refuses a push from the workflow token that modifies
+    `.github/workflows/` — so the job's commit is rejected and the default
+    branch stays red, with nothing wrong in the record. The first merge to
+    cite a pending decision from a workflow comment found this. Cite the
+    number once the decision has one, or say it in prose."""
+    cfg = current()
+    patterns = [s.temp_pattern for s in cfg.schemes.values()]
+    if not patterns:
+        return
+    for path in sorted(cfg.root.glob(".github/workflows/*.y*ml")):
+        text = path.read_text(encoding="utf-8")
+        for regex in patterns:
+            for m in regex.finditer(text):
+                line = text.count("\n", 0, m.start()) + 1
+                errors.append(
+                    f"{cfg.rel(path)}:{line}: temporary code {m.group(0)} in a "
+                    "workflow file — the generation job cannot rewrite it when "
+                    "the decision is numbered (the workflow token may not "
+                    "modify `.github/workflows/`), so its push is refused; "
+                    "cite the number once the decision has one, or say it in "
+                    "prose")
+
+
 def check_wikilinks(errors: list[str]) -> None:
     """A wikilink is the author asserting "this is a reference" (ADR-025), so
     both failure modes are violations, with different remedies: a resolvable
@@ -584,6 +610,7 @@ def run() -> None:
     check_journals(errors)
     check_version_history(errors)
     check_bare_refs(errors)
+    check_workflow_temp_codes(errors)
     check_wikilinks(errors)
     report_warnings(errors)
     if errors:

--- a/record/changelog.d/20260903-215722.md
+++ b/record/changelog.d/20260903-215722.md
@@ -1,0 +1,6 @@
+### Added
+
+- `luria lint` reports a temporary code cited in a workflow file: the
+  generation job rewrites it when the decision is numbered, and the
+  workflow token may not modify `.github/workflows/`, so the job's push is
+  refused. Cite the number once the decision has one, or say it in prose.

--- a/record/devlog.d/2026/09/03/215722.md
+++ b/record/devlog.d/2026/09/03/215722.md
@@ -1,0 +1,29 @@
+---
+title: 'A temporary code in a workflow file breaks the generation job'
+created: '2026-09-03T21:57:22'
+tags:
+- ci
+- record
+---
+
+**The first merge under the new generation shape left `main` red, and the
+record was fine.** [#148](https://github.com/dmarx/luria/issues/148) merged; the push job ran `luria concretize`, which
+numbered the decision and rewrote its temporary code everywhere the code
+globs reach — including the comment in `.github/workflows/ci.yml` that
+cited it. GitHub refuses a push from the workflow token that modifies
+`.github/workflows/`, so the bot's one commit, views and rename together,
+was rejected, and the lint job that `needs:` it never ran.
+
+**The hazard is structural, not a typo.** A workflow file is in the code
+globs on purpose — its comments cite decisions, and the reference lint
+should see a retired one there. A temporary code is the one kind of
+citation the job must later rewrite, in the one directory it can never
+write. So the guard is a lint error, not a report: a temporary code in a
+workflow file is always wrong, and the remedy is mechanical — cite the
+number once the decision has one, or say it in prose. Fired once on the
+real case before the fix: it named `ci.yml:24` and the code.
+
+**The fix on this branch cites by prose.** Naming the number the
+concretizer was about to assign would have been true and unresolvable: the
+document does not exist until the run that creates it. Prose has no such
+dependency.

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# The record's own CI, in the recommended shape (LU-ADR-029, LU-ADR-tmphzwg9).
+# The record's own CI, in the recommended shape (LU-ADR-029 and its amendment on where views land).
 # Three jobs on the default branch and pull requests, one on a schedule:
 #
 #   docs-generate  on push to the default branch: repairs the sources

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -318,3 +318,31 @@ def test_pending_documents_can_be_promoted(project, capsys):
     config.reset()
     errors, _ = dial_errors(capsys)
     assert any("undecided document(s)" in e and "failing" in e for e in errors)
+
+
+# ── Temporary codes in workflow files ────────────────────────────────────
+
+
+def workflow_errors(project, text: str) -> list[str]:
+    wf = project / ".github" / "workflows" / "docs.yml"
+    wf.parent.mkdir(parents=True)
+    wf.write_text(text)
+    found: list[str] = []
+    lint.check_workflow_temp_codes(found)
+    return found
+
+
+def test_a_temporary_code_in_a_workflow_is_reported(project):
+    """The generation job's commit would be refused: `luria concretize`
+    rewrites the code with everything else, and the workflow token may not
+    modify `.github/workflows/`. Found by the first merge that cited a
+    pending decision from a workflow comment."""
+    errors = workflow_errors(project, "# The shape (ADR-tmpabcde).\nname: Docs\n")
+    assert len(errors) == 1
+    assert "docs.yml:1" in errors[0]
+    assert "ADR-tmpabcde" in errors[0]
+    assert "cite the number once the decision has one" in errors[0]
+
+
+def test_a_numbered_code_in_a_workflow_is_fine(project):
+    assert workflow_errors(project, "# The shape (ADR-029).\nname: Docs\n") == []


### PR DESCRIPTION
Fixes the red `docs-generate` on `main` after #148 merged ([run 33809991708](https://github.com/dmarx/luria/actions/runs/33809991708)).

## What happened

The push job ran `luria concretize`, which numbered `ADR-tmphzwg9` and rewrote the citation everywhere the code globs reach — including the comment in `.github/workflows/ci.yml`. GitHub refuses a push from the workflow token that modifies `.github/workflows/`, so the bot's one commit (views, rename and repairs together) was rejected, and the lint job that `needs:` it never ran. The record itself was fine.

## The fix

- **The workflow comments cite the decision by prose.** Naming the number the concretizer was about to assign would have been true and unresolvable: the document does not exist until the run that creates it.
- **`luria lint` reports a temporary code in a workflow file.** Always wrong (the job's push will be refused), remedy mechanical: cite the number once the decision has one, or say it in prose. Fired once on the real case before the fix; it named `ci.yml:24` and the code. Two tests.
- Devlog entry and changelog fragment.

## Verification

- `python -m pytest tests -q`: 608 passed.
- `luria index` then `luria lint` in the working tree: clean. The branch carries no regenerated views.
- Once this merges, the push run on `main` concretizes `ADR-tmphzwg9` again (the rename lands as `ADR-068`), and the commit no longer touches a workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r)_