### PR TITLE
Two decisions: the workflow token's limit, and affirmative wording

### DIFF
--- a/docs/adopting.md
+++ b/docs/adopting.md
@@ -147,6 +147,20 @@ to hit.
 4. A scheduled job (weekly, in the scaffold) runs `luria collect --commit`
    to assemble changelog fragments and pushes the result.
 
+**Which token the job pushes with** decides one thing. The workflow's own
+`GITHUB_TOKEN` needs no setup and is what the scaffold uses, and it cannot
+create or update anything under `.github/workflows/` — there is no
+`workflows:` entry to grant in a `permissions:` block. So a temporary code
+cited from a workflow comment is one the job can never number: `luria
+concretize` rewrites it with everything else, and the push is refused
+whole. The lint reports that as `workflow-temp-codes`, and the scaffold's
+`luria.toml` names it in `fail_on`; cite the number once the decision has
+one, or say it in prose. A job that checks out with a personal access
+token carrying the `workflow` scope, or a GitHub App token with workflow
+write (`token:` on `actions/checkout`), can push those files — and its
+pushes trigger workflow runs, so a repair commit on a pull request gets a
+check of its own. Such a project leaves the class unenforced.
+
 Two hazards, both found by adopting this into a repository that already had
 generators of its own.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,7 +205,8 @@ full in the [reports](reports/reference-status.md):
 
 `retired-citations` · `unresolved-codes` · `hand-written-urls` ·
 `broken-targets` · `inert-status` · `legacy-spellings` · `narrow-titles` ·
-`stale-directives` · `pending-documents` · `unlinted-files`
+`stale-directives` · `pending-documents` · `unlinted-files` ·
+`workflow-temp-codes`
 
 Any of those class names listed in `[luria.lint] fail_on` fails the build
 instead. Only unacknowledged findings ever reach a class, so

--- a/luria.toml
+++ b/luria.toml
@@ -168,3 +168,10 @@ pin = true
 [luria.remotes.FX]
 name = "fixtures"
 url  = "https://github.com/dmarx/luria/blob/main/docs/directives.md#fixture-codes"
+
+
+# The generation job pushes with the workflow's own token, which cannot
+# write under .github/workflows/ — so a temporary code cited from a workflow
+# file is one the job can never number, and it fails the lint here.
+[luria.lint]
+fail_on = ["workflow-temp-codes"]

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -355,30 +355,25 @@ def check_generated_index(errors: list[str]) -> None:
             f"{remedy}")
 
 
-def check_workflow_temp_codes(errors: list[str]) -> None:
-    """A temporary code (ADR-049) in a workflow file is one the generation
-    job can never number: `luria concretize` rewrites it with everything
-    else, and GitHub refuses a push from the workflow token that modifies
-    `.github/workflows/` — so the job's commit is rejected and the default
-    branch stays red, with nothing wrong in the record. The first merge to
-    cite a pending decision from a workflow comment found this. Cite the
-    number once the decision has one, or say it in prose."""
+def workflow_temp_code_lines() -> list[str]:
+    """A temporary code (ADR-049) cited from a workflow file, one line per
+    site. `luria concretize` rewrites the code with everything else when the
+    decision is numbered, and the workflow's own token cannot push a change
+    under `.github/workflows/` — so on that token the generation job's
+    commit is refused whole. A job pushing with a token that has workflow
+    write has no such problem, which is why this is a warning class and not
+    a violation: the project says which token it runs on by naming
+    `workflow-temp-codes` in `fail_on`, or not."""
     cfg = current()
     patterns = [s.temp_pattern for s in cfg.schemes.values()]
-    if not patterns:
-        return
+    found: list[str] = []
     for path in sorted(cfg.root.glob(".github/workflows/*.y*ml")):
         text = path.read_text(encoding="utf-8")
         for regex in patterns:
             for m in regex.finditer(text):
                 line = text.count("\n", 0, m.start()) + 1
-                errors.append(
-                    f"{cfg.rel(path)}:{line}: temporary code {m.group(0)} in a "
-                    "workflow file — the generation job cannot rewrite it when "
-                    "the decision is numbered (the workflow token may not "
-                    "modify `.github/workflows/`), so its push is refused; "
-                    "cite the number once the decision has one, or say it in "
-                    "prose")
+                found.append(f"{cfg.rel(path)}:{line}: {m.group(0)}")
+    return found
 
 
 def check_wikilinks(errors: list[str]) -> None:
@@ -432,7 +427,7 @@ def check_bare_refs(errors: list[str]) -> None:
 FAILABLE = ("retired-citations", "unresolved-codes", "hand-written-urls",
             "broken-targets", "remote-drift", "inert-status",
             "legacy-spellings", "narrow-titles", "stale-directives",
-            "pending-documents", "unlinted-files")
+            "pending-documents", "unlinted-files", "workflow-temp-codes")
 
 
 def status_sections() -> list[tuple[str, str, list[str]]]:
@@ -459,6 +454,19 @@ def status_sections() -> list[tuple[str, str, list[str]]]:
             f"{len(loose)} code(s) resolve to no document "
             "(`luria reports` for the sites, `unresolved-ok:` for the "
             "deliberate ones)", loose))
+
+    # A temporary code in a workflow file is one the generation job cannot
+    # rewrite on the workflow's own token; a project on that token names the
+    # class in `fail_on`, one whose job pushes with workflow write leaves it.
+    sites = workflow_temp_code_lines()
+    if sites:
+        sections.append((
+            "workflow-temp-codes",
+            f"{len(sites)} temporary code(s) cited from a workflow file — the "
+            "workflow's own token cannot push the rewrite once the decision "
+            "is numbered; cite the number when it has one, say it in prose, "
+            "or give the generation job a token with workflow write and "
+            "leave this class unenforced", sites))
 
     # A whole file opting out of reference checking is legitimate and blunt
     # (#37) — blunt enough that the count surfaces even though nothing here
@@ -610,7 +618,6 @@ def run() -> None:
     check_journals(errors)
     check_version_history(errors)
     check_bare_refs(errors)
-    check_workflow_temp_codes(errors)
     check_wikilinks(errors)
     report_warnings(errors)
     if errors:

--- a/record/changelog.d/20260903-222323.md
+++ b/record/changelog.d/20260903-222323.md
@@ -1,0 +1,7 @@
+### Changed
+
+- A temporary code cited from a workflow file is the `workflow-temp-codes`
+  warning class, on the enforcement dial, rather than a lint error: the
+  generation job cannot push the rewrite on the workflow's own token, and
+  can on a token with workflow write. This repository and the scaffold
+  name the class in `fail_on`.

--- a/record/decisions.d/ADR-tmpwa5cm.md
+++ b/record/decisions.d/ADR-tmpwa5cm.md
@@ -1,0 +1,146 @@
+---
+# Don't copy this file by hand — run `luria new adr`, which assigns the
+# identity and fills in the fields a machine can compute. WHICH identity
+# depends on the scheme's `allocate` mode: `filing` (the default) takes the
+# next free number on the spot, `merge` mints a temporary code that
+# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
+# config: every scheme, fragment directory and journal in luria.toml is one, so
+# `luria new <kind>` works for a scheme the moment it is declared.
+#
+# Numbering is sequential and carries information (it's the order decisions were
+# made). The filename is the code and nothing else; the title goes in `title:`
+# below, where correcting it costs an edit rather than a rename plus every link
+# (ADR-013).
+#
+# This frontmatter is the ONLY place these facts live. The index and the per-tag
+# pages are generated from it (ADR-004) — never edit them by hand; run
+# `luria index`.
+
+# Active | Proposed | Deferred | Superseded | Rejected, optionally " — <note>".
+# Supersede when the CHOICE changes: set the old one to
+# `Superseded — by [ADR-tmpwa5cm](ADR-tmpwa5cm.md)` and leave its body intact. When the
+# choice stands and only a REASON was wrong, correct this body in place and
+# bump `version:` below — the rule objects to silent revision, not to editing.
+status: 'Active'
+
+# What the index shows in place of the code. Repeat it as the body's `# ADR-tmpwa5cm:`
+# heading — someone reading the file alone needs one — and `luria lint` checks
+# that the two agree, because two copies of a string is a projection that drifts.
+title: "A workflow file cites decisions in a form the generation job's token can commit: by number, or in prose"
+
+# Which revision of this decision's claim you are reading. Standard frontmatter
+# for every scheme, and it moves rarely here: a decision that CHANGES is
+# superseded by a new one, not edited. Bump it when the same choice is restated
+# more broadly — scope widened, wording generalized — and say what changed in a
+# `history:` entry. Shown in the index only when it is not 1.
+version: 1
+
+# Browsing categories, pushed down onto the decision itself. One is normal; more
+# than one is fine. A tag not listed in tags.yaml still works.
+tags:
+- ci
+- mechanism
+
+date: '2026-09-03'
+
+# Optional. The issue(s) this decision came from: '#123'.
+
+# Optional but wanted: the one-blob description the index table shows. Without
+# it the table falls back to the title, which is usually too terse to browse by.
+# Say what was decided AND what was rejected — the index is read far more often
+# than the decision, and "why not the obvious thing" is what people come for.
+# This field is prose, so it carries links like any other prose; the rest of the
+# frontmatter is data and stays plain. (`origin:` on a principle is
+# prose for the same reason — the generator renders it.)
+summary: >-
+  The generation job pushes with the workflow's own token, and that token
+  cannot write under `.github/workflows/`; when `luria concretize` numbered
+  [ADR-068](ADR-068.md) it rewrote the temporary code in a `ci.yml` comment too, and the
+  bot's whole commit was refused. The job keeps the workflow token — no
+  setup, fork-safe — and a workflow file cites a decision by its number or
+  in prose; a temporary code there is the `workflow-temp-codes` warning
+  class, enforced here and in the scaffold through `fail_on`. A project
+  that gives its job a token with workflow write leaves the class alone
+  and the bot rewrites the file. A person's `luria concretize` was never
+  constrained: the limit is the token, not the file. Rejected: a lint
+  error regardless of token (the first draft, [#150](https://github.com/dmarx/luria/issues/150)), a concretizer that
+  skips workflow files, and dropping them from the code globs.
+  alternatives that lost. Written to be read in a table row.
+---
+
+# ADR-tmpwa5cm: A workflow file cites decisions in a form the generation job's token can commit: by number, or in prose
+
+## Context
+
+A merge-allocated decision carries a temporary code until the generation
+job on the default branch numbers it ([ADR-049](ADR-049.md)), and `luria concretize`
+then rewrites that code everywhere the record and the code globs reach —
+source, tests, the composite actions, the workflow files — so that no
+second spelling of the document survives ([ADR-040](ADR-040.md)). Workflow files are in
+the code globs on purpose: their comments cite decisions, and the
+reference lint should see a retired one there like anywhere else.
+
+The job pushes with the workflow's own token, `GITHUB_TOKEN`. That token
+cannot create or update anything under `.github/workflows/`, and there is
+no `workflows:` entry a `permissions:` block could grant; a personal
+access token with the `workflow` scope, or a GitHub App token with
+workflow write, can, handed to `actions/checkout` as `token:`. So when
+[ADR-068](ADR-068.md) was numbered, the rename reached a comment in `ci.yml` and the
+bot's one commit — views, rename and repairs together — was refused, and
+the lint job that `needs:` it never ran. The record was right; the branch
+was red; a second pull request was the only fix.
+
+The constraint is the token's, not the file's. A person running
+`luria concretize` locally rewrites a workflow file like any other and
+pushes it like any other; only the job's push is refused, and only on
+that token. The first draft of this decision ([#150](https://github.com/dmarx/luria/issues/150)) wrote "never" where
+the mechanism enforced no such thing — the case [ADR-tmpxgn2o](ADR-tmpxgn2o.md) names.
+
+## Decision
+
+**The generation job pushes with the workflow's own token, and a workflow
+file cites a decision in a form that token can commit: by number, or in
+prose.** A temporary code cited from a workflow file is the
+`workflow-temp-codes` warning class ([ADR-035](ADR-035.md)): reported by default, with
+the remedy in the headline — cite the number when the decision has one,
+say it in prose, or give the job a token with workflow write and leave
+the class unenforced. This repository and the scaffold name the class in
+`[luria.lint] fail_on`, because their jobs run on the workflow token.
+
+A project whose job checks out with a token that has workflow write
+leaves the class where the dial puts it and lets the bot rewrite the
+file; the docs say which tokens those are and what else they buy — a
+push made with one triggers workflow runs, so a repair commit on a pull
+request gets a check of its own ([ADR-068](ADR-068.md)).
+
+## Alternatives considered
+
+- **A lint error regardless of token** — the first draft ([#150](https://github.com/dmarx/luria/issues/150)). Right on
+  the workflow token and wrong on any other, and it said "never" about a
+  file a person can edit freely. A judgement that depends on how the job
+  is configured is a warning class on the dial, which is what [ADR-035](ADR-035.md)
+  built the dial for.
+- **Push with a workflow-capable token by default.** Works, and makes the
+  scaffold depend on a secret someone has to create, scope, store and
+  rotate before its first run succeeds. Offered, not required.
+- **Have `luria concretize` skip `.github/workflows/`.** The push
+  succeeds, and the workflow file keeps a code naming a document that no
+  longer exists under that name — an unresolvable reference on every run
+  until someone edits it by hand — and `--check` needs the same exception.
+- **Drop workflow files from the code globs.** The concretizer leaves them
+  alone, and so does the reference lint: a workflow comment citing a
+  superseded decision stops being caught, in the comments that explain
+  why CI is shaped the way it is.
+
+## Consequences
+
+An author citing a pending decision from a workflow comment writes prose
+— "the amendment to [ADR-029](ADR-029.md) on where views land" — where a source file
+would carry the code. The scaffold's workflow does the same. The finding
+fired once on the real case before the fix, naming the file, the line and
+the code.
+
+A *numbered* citation in a workflow file that a migration renames
+([ADR-040](ADR-040.md)) meets the same refusal on the workflow token; the migration's
+pull request edits that file by hand. This decision covers the temporary
+code, which is the case that recurs.

--- a/record/decisions.d/ADR-tmpxgn2o.md
+++ b/record/decisions.d/ADR-tmpxgn2o.md
@@ -1,0 +1,123 @@
+---
+# Don't copy this file by hand — run `luria new adr`, which assigns the
+# identity and fills in the fields a machine can compute. WHICH identity
+# depends on the scheme's `allocate` mode: `filing` (the default) takes the
+# next free number on the spot, `merge` mints a temporary code that
+# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
+# config: every scheme, fragment directory and journal in luria.toml is one, so
+# `luria new <kind>` works for a scheme the moment it is declared.
+#
+# Numbering is sequential and carries information (it's the order decisions were
+# made). The filename is the code and nothing else; the title goes in `title:`
+# below, where correcting it costs an edit rather than a rename plus every link
+# (ADR-013).
+#
+# This frontmatter is the ONLY place these facts live. The index and the per-tag
+# pages are generated from it (ADR-004) — never edit them by hand; run
+# `luria index`.
+
+# Active | Proposed | Deferred | Superseded | Rejected, optionally " — <note>".
+# Supersede when the CHOICE changes: set the old one to
+# `Superseded — by [ADR-tmpxgn2o](ADR-tmpxgn2o.md)` and leave its body intact. When the
+# choice stands and only a REASON was wrong, correct this body in place and
+# bump `version:` below — the rule objects to silent revision, not to editing.
+status: 'Active'
+
+# What the index shows in place of the code. Repeat it as the body's `# ADR-tmpxgn2o:`
+# heading — someone reading the file alone needs one — and `luria lint` checks
+# that the two agree, because two copies of a string is a projection that drifts.
+title: 'A decision is stated for what it chooses; a prohibition is reserved for a constraint that has been verified'
+
+# Which revision of this decision's claim you are reading. Standard frontmatter
+# for every scheme, and it moves rarely here: a decision that CHANGES is
+# superseded by a new one, not edited. Bump it when the same choice is restated
+# more broadly — scope widened, wording generalized — and say what changed in a
+# `history:` entry. Shown in the index only when it is not 1.
+version: 1
+
+# Browsing categories, pushed down onto the decision itself. One is normal; more
+# than one is fine. A tag not listed in tags.yaml still works.
+tags:
+- process
+- record
+
+date: '2026-09-03'
+
+# Optional. The issue(s) this decision came from: '#123'.
+
+# Optional but wanted: the one-blob description the index table shows. Without
+# it the table falls back to the title, which is usually too terse to browse by.
+# Say what was decided AND what was rejected — the index is read far more often
+# than the decision, and "why not the obvious thing" is what people come for.
+# This field is prose, so it carries links like any other prose; the rest of the
+# frontmatter is data and stays plain. (`origin:` on a principle is
+# prose for the same reason — the generator renders it.)
+summary: >-
+  Three decision drafts in one day carried a "never" the mechanism did
+  not enforce — a title saying edges are never inferred from prose, a
+  rule that a workflow file never cites a temporary code — and each was
+  sent back in review. A decision is stated for what it chooses: the
+  title and the decision paragraph say what is preferred and what is
+  done, and a rejected alternative is named as such. A prohibition
+  ("never", "must not") appears only where the constraint has been
+  verified against the thing that enforces it, and the text names that
+  enforcer. The "X, not Y" title names a rejected alternative and is not
+  a prohibition. Rejected: a lint for the words (a rejected-alternative
+  list legitimately says "never"), and leaving it to review, which is
+  where it kept being caught.
+  alternatives that lost. Written to be read in a table row.
+---
+
+# ADR-tmpxgn2o: A decision is stated for what it chooses; a prohibition is reserved for a constraint that has been verified
+
+## Context
+
+A decision document is read far more often than it is written, mostly by
+someone deciding whether a rule applies to the case in front of them. A
+title that says *never* settles that question before the body is opened.
+When the mechanism enforces no such thing — or the constraint has an
+exception the author did not check — the reader inherits a rule the
+record does not actually keep.
+
+Three drafts in one day did this. The typed-edges decision's title said a
+successor is *never* inferred from prose, where the decision was that
+fields are preferred and prose allowed ([#143](https://github.com/dmarx/luria/issues/143)). The first draft of
+[ADR-tmpwa5cm](ADR-tmpwa5cm.md) said a workflow file *never* cites a temporary code, where the
+constraint belongs to one token and a person can edit the file freely
+([#150](https://github.com/dmarx/luria/issues/150)). Each was sent back in review with the same note; a guard that
+keeps catching the same thing is a bug report about the workflow, so the
+note becomes a decision the review can cite.
+
+## Decision
+
+**A decision is stated for what it chooses.** The title and the decision
+paragraph say what is preferred and what is done. What was rejected is
+named under alternatives, as a rejection.
+
+**A prohibition is reserved for a constraint that has been verified.**
+"Never", "must not", "forbidden" and their kin appear in a title or a
+decision paragraph only where the author has checked the constraint
+against the thing that enforces it — a platform's refusal, a lint error,
+a type — and the text names that enforcer. A constraint on one actor
+(the generation job's token) is stated for that actor, not for the file.
+
+The record's "X, not Y" titles — *reported, not enforced*; *populated,
+not demanded* — name the rejected alternative beside the choice, and are
+the affirmative form.
+
+## Alternatives considered
+
+- **A lint for the words.** A rejected-alternative list says "never"
+  legitimately, and so does a verified constraint; telling them apart is
+  the judgement this decision asks the author to make, and a check that
+  fires on the word would catch the right cases with the wrong ones.
+- **Leave it to review.** That is where it was caught, three times, by
+  the same reviewer with the same note. Writing it down is what lets the
+  next review point instead of explain.
+
+## Consequences
+
+Existing decisions keep their wording; a title is corrected when its
+decision is next revised, not in a sweep. A reviewer sending a draft back
+for a "never" cites this decision. The two drafts that prompted it were
+reworded before they merged.

--- a/record/devlog.d/2026/09/03/222323.md
+++ b/record/devlog.d/2026/09/03/222323.md
@@ -1,0 +1,32 @@
+---
+title: "An ADR closed in review: the constraint was the token's, not the file's"
+created: '2026-09-03T22:23:23'
+tags:
+- record
+- ci
+---
+
+**[#150](https://github.com/dmarx/luria/issues/150) was closed with two comments, and both were right.** The decision
+behind [#149](https://github.com/dmarx/luria/issues/149)'s guard said a workflow file *never* cites a temporary code.
+A person running `luria concretize` locally rewrites that file like any
+other and pushes it like any other; only the generation job's push is
+refused, and only because it runs on the workflow's own token, which
+cannot write under `.github/workflows/`. The decision was about the
+token and had been written about the file.
+
+**So the guard moved onto the dial.** A lint error is for what is always
+wrong; a finding that is wrong on one token and fine on another is a
+warning class ([ADR-035](../../record/decisions.d/ADR-035.md)). `workflow-temp-codes` is reported by default,
+and this repository and the scaffold name it in `fail_on` because their
+jobs run on the workflow token. A project that hands its job a personal
+access token with the `workflow` scope, or an App token with workflow
+write, leaves the class alone and the bot rewrites the file — and, as a
+side effect worth having, that job's pushes trigger workflow runs, so a
+repair commit on a pull request gets a check of its own. Decided as [ADR-tmpwa5cm](../../record/decisions.d/ADR-tmpwa5cm.md).
+
+**The second comment became a decision too.** Three drafts in one day
+carried a "never" the mechanism did not enforce, and the same reviewer
+sent each one back with the same note. [ADR-tmpxgn2o](../../record/decisions.d/ADR-tmpxgn2o.md): a decision is stated for
+what it chooses, and a prohibition is reserved for a constraint that has
+been verified against the thing that enforces it. The note is now
+something a review can cite instead of repeat.

--- a/remotes.lock.json
+++ b/remotes.lock.json
@@ -54,6 +54,10 @@
       "ADR-049": {
         "endorsed": "sha256:a90407eeb41be3fb7e3d70f8c0ec166e01353b3e6fb2f47546c3c3ccdc288acf",
         "seen": "sha256:a90407eeb41be3fb7e3d70f8c0ec166e01353b3e6fb2f47546c3c3ccdc288acf"
+      },
+      "ADR-068": {
+        "endorsed": "sha256:11af8a877b112a191d3c28b9e72b659eacdae84897d10afcf59167be73795036",
+        "seen": "sha256:11af8a877b112a191d3c28b9e72b659eacdae84897d10afcf59167be73795036"
       }
     }
   }

--- a/template/luria.toml
+++ b/template/luria.toml
@@ -133,5 +133,10 @@ url  = "https://github.com/dmarx/luria/blob/main/docs/directives.md#fixture-code
 # The enforcement dial (LU-ADR-035): status findings are warnings by default,
 # and a class named here fails `luria lint` instead. The acknowledgement
 # directives keep working under enforcement — only unacknowledged rows fail.
-# [luria.lint]
-# fail_on = ["retired-citations", "pending-documents"]
+# The scaffolded docs workflow pushes with the workflow's own token, which
+# cannot write under .github/workflows/, so a temporary code cited from a
+# workflow file is one the generation job can never number: enforced from
+# the start. Give the job a token with workflow write and drop it.
+[luria.lint]
+fail_on = ["workflow-temp-codes"]
+# fail_on = ["workflow-temp-codes", "retired-citations", "pending-documents"]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -323,26 +323,37 @@ def test_pending_documents_can_be_promoted(project, capsys):
 # ── Temporary codes in workflow files ────────────────────────────────────
 
 
-def workflow_errors(project, text: str) -> list[str]:
+def workflow_project(project, text: str, fail_on: str = "") -> None:
     wf = project / ".github" / "workflows" / "docs.yml"
     wf.parent.mkdir(parents=True)
     wf.write_text(text)
-    found: list[str] = []
-    lint.check_workflow_temp_codes(found)
-    return found
+    (project / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        f'[luria.lint]\nfail_on = [{fail_on}]\n')
+    from luria import config
+    config.reset()
 
 
-def test_a_temporary_code_in_a_workflow_is_reported(project):
-    """The generation job's commit would be refused: `luria concretize`
-    rewrites the code with everything else, and the workflow token may not
-    modify `.github/workflows/`. Found by the first merge that cited a
-    pending decision from a workflow comment."""
-    errors = workflow_errors(project, "# The shape (ADR-tmpabcde).\nname: Docs\n")
-    assert len(errors) == 1
-    assert "docs.yml:1" in errors[0]
-    assert "ADR-tmpabcde" in errors[0]
-    assert "cite the number once the decision has one" in errors[0]
+def test_a_temporary_code_in_a_workflow_is_a_warning_class(project, capsys):
+    """On the workflow's own token the generation job's push would be
+    refused: `luria concretize` rewrites the code with everything else, and
+    that token may not modify `.github/workflows/`. A job pushing with
+    workflow write has no such problem — so a warning class, on the dial."""
+    workflow_project(project, "# The shape (ADR-tmpabcde).\nname: Docs\n")
+    errors, err = dial_errors(capsys)
+    assert errors == []
+    assert "temporary code(s) cited from a workflow file" in err
+    assert "docs.yml:1: ADR-tmpabcde" in err
+
+
+def test_a_project_on_the_workflow_token_fails_on_it(project, capsys):
+    workflow_project(project, "# The shape (ADR-tmpabcde).\nname: Docs\n",
+                     '"workflow-temp-codes"')
+    errors, _ = dial_errors(capsys)
+    assert any("failing: `fail_on`" in e for e in errors)
+    assert any("docs.yml:1: ADR-tmpabcde" in e for e in errors)
 
 
 def test_a_numbered_code_in_a_workflow_is_fine(project):
-    assert workflow_errors(project, "# The shape (ADR-029).\nname: Docs\n") == []
+    workflow_project(project, "# The shape (ADR-029).\nname: Docs\n")
+    assert lint.workflow_temp_code_lines() == []


### PR DESCRIPTION
Replaces #150, closed with two comments. Both taken.

## 1. The constraint is the token's, not the file's — `ADR-tmpwa5cm`

To the question in the review: a `permissions:` block cannot grant it — there is no `workflows:` entry, and `GITHUB_TOKEN` can never create or update a file under `.github/workflows/`. A personal access token with the `workflow` scope, or a GitHub App token with workflow write, can, handed to `actions/checkout` as `token:`. Such pushes also trigger workflow runs, which is the other thing a stronger token buys: a repair commit on a pull request gets a check of its own.

So the decision is stated for the job and its token, not the file. A person's `luria concretize` was never constrained.

**Mechanism changed to match.** A temporary code cited from a workflow file is now the `workflow-temp-codes` warning class on the enforcement dial (ADR-035), not a lint error: right on the workflow token, wrong on any other, which is exactly what the dial is for. This repository and the scaffold name it in `[luria.lint] fail_on` because both jobs push with the workflow token; a project that hands its job a stronger token leaves the class alone and the bot rewrites the file. `docs/adopting.md` says which tokens and what they buy.

Rejected in the ADR: the lint error regardless of token (#150's draft), a stronger token by default (a secret the scaffold would depend on before its first run), a concretizer that skips workflow files (a dangling code forever), dropping workflow files from the code globs (loses the retired-citation check there).

## 2. Affirmative wording — `ADR-tmpxgn2o`

A decision is stated for what it chooses; a prohibition ("never", "must not") is reserved for a constraint verified against the thing that enforces it, with the enforcer named. The record's "X, not Y" titles name a rejected alternative and are the affirmative form. Context names the three drafts today that were sent back with this note. Rejected: a lint for the words (a rejected-alternatives list says "never" legitimately), and leaving it to review, which is where it kept being caught.

Both filed Active: the first's mechanism ships here, the second is already how review works.

## Also

- Endorses the `LU-ADR-068` pin that concretization left unendorsed (the lint warned on `main` since the bot commit).
- Devlog entry and changelog fragment.

## Verification

- `python -m pytest tests -q`: 609 passed.
- `luria index` then `luria lint` in the working tree: clean, the pin warning gone. The branch carries no regenerated views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r)_