### PR TITLE
Principle granularity: DP-012 v2, and the two principles the record was leaning on unstated

### DIFF
--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -363,62 +363,112 @@ anything, and that restraint is what keeps the licence worth having.
 
 <a name="dp-12"></a>
 
-## 12. One decision, one thing
+## 12. One document, one thing
 
-**A decision with two unrelated halves is one nobody can cite half of.**
+**A document with two unrelated halves is one nobody can cite half of.**
 
 Bundling is always cheaper at writing time. One record, one review, one merge —
 and the second half arrives free, because it was going to be written anyway.
 The cost lands later and never goes away.
 
+This was first written about decisions, and it is not about decisions. It holds
+for any document a reader is expected to name: a decision, a principle, a
+practice in a record of practices, a claim in an anthology. The unit is
+whatever gets cited.
+
 ## What it costs
 
-**The second half has no code.** A citation is how this record is used: an
+**The second half has no code.** A citation is how a record is used: an
 argument names its premise, a module names the decision it implements, a lint
-message names the rule it enforces. Half a decision cannot be named, so the
+message names the rule it enforces. Half a document cannot be named, so the
 half that was cheap to add is the half nothing can point at — and a rule
 nothing points at is a rule nobody knows applies to them.
 
-**Superseding withdraws more than intended.** A decision that changes gets
-superseded whole. If two choices share a record, retiring the one that aged out
+**Superseding withdraws more than intended.** A document that changes gets
+superseded whole. If two things share a record, retiring the one that aged out
 silently retires the one that did not, and the record now says nothing about a
 question it had answered. That is the failure the status vocabulary exists to
 prevent, reintroduced at a coarser grain.
 
-**Alternatives stop being reconstructable.** The alternatives section is the
-highest-value part of a decision, and it only works when it is the alternatives
-to *one* choice. Two choices produce a cross-product, or — far more often — an
-alternatives section that silently covers whichever half the author found more
-interesting.
+**Alternatives stop being reconstructable.** For a decision, the alternatives
+section is the highest-value part, and it only works when it is the
+alternatives to *one* choice. Two choices produce a cross-product, or — far
+more often — an alternatives section that silently covers whichever half the
+author found more interesting.
 
-## The test
+## Two tests
 
-**Could the two halves have been decided differently?** If a project could
-adopt one and reject the other, they are two decisions, however naturally they
+**Could the halves have been decided differently?** If a project could adopt
+one and reject the other, they are two documents, however naturally they
 arrived together.
 
-The tempting counterexample is the pair where one half motivated the other.
-That is exactly when to split, and it is worth being concrete: a feature was
-built to fix a defect, and a separate check would actually have *caught* that
-defect. Bundling them would have produced a record whose stated motivation was
-served by only one of its halves — and a reader asking "why does this check
-exist?" would find the answer to a different question.
+That one only fires while writing, and it depends on the author asking. Typed
+edges ([ADR-071](../record/decisions.d/ADR-071.md), [ADR-060](../record/decisions.d/ADR-060.md))
+make a second test possible, and this one fires afterwards, mechanically:
 
-Splitting them also produced something bundling would have hidden. Building the
-second after the first landed revealed an exemption the second needed *because
-of* the first, which is a relationship that only exists between two things.
+**Does an edge into this document have to name which *part* of it applies?**
+If stating what a relation asserts requires pointing at one clause of its
+target, the target is two documents.
+
+Note what this test is not. An `overrides` edge already means *where both bear,
+this one wins* — the overlap is decided by the two documents' contents, so an
+edge is not over-claiming merely by being silent about scope. The tell is
+narrower and shows up in the prose beside the edge: a body that has to explain
+which sentence of the target it is arguing with.
+
+The worked case is a record of an assistant's operating constitution, which
+contains no decisions at all. A boundary — *never infer a person's pronouns
+from their name* — declares that it `overrides` a practice titled *deliver the
+whole requested scope; state assumptions rather than narrowing*. But the
+boundary's body does not argue with delivering the whole scope. It argues with
+a different claim the same document happens to carry: *make the routine
+judgment call yourself rather than escalating it*. The override had to say so
+in prose, because the code it names covers both.
+
+Applying the first test confirms it. *Deliver the whole scope* and *make the
+routine call yourself* could be adopted separately — a project could want one
+and reject the other — so they were always two practices. They had simply
+arrived in the same paragraph of the source. Splitting them let each override
+name what it actually beats, and immediately exposed a second error: one of the
+two edges, checked against the narrower practice, turned out not to hold at all.
+
+That is the useful property. The a-priori test needs an author to stop and ask.
+This one arrives as friction while writing something else, which is when a
+granularity defect is cheapest to notice and most likely to be noticed at all.
+
+## Why not just qualify the edge
+
+Because a condition on a relation is unfalsifiable in exactly the way this
+record's machinery exists to prevent. `overrides` is checked — the code must
+resolve, to a document of the declared scheme, that actually exists. A `when:`
+beside it is prose in a data field: nothing evaluates it, nothing notices when
+it stops being true, and nothing tells a reader whether the qualifier or the
+edge governs their case. It is escalating emphasis in a new costume, one level
+up, and the graph it produces is worse than no graph because it looks checked.
+
+This is why [#141](https://github.com/dmarx/luria/issues/141) puts `when`
+expressions among its non-goals, and why it refuses precedence between
+configuration surfaces — a conflict there is an error rather than something a
+tie-break rule resolves. Same move: **decline the qualifier, and remove what
+made it necessary.**
 
 ## What this is not
 
-Not an argument for small decisions. A decision covering one choice can be long,
+Not an argument for small documents. A document covering one thing can be long,
 and usually should be — the context, the alternatives and the consequences of a
-single choice are most of what makes a record worth keeping.
+single claim are most of what makes a record worth keeping.
 
-Nor is it an argument against related decisions landing together. Ship them in
+Nor is it an argument against related documents landing together. Ship them in
 one contribution if that is honest; give them separate codes so each can be
 cited, revisited, and retired on its own evidence.
 
-*v1 · shaped by [ADR-035](../record/decisions.d/ADR-035.md), [ADR-056](../record/decisions.d/ADR-056.md) · origin: Three splits in one session, each made for the same reason and none of them by rule: a lint check separated from the vocabulary it reads, two scheme audits written as two decisions rather than one, and a status feature split from the report that would have caught the bug motivating it. Each bundle would have been smaller to write and impossible to cite half of*
+And it is not a licence to split on sight. The second test is the discipline
+that keeps it honest: split when something *points* at a part rather than the
+whole, not whenever a document could conceivably be subdivided. A record of
+maximally small documents has the same problem in reverse — every claim needs
+five citations to state, and none of them means anything alone.
+
+*v2 · shaped by [ADR-035](../record/decisions.d/ADR-035.md), [ADR-056](../record/decisions.d/ADR-056.md), [ADR-060](../record/decisions.d/ADR-060.md), [ADR-071](../record/decisions.d/ADR-071.md) · origin: Three splits in one session, each made for the same reason and none of them by rule: a lint check separated from the vocabulary it reads, two scheme audits written as two decisions rather than one, and a status feature split from the report that would have caught the bug motivating it. Then, in a record of practices rather than decisions, an `overrides` edge whose prose had to name which clause of its target it argued with — the same defect, arriving as a relation instead of as a bundle*
 
 <a name="dp-13"></a>
 

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -43,6 +43,12 @@ one that has stopped applying is reported in its own right — otherwise the
 mechanism for saying "this is fine" becomes the mechanism for never hearing
 about it again.
 
+
+The reason a silent no-op is worse than a loud one is [DP-015](design-principles.md#dp-15): nothing
+happening and everything working produce the same observation, so the user's
+next move is to conclude the tool is broken rather than to look for the
+precondition.
+
 *v1 · origin: The strata-g design-language review, where tools silently no-opped on inputs that didn't meet their preconditions*
 
 <a name="dp-2"></a>
@@ -102,6 +108,12 @@ Three remedies, in order of strength:
    polarity a naive list has by default.
 
 In this package, the decision index is rung 1 and the reference lint is rung 2.
+
+
+Why fail-stale specifically is the unacceptable polarity, rather than merely
+the worst of three: it is the silent one, and [DP-015](design-principles.md#dp-15) is the general form —
+a missed entry that ships as wrong behaviour is indistinguishable from a
+complete list, so nothing about the system reports the gap.
 
 *v2 · shaped by [ADR-004](../record/decisions.d/ADR-004.md), [ADR-005](../record/decisions.d/ADR-005.md) · origin: A hardcoded type union that had drifted to 13 of 21 keys; generalized by a later arc where every one of five converted projections was already wrong*
 
@@ -174,6 +186,11 @@ benefit it exists for.
 broken, what the guard printed, what it printed after the repair — is the
 difference between a guard someone trusts and a guard someone re-tests from
 scratch because they can't tell whether it works.
+
+
+The general case is [DP-015](design-principles.md#dp-15). An unfired guard emits exactly what a guard
+with nothing to catch emits, so "no findings" is not evidence of a clean tree
+until something has proved the instrument can speak.
 
 *v1 · shaped by [ADR-007](../record/decisions.d/ADR-007.md) · origin: Two inert mechanisms in strata-g — an alert shape that could never fire, and a CI fast path whose fail-safe polarity made a month of inertness invisible. Both were discovered by accident rather than by the thing they guarded*
 
@@ -307,6 +324,12 @@ The test, when a new switch appears: *what does the silent position cost,
 and who pays?* If the project pays in missed defects, on-by-default. If
 the author pays in unwanted exposure, off-by-default. A switch where both
 answers feel true is usually two switches wearing one name — split it.
+
+
+Both halves of the rule descend from [DP-015](design-principles.md#dp-15). A default is the position that
+ships when nobody reads the docs, and its failure is silent by construction —
+so the polarity question is really "which direction can announce itself?", and
+the answer sets the default.
 
 *v1 · shaped by [ADR-035](../record/decisions.d/ADR-035.md)*
 
@@ -583,3 +606,68 @@ reach — and reach is the point, because the projects that most need a memory
 are rarely the ones that look like yours.
 
 *v1 · shaped by [ADR-064](../record/decisions.d/ADR-064.md) · origin: A Windows user ran `luria init` and then `luria index`, and got a stack trace writing a check mark into a status report. Nothing about their project was unusual. The tool had required a UTF-8-capable platform without ever saying so*
+
+<a name="dp-15"></a>
+
+## 15. An absence reads exactly like a success — give the silent case a signal
+
+**Nothing happening and everything working produce the same observation.**
+
+This is the premise underneath a family of rules in this record, and it was
+never stated because each rule looks self-evidently right on its own. Written
+down, it explains why they are the *same* rule wearing four coats, and it
+predicts where the fifth will be.
+
+| the silent thing | what it looks like from outside |
+|---|---|
+| a tool that no-ops on an input it can't handle | a tool that ran and found nothing to do |
+| a guard nobody has ever fired | a guard that has never had cause to fire |
+| a hand list missing one entry | a hand list that is complete |
+| a default nobody chose | a default someone chose |
+| a measurement of nothing | a measurement of no change |
+
+Every row is a real bug shape, and every one passes review, because review looks
+at the output and the output is *correct-looking*. That is the whole mechanism:
+these failures are not hard to fix, they are hard to **see**, and the thing that
+hides them is the same thing in each case — the failing path emits nothing, and
+nothing is what success emits too.
+
+## What follows from it
+
+Each of these already exists here as its own principle, and each stays its own
+principle because the *remedies* differ. What they share is this diagnosis:
+
+- [DP-001](design-principles.md#dp-1) — a refusal that says nothing reads as a broken tool. Remedy: the
+  refusal explains itself.
+- [DP-003](design-principles.md#dp-3) — rung three is the polarity rule, and fail-stale is singled out as
+  the never-acceptable one precisely because it is the silent polarity. Remedy:
+  derive, or guard the property, or choose a polarity that is not silence.
+- [DP-006](design-principles.md#dp-6) — provisioned is not working; an unfired guard reports what a
+  working one reports. Remedy: sabotage it once, and record that you did.
+- [DP-010](design-principles.md#dp-10) — the silent position of a switch is the one that ships, so it
+  should be the position whose failure is visible. Remedy: guards default on,
+  disclosures default off.
+
+Four different remedies for one diagnosis, which is why folding them together
+would lose more than it saved: a merged principle's advice section would be a
+disjunction, and a reader arriving with a concrete problem would have to guess
+which arm applies.
+
+## The corollary
+
+**A test can have this shape too, and then the safety net has the bug.** An
+assertion that cannot fail passes exactly as loudly as one that can, so a suite
+can grow a hole that reports itself green — the same defect one level up, where
+it is least likely to be looked for. The strata-g record states this as its own
+principle, arrived at independently
+([SG-DP-022](https://github.com/dmarx/strata-g/blob/main/docs/design-principles.md#dp-22)): before believing a comparison,
+require a non-zero count of whatever was counted, and perturb something the
+measurement should detect to confirm the reading moves.
+
+That is the general form of the remedy, and it is worth stating as an
+instruction rather than an observation: **for any silent path, either make it
+emit, or make the emitting case the only reachable one.** Counting the deviations
+is the second-best option and is what [DP-010](design-principles.md#dp-10) settles for; it works because a
+count of zero is itself a signal.
+
+*v1 · origin: Not one episode but an audit. Four principles in this record — [DP-001](design-principles.md#dp-1), [DP-003](design-principles.md#dp-3), [DP-006](design-principles.md#dp-6), [DP-010](design-principles.md#dp-10) — each lean on the word *silent* at the load-bearing moment, and none of them says why silence is the problem. The premise had been re-derived four times without once being written down*

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -257,14 +257,10 @@ human or stateless; a rule living only in prose is discoverable by whoever
 happens to read that prose.
 
 **Diagnosis.** Affordance inconsistency is a smell to *read*, not an
-untidiness to tolerate. The same shape carrying opposite rules — one
-`README.md` you must edit and another you must not; a marked container beside
-an unmarked sibling doing the same job — says a rule has moved out of the tree
-and into somebody's memory. A file whose neighbours are the wrong kind — an
-authored `.stub` sitting beside the generated page it feeds — says something
-is filed where it doesn't belong. When an affordance feels wrong, trust the
-feeling and ask which boundary it is straddling; the discomfort is usually a
-distinction the layout has stopped expressing.
+untidiness to tolerate — the same shape carrying opposite rules, a file whose
+neighbours are the wrong kind. That reading turned out not to be about
+affordances at all: the citation graph reports the same class of fault the
+same way, so it is now [DP-016](design-principles.md#dp-16), and this is the tree half of it.
 
 Two disciplines keep the spend honest. **Structural beats documentary**: a
 comment saying "GENERATED — do not edit" is read after landing in the wrong
@@ -286,7 +282,7 @@ principle binds affordances to the truth. This one is its complement about
 *reach*: affordances are the widest channel an artifact has — spend them,
 don't merely avoid falsifying them.
 
-*v1 · shaped by [ADR-012](../record/decisions.d/ADR-012.md), [ADR-013](../record/decisions.d/ADR-013.md), [ADR-021](../record/decisions.d/ADR-021.md) · origin: An inventory of one repository's layout found the same rules expressed structurally in some places and not at all in others — two source containers marked `.d` and two unmarked, a generated document beside its own sources, an index buried under the things it indexes, and `README.md` meaning "edit me" in one directory and "never edit me" in the next. The layout had been shaping attention the whole time; nobody had been steering it*
+*v2 · shaped by [ADR-012](../record/decisions.d/ADR-012.md), [ADR-013](../record/decisions.d/ADR-013.md), [ADR-021](../record/decisions.d/ADR-021.md) · origin: An inventory of one repository's layout found the same rules expressed structurally in some places and not at all in others — two source containers marked `.d` and two unmarked, a generated document beside its own sources, an index buried under the things it indexes, and `README.md` meaning "edit me" in one directory and "never edit me" in the next. The layout had been shaping attention the whole time; nobody had been steering it*
 
 <a name="dp-10"></a>
 
@@ -458,6 +454,12 @@ two edges, checked against the narrower practice, turned out not to hold at all.
 That is the useful property. The a-priori test needs an author to stop and ask.
 This one arrives as friction while writing something else, which is when a
 granularity defect is cheapest to notice and most likely to be noticed at all.
+
+The general form is [DP-016](design-principles.md#dp-16) — an awkward structure is reporting a
+distinction the model has stopped expressing — and this is its granularity
+case. What that principle adds is the instruction not to resolve the
+awkwardness with a clarifying sentence, which is always available and always
+leaves the model wrong.
 
 ## Why not just qualify the edge
 
@@ -671,3 +673,74 @@ is the second-best option and is what [DP-010](design-principles.md#dp-10) settl
 count of zero is itself a signal.
 
 *v1 · origin: Not one episode but an audit. Four principles in this record — [DP-001](design-principles.md#dp-1), [DP-003](design-principles.md#dp-3), [DP-006](design-principles.md#dp-6), [DP-010](design-principles.md#dp-10) — each lean on the word *silent* at the load-bearing moment, and none of them says why silence is the problem. The premise had been re-derived four times without once being written down*
+
+<a name="dp-16"></a>
+
+## 16. An awkward structure is reporting a distinction the model has stopped expressing
+
+**A structure that is hard to state cleanly is telling you something about the
+model, not about your prose.**
+
+A record maintains two structures, and both are derived from the same
+decisions about what counts as a thing. The **tree** — names, placement,
+neighbours — and the **graph** — the typed edges between documents. Neither is
+merely output. Both are instruments, and both report the same class of fault:
+a distinction that the model has stopped expressing has to live *somewhere*,
+and where it goes is prose, or a comment, or nobody's notes at all.
+
+The tell is friction while writing something else. Not a review finding, not a
+lint failure — the small awkwardness of having to explain, in a sentence,
+something the structure should have carried.
+
+## In the tree
+
+Two files with the same shape and opposite rules — one `README.md` you must
+edit and one you must not. A marked container beside an unmarked sibling doing
+the same job. An authored `.stub` filed among the generated pages it feeds.
+Each is a rule that has moved out of the layout and into somebody's memory,
+and each announces itself as mild untidiness rather than as a defect.
+
+## In the graph
+
+A typed edge is a claim, and it can be awkward in the same way. The instance
+that promoted this: a boundary declared `overrides` against a practice, and its
+body then had to say *which sentence* of that practice it argued with — because
+the target carried two claims under one code. The edge was correct and the
+prose beside it was doing work the graph could not. Splitting the target let
+the edge name what it actually beat, and immediately exposed a second edge that
+did not hold at all ([DP-012](design-principles.md#dp-12) has the worked case).
+
+The same reading applies to an edge nobody can state without a condition, to a
+required reference that had to be filled with the nearest available document,
+and to a relation that needs three sentences of context to be intelligible.
+
+## What to do with the reading
+
+**Read it before absorbing it.** The instinct is to write the clarifying
+sentence and move on; the sentence is cheap and the model stays wrong. Ask
+instead which boundary the awkwardness is straddling — the answer is usually
+a distinction that was real and is no longer represented.
+
+**Then fix the model, not the prose.** Split the document, retype the field,
+move the file, add the vocabulary. The clarifying sentence is what you write
+when you have decided the distinction is not worth representing — which is a
+legitimate answer, and a different one from not having noticed.
+
+**Do not add a qualifier to the relation.** That is the failure mode specific
+to the graph half: a condition beside a checked reference is prose in a data
+field, so nothing evaluates it and nothing notices when it stops holding, while
+the edge keeps looking checked. It is escalating emphasis one rung up — which
+is why [#141](https://github.com/dmarx/luria/issues/141) puts `when` expressions among its non-goals and refuses
+precedence between configuration surfaces.
+
+## The corollary
+
+**This only works if the structures are load-bearing.** A tree nobody navigates
+and a graph nobody reads generate no friction, so they report nothing — the
+instrument has to be used to be an instrument. That is the practical argument
+for typed edges over a general "mentions" relation ([ADR-071](../record/decisions.d/ADR-071.md), [ADR-060](../record/decisions.d/ADR-060.md)),
+and for a layout the lint holds ([ADR-021](../record/decisions.d/ADR-021.md)): the checking is what makes the
+awkwardness surface at authoring time instead of at the reader's expense, a
+year later.
+
+*v1 · shaped by [ADR-060](../record/decisions.d/ADR-060.md), [ADR-071](../record/decisions.d/ADR-071.md) · origin: Extracted from [DP-009](design-principles.md#dp-9), where it had been the third of three jobs and had never once been cited — the symptom [DP-012](design-principles.md#dp-12) names. Promoted on its second substrate: [DP-009](design-principles.md#dp-9) found it in the file tree (a `.stub` beside the page it feeds, two `README.md` files with opposite rules), and a typed `overrides` edge found it again in the citation graph, where the edge's prose had to name which clause of its target it argued with*

--- a/examples/constitution/docs/constitution.md
+++ b/examples/constitution/docs/constitution.md
@@ -105,11 +105,15 @@ user-visible text, including visible thinking.
 
 > **Decomposed as** — [BOUNDARY-003](../record/boundaries.d/BOUNDARY-003.md) (never infer pronouns from a name),
 > grounded in [VALUE-005](values.md#value-5) (an error that lands on a person is not symmetric
-> with one that lands on the work). This is the clearest `overrides` edge in
-> the record: [PRACTICE-001](../record/practices.d/PRACTICE-001.md) and [PRACTICE-005](../record/practices.d/PRACTICE-005.md) both say to make the
-> routine call yourself rather than stalling, and both would license the
-> inference. The boundary is what says *not here*, and the reason it can say so
-> is that the two errors are different in kind rather than in frequency.
+> with one that lands on the work), overriding [PRACTICE-010](../record/practices.d/PRACTICE-010.md) (resolve
+> ambiguity by making the call a careful colleague would). That is the clearest
+> `overrides` edge in the record, and it took two attempts to state. It first
+> named [PRACTICE-001](../record/practices.d/PRACTICE-001.md), which then carried *two* claims, so the boundary's
+> body had to explain which of them it argued with — the tell that a document
+> is really two. Splitting produced [PRACTICE-010](../record/practices.d/PRACTICE-010.md) and exposed a second
+> error: the edge to [PRACTICE-005](../record/practices.d/PRACTICE-005.md) was dropped, not repointed, because that
+> practice licenses acting on what is *established* and explicitly not on what
+> is assumed, so it never permitted the inference.
 
 ## Consequential actions, and reporting
 
@@ -180,8 +184,9 @@ criticism. This applies to producing work products: it doesn't override
 necessary refusals or the need for confirmation on risky or destructive
 actions.
 
-> **Decomposed as** — [PRACTICE-001](../record/practices.d/PRACTICE-001.md) (deliver the whole requested scope;
-> state assumptions rather than narrowing), [PRACTICE-009](../record/practices.d/PRACTICE-009.md) (a reaffirmed
+> **Decomposed as** — [PRACTICE-001](../record/practices.d/PRACTICE-001.md) (deliver the whole requested scope),
+> [PRACTICE-010](../record/practices.d/PRACTICE-010.md) (resolve ambiguity by making the call rather than
+> escalating — the second paragraph here is entirely its), [PRACTICE-009](../record/practices.d/PRACTICE-009.md) (a reaffirmed
 > request is settled), grounded in [VALUE-007](values.md#value-7) (a refusal from the person you
 > are working for is information, not an obstacle). The last two sentences are
 > the seam where this section meets [BOUNDARY-001](../record/boundaries.d/BOUNDARY-001.md): [PRACTICE-009](../record/practices.d/PRACTICE-009.md) governs

--- a/examples/constitution/record/boundaries.d/BOUNDARY-003.md
+++ b/examples/constitution/record/boundaries.d/BOUNDARY-003.md
@@ -1,11 +1,24 @@
 ---
 status: Active
 title: "Never infer a person's pronouns from their name"
-version: 1
+version: 2
 tags: [identity]
 date: '2026-09-05'
+history:
+- version: 1
+  date: '2026-09-05'
+  note: >-
+    Overrode PRACTICE-001 and PRACTICE-005, and had to say in prose which
+    clause of each it argued with.
+- version: 2
+  date: '2026-09-05'
+  note: >-
+    Narrowed to PRACTICE-010 once that was split out. The PRACTICE-005 edge was
+    dropped rather than repointed: that practice licenses acting on what is
+    *established*, explicitly not on what is assumed, so it never permitted the
+    inference and there was nothing to override.
 grounds: VALUE-005
-overrides: [PRACTICE-001, PRACTICE-005]
+overrides: [PRACTICE-010]
 summary: >-
   Where pronouns have not been stated, use they/them — in every user-visible
   surface, reasoning included. A name is not evidence, and this is one of the
@@ -20,12 +33,15 @@ person being spoken to and for anyone mentioned, in replies and in any
 reasoning the person can see.
 
 It is written as a boundary rather than a default because of what it overrides.
-[PRACTICE-001](../practices.d/PRACTICE-001.md) says to make routine judgment
-calls rather than escalating them, and
-[PRACTICE-005](../practices.d/PRACTICE-005.md) says to act on what is
-established instead of stalling. Both are right, and both would license
-inferring from a name — the inference is easy, usually correct, and asking
-would be an interruption. This says: not here.
+[PRACTICE-010](../practices.d/PRACTICE-010.md) says to resolve ambiguity by
+making the call a careful colleague would rather than escalating it. That is
+right, and it would license inferring from a name — the inference is easy,
+usually correct, and asking would be an interruption. This says: not here.
+
+The edge names [PRACTICE-010](../practices.d/PRACTICE-010.md) and not the practice it was split from, and that
+is not a detail. Until the split, this override had to explain in prose which
+sentence of a two-claim practice it argued with; now the code it names is the
+claim it beats.
 
 The reason is the asymmetry [VALUE-005](../../docs/values.md#value-5) names.
 The two errors are not the same size. Using they/them for someone who would

--- a/examples/constitution/record/practices.d/PRACTICE-001.md
+++ b/examples/constitution/record/practices.d/PRACTICE-001.md
@@ -1,15 +1,27 @@
 ---
 status: Active
 title: 'Deliver the whole requested scope; state assumptions rather than narrowing'
-version: 1
+version: 2
 tags: [scope]
 date: '2026-09-05'
+history:
+- version: 1
+  date: '2026-09-05'
+  note: >-
+    Carried two claims that arrived in the same paragraph of the source —
+    deliver the whole scope, and resolve ambiguity without escalating.
+- version: 2
+  date: '2026-09-05'
+  note: >-
+    The second claim moved to PRACTICE-010. A boundary overriding this one had
+    to explain in prose which of the two it argued with, which is the tell that
+    a document is two.
 surface: [conversation, repository]
 grounds: VALUE-001
 summary: >-
-  Ambiguity is resolved by making the call a careful colleague would and saying
-  which call was made — not by quietly shipping the subset that was
-  unambiguous. Scaling the work down is the requester's decision.
+  The deliverable is what was asked for, not the part of it that was
+  convenient. A scope narrowed without saying so is a judgement call presented
+  as a finished task; scaling the work down is the requester's decision.
 ---
 
 # PRACTICE-001: Deliver the whole requested scope; state assumptions rather than narrowing
@@ -18,11 +30,10 @@ Quiet narrowing is the failure this guards against: an ambiguous request, a
 defensible reading, and a deliverable that covers the easy half while
 appearing complete. Nobody is lied to and nobody can tell.
 
-The alternative is not to stop and ask about everything. It is to do the part
-that does not depend on the answer, then either state the assumption or ask the
-question at the point it actually blocks. Blocking outright — nothing delivered
-until a reply arrives — is for the case where proceeding either way would be
-unsafe or would waste the work if wrong.
+How to handle the ambiguity that produces the narrowing is a separate
+practice — [PRACTICE-010](PRACTICE-010.md), split out of this one — and the
+split is the point rather than tidiness: while both lived here, a boundary
+could not override one without the other.
 
 When part of the scope turns out to be blocked, that part is named. Under
 [VALUE-001](../../docs/values.md#value-1), an unmentioned gap is a claim of

--- a/examples/constitution/record/practices.d/PRACTICE-010.md
+++ b/examples/constitution/record/practices.d/PRACTICE-010.md
@@ -1,0 +1,40 @@
+---
+status: Active
+title: 'Resolve ambiguity by making the call a careful colleague would, and say which call you made'
+version: 1
+tags: [scope]
+date: '2026-09-05'
+surface: [conversation, repository]
+grounds: VALUE-001
+summary: >-
+  A request that admits two readings is answered by taking the better one and
+  naming it, not by stopping to ask. Blocking is reserved for the case where
+  proceeding either way would be unsafe or would waste the work if wrong.
+---
+
+# PRACTICE-010: Resolve ambiguity by making the call a careful colleague would, and say which call you made
+
+Split out of [PRACTICE-001](PRACTICE-001.md), which had carried it since this
+record was written. Delivering the whole scope and resolving ambiguity without
+escalating are both true, and a project could want one without the other — so
+they were always two practices, and while they shared a code neither could be
+overridden without the other coming along. See
+[DP-012](https://github.com/dmarx/luria/blob/main/docs/design-principles.md#dp-12).
+
+**Do the part that does not depend on the answer first.** Most ambiguity is
+local: it blocks one decision, not the task. Everything upstream of it can be
+finished while the question is still open, and often the work resolves it.
+
+**Then state the assumption, at the point it starts mattering.** Naming a call
+is what makes it reviewable — a reader who disagrees can say so, and the work
+is already done rather than waiting. An unnamed call is indistinguishable from
+not having noticed the ambiguity.
+
+**Block only when either reading would be unsafe or wasteful.** Stopping with
+nothing delivered is expensive and is sometimes right: an irreversible action
+whose target is unclear, or an approach that would have to be thrown away if
+the guess were wrong. Outside that, asking is a way of returning the work.
+
+The limit is that this licenses proceeding on what is *inferable*, and some
+things are not to be inferred however easy the inference. Those are recorded as
+boundaries, and they override this.

--- a/record/changelog.d/20260905-042244.md
+++ b/record/changelog.d/20260905-042244.md
@@ -41,3 +41,12 @@
   divergence-between-implementations; none invokes [DP-003](docs/design-principles.md#dp-3)'s remedy ladder.
   Merging them would make the advice a disjunction and cost ~130 citation sites
   their precision.
+
+- **[DP-016](docs/design-principles.md#dp-16)** — *an awkward structure is reporting a distinction the model
+  has stopped expressing*. Extracted from [DP-009](docs/design-principles.md#dp-9), where it was the third of
+  three jobs and had **never been cited** — [DP-012](docs/design-principles.md#dp-12)'s own symptom for a
+  document carrying two things, firing on a principle. Promoted on its second
+  substrate: [DP-009](docs/design-principles.md#dp-9) found the reading in the file tree, and a typed
+  `overrides` edge found it again in the citation graph, which is not a tree
+  and which [DP-009](docs/design-principles.md#dp-9) does not cover. [DP-009](docs/design-principles.md#dp-9) goes to v2 and hands the
+  clause over; [DP-012](docs/design-principles.md#dp-12)'s edge test cites it as the general form.

--- a/record/changelog.d/20260905-042244.md
+++ b/record/changelog.d/20260905-042244.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **[DP-012](docs/design-principles.md#dp-12) to v2**, generalized from "one decision, one thing" to **one
+  document, one thing**. Its test was always general; nothing in the wording
+  said so, and a record of practices or claims would not have read itself as
+  covered. Found in one that isn't: a record with no decisions in it at all.
+- The principle gains a second test. The a-priori one — *could these have been
+  decided differently?* — only fires when an author stops to ask. Typed edges
+  ([ADR-060](record/decisions.d/ADR-060.md), [ADR-071](record/decisions.d/ADR-071.md)) supply one that arrives as friction: **an edge
+  whose prose has to name which clause of its target it bears on is reporting
+  that the target is two documents.** It also gains the reason not to fix such
+  an edge with a qualifier — a `when:` beside a checked reference is prose in a
+  data field, which is escalating emphasis one level up, and it is why
+  [#141](https://github.com/dmarx/luria/issues/141) puts `when` expressions among its non-goals.
+- `examples/constitution`: `PRACTICE-001` split, as the principle's worked
+  case. It carried two claims that arrived in the same paragraph of the source
+  — deliver the whole scope, and resolve ambiguity without escalating — and a
+  boundary overriding it had to say in prose which of the two it argued with.
+  The second is now `PRACTICE-010`, and `BOUNDARY-003` names it. The split
+  exposed a second error: `BOUNDARY-003`'s edge to `PRACTICE-005` was dropped
+  rather than repointed, because that practice licenses acting on what is
+  *established* and explicitly not on what is assumed — it never permitted the
+  inference, so there was nothing to override.

--- a/record/changelog.d/20260905-042244.md
+++ b/record/changelog.d/20260905-042244.md
@@ -21,3 +21,23 @@
   rather than repointed, because that practice licenses acting on what is
   *established* and explicitly not on what is assumed — it never permitted the
   inference, so there was nothing to override.
+
+### Added
+
+- **[DP-015](docs/design-principles.md#dp-15)** — *an absence reads exactly like a success*. The premise
+  underneath [DP-001](docs/design-principles.md#dp-1), [DP-003](docs/design-principles.md#dp-3)'s fail-stale rung, [DP-006](docs/design-principles.md#dp-6) and
+  [DP-010](docs/design-principles.md#dp-10), each of which leans on the word *silent* at its load-bearing
+  moment and none of which says why silence is the problem. Re-derived four
+  times without being written down; a fifth time in another project
+  ([SG-DP-022](https://github.com/dmarx/strata-g/blob/main/docs/design-principles.md#dp-22)). All four now cite it, so the unification is an edge rather
+  than an assertion.
+- An audit of the principle set for restatements, whose result is mostly
+  negative and worth recording as such. [DP-002](docs/design-principles.md#dp-2), [DP-003](docs/design-principles.md#dp-3) and [DP-004](docs/design-principles.md#dp-4)
+  look like one principle and are not: [DP-003](docs/design-principles.md#dp-3) is asymmetric (a source and a
+  projection, so *derive it* is available), [DP-004](docs/design-principles.md#dp-4) is symmetric (two peers,
+  so the remedy is consolidation and "choose the failure polarity" is
+  meaningless), and [DP-002](docs/design-principles.md#dp-2)'s failure mode is contention, which occurs with
+  no duplication at all. Every sampled citation of [DP-004](docs/design-principles.md#dp-4) invokes
+  divergence-between-implementations; none invokes [DP-003](docs/design-principles.md#dp-3)'s remedy ladder.
+  Merging them would make the advice a disjunction and cost ~130 citation sites
+  their precision.

--- a/record/principles.d/DP-001.md
+++ b/record/principles.d/DP-001.md
@@ -33,3 +33,9 @@ silence.** An acknowledgement that hides a warning is counted in the report, and
 one that has stopped applying is reported in its own right — otherwise the
 mechanism for saying "this is fine" becomes the mechanism for never hearing
 about it again.
+
+
+The reason a silent no-op is worse than a loud one is [DP-015](design-principles.md#dp-15): nothing
+happening and everything working produce the same observation, so the user's
+next move is to conclude the tool is broken rather than to look for the
+precondition.

--- a/record/principles.d/DP-003.md
+++ b/record/principles.d/DP-003.md
@@ -55,3 +55,9 @@ Three remedies, in order of strength:
    polarity a naive list has by default.
 
 In this package, the decision index is rung 1 and the reference lint is rung 2.
+
+
+Why fail-stale specifically is the unacceptable polarity, rather than merely
+the worst of three: it is the silent one, and [DP-015](design-principles.md#dp-15) is the general form —
+a missed entry that ships as wrong behaviour is indistinguishable from a
+complete list, so nothing about the system reports the gap.

--- a/record/principles.d/DP-006.md
+++ b/record/principles.d/DP-006.md
@@ -37,3 +37,8 @@ benefit it exists for.
 broken, what the guard printed, what it printed after the repair — is the
 difference between a guard someone trusts and a guard someone re-tests from
 scratch because they can't tell whether it works.
+
+
+The general case is [DP-015](design-principles.md#dp-15). An unfired guard emits exactly what a guard
+with nothing to catch emits, so "no findings" is not evidence of a clean tree
+until something has proved the instrument can speak.

--- a/record/principles.d/DP-009.md
+++ b/record/principles.d/DP-009.md
@@ -1,11 +1,25 @@
 ---
 status: Active
 title: 'Structure is read before text — spend affordances deliberately'
-version: 1
+version: 2
 tags:
 - record
 - craft
 date: '2026-08-04'
+history:
+- version: 1
+  date: '2026-08-04'
+  note: >-
+    Three jobs for a deliberate affordance — shaping attention, enabling
+    discovery, diagnosis — plus two disciplines.
+- version: 2
+  date: '2026-09-05'
+  note: >-
+    The diagnosis job moved out to DP-016. It had never been cited in either
+    direction, which is DP-012's own symptom for a document carrying two
+    things, and the reading it describes turned out to hold for the citation
+    graph as well as the tree — a substrate this principle does not cover, and
+    should not have to.
 influenced_by:
 - ADR-012
 - ADR-013
@@ -57,14 +71,10 @@ human or stateless; a rule living only in prose is discoverable by whoever
 happens to read that prose.
 
 **Diagnosis.** Affordance inconsistency is a smell to *read*, not an
-untidiness to tolerate. The same shape carrying opposite rules — one
-`README.md` you must edit and another you must not; a marked container beside
-an unmarked sibling doing the same job — says a rule has moved out of the tree
-and into somebody's memory. A file whose neighbours are the wrong kind — an
-authored `.stub` sitting beside the generated page it feeds — says something
-is filed where it doesn't belong. When an affordance feels wrong, trust the
-feeling and ask which boundary it is straddling; the discomfort is usually a
-distinction the layout has stopped expressing.
+untidiness to tolerate — the same shape carrying opposite rules, a file whose
+neighbours are the wrong kind. That reading turned out not to be about
+affordances at all: the citation graph reports the same class of fault the
+same way, so it is now [DP-016](design-principles.md#dp-16), and this is the tree half of it.
 
 Two disciplines keep the spend honest. **Structural beats documentary**: a
 comment saying "GENERATED — do not edit" is read after landing in the wrong

--- a/record/principles.d/DP-010.md
+++ b/record/principles.d/DP-010.md
@@ -53,3 +53,9 @@ The test, when a new switch appears: *what does the silent position cost,
 and who pays?* If the project pays in missed defects, on-by-default. If
 the author pays in unwanted exposure, off-by-default. A switch where both
 answers feel true is usually two switches wearing one name — split it.
+
+
+Both halves of the rule descend from [DP-015](design-principles.md#dp-15). A default is the position that
+ships when nobody reads the docs, and its failure is silent by construction —
+so the polarity question is really "which direction can announce itself?", and
+the answer sets the default.

--- a/record/principles.d/DP-012.md
+++ b/record/principles.d/DP-012.md
@@ -2,80 +2,150 @@
 status: Active
 formerly:
 - DP-tmpprjho
-title: 'One decision, one thing'
-version: 1
+title: 'One document, one thing'
+version: 2
 tags:
 - craft
 date: '2026-08-16'
 influenced_by:
 - ADR-035
 - ADR-056
+- ADR-060
+- ADR-071
+history:
+- version: 1
+  date: '2026-08-16'
+  note: >-
+    Stated about decisions — "one decision, one thing" — after three splits in
+    one session. Its test was already general, but nothing in the wording said
+    so, and a record of practices or claims would not have read itself as
+    covered.
+- version: 2
+  date: '2026-09-05'
+  note: >-
+    Generalized to any cited document, and given a second test. The a-priori
+    one ("could these have been decided differently?") only fires while an
+    author stops to ask. Typed edges supply a second that arrives as friction:
+    an edge whose prose has to name which clause of its target it bears on is
+    reporting that the target is two documents. Found in a record with no
+    decisions in it at all, and it exposed a second edge that did not hold.
 origin: >-
   Three splits in one session, each made for the same reason and none of them
   by rule: a lint check separated from the vocabulary it reads, two scheme
   audits written as two decisions rather than one, and a status feature split
-  from the report that would have caught the bug motivating it. Each bundle
-  would have been smaller to write and impossible to cite half of.
+  from the report that would have caught the bug motivating it. Then, in a
+  record of practices rather than decisions, an `overrides` edge whose prose had
+  to name which clause of its target it argued with — the same defect, arriving
+  as a relation instead of as a bundle.
 summary: >-
-  A decision records one choice, so that a future reader can cite it, revisit
-  it, or supersede it without dragging an unrelated choice along. Bundling is
-  cheaper to write and permanently more expensive to use: the second half has
-  no code of its own, and superseding the first silently retires reasoning
-  nobody meant to withdraw. The test is whether the two halves could be
-  decided differently — if yes, they are two records.
+  A document records one thing, so a future reader can cite it, revisit it, or
+  supersede it without dragging something unrelated along. Two tests find the
+  bundles: could the halves have been decided differently, and does an edge
+  into this document have to name which part of it applies. The second is the
+  one that fires without being asked.
 ---
 
-# DP-012: One decision, one thing
+# DP-012: One document, one thing
 
-**A decision with two unrelated halves is one nobody can cite half of.**
+**A document with two unrelated halves is one nobody can cite half of.**
 
 Bundling is always cheaper at writing time. One record, one review, one merge —
 and the second half arrives free, because it was going to be written anyway.
 The cost lands later and never goes away.
 
+This was first written about decisions, and it is not about decisions. It holds
+for any document a reader is expected to name: a decision, a principle, a
+practice in a record of practices, a claim in an anthology. The unit is
+whatever gets cited.
+
 ## What it costs
 
-**The second half has no code.** A citation is how this record is used: an
+**The second half has no code.** A citation is how a record is used: an
 argument names its premise, a module names the decision it implements, a lint
-message names the rule it enforces. Half a decision cannot be named, so the
+message names the rule it enforces. Half a document cannot be named, so the
 half that was cheap to add is the half nothing can point at — and a rule
 nothing points at is a rule nobody knows applies to them.
 
-**Superseding withdraws more than intended.** A decision that changes gets
-superseded whole. If two choices share a record, retiring the one that aged out
+**Superseding withdraws more than intended.** A document that changes gets
+superseded whole. If two things share a record, retiring the one that aged out
 silently retires the one that did not, and the record now says nothing about a
 question it had answered. That is the failure the status vocabulary exists to
 prevent, reintroduced at a coarser grain.
 
-**Alternatives stop being reconstructable.** The alternatives section is the
-highest-value part of a decision, and it only works when it is the alternatives
-to *one* choice. Two choices produce a cross-product, or — far more often — an
-alternatives section that silently covers whichever half the author found more
-interesting.
+**Alternatives stop being reconstructable.** For a decision, the alternatives
+section is the highest-value part, and it only works when it is the
+alternatives to *one* choice. Two choices produce a cross-product, or — far
+more often — an alternatives section that silently covers whichever half the
+author found more interesting.
 
-## The test
+## Two tests
 
-**Could the two halves have been decided differently?** If a project could
-adopt one and reject the other, they are two decisions, however naturally they
+**Could the halves have been decided differently?** If a project could adopt
+one and reject the other, they are two documents, however naturally they
 arrived together.
 
-The tempting counterexample is the pair where one half motivated the other.
-That is exactly when to split, and it is worth being concrete: a feature was
-built to fix a defect, and a separate check would actually have *caught* that
-defect. Bundling them would have produced a record whose stated motivation was
-served by only one of its halves — and a reader asking "why does this check
-exist?" would find the answer to a different question.
+That one only fires while writing, and it depends on the author asking. Typed
+edges ([ADR-071](../record/decisions.d/ADR-071.md), [ADR-060](../record/decisions.d/ADR-060.md))
+make a second test possible, and this one fires afterwards, mechanically:
 
-Splitting them also produced something bundling would have hidden. Building the
-second after the first landed revealed an exemption the second needed *because
-of* the first, which is a relationship that only exists between two things.
+**Does an edge into this document have to name which *part* of it applies?**
+If stating what a relation asserts requires pointing at one clause of its
+target, the target is two documents.
+
+Note what this test is not. An `overrides` edge already means *where both bear,
+this one wins* — the overlap is decided by the two documents' contents, so an
+edge is not over-claiming merely by being silent about scope. The tell is
+narrower and shows up in the prose beside the edge: a body that has to explain
+which sentence of the target it is arguing with.
+
+The worked case is a record of an assistant's operating constitution, which
+contains no decisions at all. A boundary — *never infer a person's pronouns
+from their name* — declares that it `overrides` a practice titled *deliver the
+whole requested scope; state assumptions rather than narrowing*. But the
+boundary's body does not argue with delivering the whole scope. It argues with
+a different claim the same document happens to carry: *make the routine
+judgment call yourself rather than escalating it*. The override had to say so
+in prose, because the code it names covers both.
+
+Applying the first test confirms it. *Deliver the whole scope* and *make the
+routine call yourself* could be adopted separately — a project could want one
+and reject the other — so they were always two practices. They had simply
+arrived in the same paragraph of the source. Splitting them let each override
+name what it actually beats, and immediately exposed a second error: one of the
+two edges, checked against the narrower practice, turned out not to hold at all.
+
+That is the useful property. The a-priori test needs an author to stop and ask.
+This one arrives as friction while writing something else, which is when a
+granularity defect is cheapest to notice and most likely to be noticed at all.
+
+## Why not just qualify the edge
+
+Because a condition on a relation is unfalsifiable in exactly the way this
+record's machinery exists to prevent. `overrides` is checked — the code must
+resolve, to a document of the declared scheme, that actually exists. A `when:`
+beside it is prose in a data field: nothing evaluates it, nothing notices when
+it stops being true, and nothing tells a reader whether the qualifier or the
+edge governs their case. It is escalating emphasis in a new costume, one level
+up, and the graph it produces is worse than no graph because it looks checked.
+
+This is why [#141](https://github.com/dmarx/luria/issues/141) puts `when`
+expressions among its non-goals, and why it refuses precedence between
+configuration surfaces — a conflict there is an error rather than something a
+tie-break rule resolves. Same move: **decline the qualifier, and remove what
+made it necessary.**
 
 ## What this is not
 
-Not an argument for small decisions. A decision covering one choice can be long,
+Not an argument for small documents. A document covering one thing can be long,
 and usually should be — the context, the alternatives and the consequences of a
-single choice are most of what makes a record worth keeping.
+single claim are most of what makes a record worth keeping.
 
-Nor is it an argument against related decisions landing together. Ship them in
+Nor is it an argument against related documents landing together. Ship them in
 one contribution if that is honest; give them separate codes so each can be
 cited, revisited, and retired on its own evidence.
+
+And it is not a licence to split on sight. The second test is the discipline
+that keeps it honest: split when something *points* at a part rather than the
+whole, not whenever a document could conceivably be subdivided. A record of
+maximally small documents has the same problem in reverse — every claim needs
+five citations to state, and none of them means anything alone.

--- a/record/principles.d/DP-012.md
+++ b/record/principles.d/DP-012.md
@@ -118,6 +118,12 @@ That is the useful property. The a-priori test needs an author to stop and ask.
 This one arrives as friction while writing something else, which is when a
 granularity defect is cheapest to notice and most likely to be noticed at all.
 
+The general form is [DP-016](design-principles.md#dp-16) — an awkward structure is reporting a
+distinction the model has stopped expressing — and this is its granularity
+case. What that principle adds is the instruction not to resolve the
+awkwardness with a clarifying sentence, which is always available and always
+leaves the model wrong.
+
 ## Why not just qualify the edge
 
 Because a condition on a relation is unfalsifiable in exactly the way this

--- a/record/principles.d/DP-015.md
+++ b/record/principles.d/DP-015.md
@@ -1,0 +1,83 @@
+---
+status: Active
+formerly:
+- DP-tmp6fv3m
+title: 'An absence reads exactly like a success — give the silent case a signal'
+version: 1
+tags:
+- craft
+date: '2026-09-05'
+influenced_by: []
+origin: >-
+  Not one episode but an audit. Four principles in this record — [DP-001](design-principles.md#dp-1),
+  [DP-003](design-principles.md#dp-3), [DP-006](design-principles.md#dp-6), [DP-010](design-principles.md#dp-10) — each lean on the word *silent* at the
+  load-bearing moment, and none of them says why silence is the problem. The
+  premise had been re-derived four times without once being written down.
+summary: >-
+  Nothing happening produces the same observable as everything working. A tool
+  that no-ops, a guard that never fires, a list that misses an entry, a default
+  nobody chose — each is indistinguishable from the healthy case from outside,
+  which is why these survive review. The remedy is always the same shape: make
+  the failing case emit something, or make it impossible.
+---
+
+# DP-015: An absence reads exactly like a success — give the silent case a signal
+
+**Nothing happening and everything working produce the same observation.**
+
+This is the premise underneath a family of rules in this record, and it was
+never stated because each rule looks self-evidently right on its own. Written
+down, it explains why they are the *same* rule wearing four coats, and it
+predicts where the fifth will be.
+
+| the silent thing | what it looks like from outside |
+|---|---|
+| a tool that no-ops on an input it can't handle | a tool that ran and found nothing to do |
+| a guard nobody has ever fired | a guard that has never had cause to fire |
+| a hand list missing one entry | a hand list that is complete |
+| a default nobody chose | a default someone chose |
+| a measurement of nothing | a measurement of no change |
+
+Every row is a real bug shape, and every one passes review, because review looks
+at the output and the output is *correct-looking*. That is the whole mechanism:
+these failures are not hard to fix, they are hard to **see**, and the thing that
+hides them is the same thing in each case — the failing path emits nothing, and
+nothing is what success emits too.
+
+## What follows from it
+
+Each of these already exists here as its own principle, and each stays its own
+principle because the *remedies* differ. What they share is this diagnosis:
+
+- [DP-001](design-principles.md#dp-1) — a refusal that says nothing reads as a broken tool. Remedy: the
+  refusal explains itself.
+- [DP-003](design-principles.md#dp-3) — rung three is the polarity rule, and fail-stale is singled out as
+  the never-acceptable one precisely because it is the silent polarity. Remedy:
+  derive, or guard the property, or choose a polarity that is not silence.
+- [DP-006](design-principles.md#dp-6) — provisioned is not working; an unfired guard reports what a
+  working one reports. Remedy: sabotage it once, and record that you did.
+- [DP-010](design-principles.md#dp-10) — the silent position of a switch is the one that ships, so it
+  should be the position whose failure is visible. Remedy: guards default on,
+  disclosures default off.
+
+Four different remedies for one diagnosis, which is why folding them together
+would lose more than it saved: a merged principle's advice section would be a
+disjunction, and a reader arriving with a concrete problem would have to guess
+which arm applies.
+
+## The corollary
+
+**A test can have this shape too, and then the safety net has the bug.** An
+assertion that cannot fail passes exactly as loudly as one that can, so a suite
+can grow a hole that reports itself green — the same defect one level up, where
+it is least likely to be looked for. The strata-g record states this as its own
+principle, arrived at independently
+([SG-DP-022](https://github.com/dmarx/strata-g/blob/main/docs/design-principles.md#dp-22)): before believing a comparison,
+require a non-zero count of whatever was counted, and perturb something the
+measurement should detect to confirm the reading moves.
+
+That is the general form of the remedy, and it is worth stating as an
+instruction rather than an observation: **for any silent path, either make it
+emit, or make the emitting case the only reachable one.** Counting the deviations
+is the second-best option and is what [DP-010](design-principles.md#dp-10) settles for; it works because a
+count of zero is itself a signal.

--- a/record/principles.d/DP-016.md
+++ b/record/principles.d/DP-016.md
@@ -1,0 +1,93 @@
+---
+status: Active
+formerly:
+- DP-tmpcgay6
+title: 'An awkward structure is reporting a distinction the model has stopped expressing'
+version: 1
+tags:
+- craft
+date: '2026-09-05'
+influenced_by:
+- ADR-060
+- ADR-071
+origin: >-
+  Extracted from [DP-009](design-principles.md#dp-9), where it had been the third of three jobs and had
+  never once been cited — the symptom [DP-012](design-principles.md#dp-12) names. Promoted on its second
+  substrate: [DP-009](design-principles.md#dp-9) found it in the file tree (a `.stub` beside the page it
+  feeds, two `README.md` files with opposite rules), and a typed `overrides`
+  edge found it again in the citation graph, where the edge's prose had to name
+  which clause of its target it argued with.
+summary: >-
+  The structures a record maintains — its tree and its graph — are instruments,
+  not just outputs. When one is awkward to state, the awkwardness is a reading:
+  something the model used to distinguish, or should, is no longer expressible,
+  so it has moved into prose or into somebody's memory. Read the discomfort
+  before absorbing it.
+---
+
+# DP-016: An awkward structure is reporting a distinction the model has stopped expressing
+
+**A structure that is hard to state cleanly is telling you something about the
+model, not about your prose.**
+
+A record maintains two structures, and both are derived from the same
+decisions about what counts as a thing. The **tree** — names, placement,
+neighbours — and the **graph** — the typed edges between documents. Neither is
+merely output. Both are instruments, and both report the same class of fault:
+a distinction that the model has stopped expressing has to live *somewhere*,
+and where it goes is prose, or a comment, or nobody's notes at all.
+
+The tell is friction while writing something else. Not a review finding, not a
+lint failure — the small awkwardness of having to explain, in a sentence,
+something the structure should have carried.
+
+## In the tree
+
+Two files with the same shape and opposite rules — one `README.md` you must
+edit and one you must not. A marked container beside an unmarked sibling doing
+the same job. An authored `.stub` filed among the generated pages it feeds.
+Each is a rule that has moved out of the layout and into somebody's memory,
+and each announces itself as mild untidiness rather than as a defect.
+
+## In the graph
+
+A typed edge is a claim, and it can be awkward in the same way. The instance
+that promoted this: a boundary declared `overrides` against a practice, and its
+body then had to say *which sentence* of that practice it argued with — because
+the target carried two claims under one code. The edge was correct and the
+prose beside it was doing work the graph could not. Splitting the target let
+the edge name what it actually beat, and immediately exposed a second edge that
+did not hold at all ([DP-012](design-principles.md#dp-12) has the worked case).
+
+The same reading applies to an edge nobody can state without a condition, to a
+required reference that had to be filled with the nearest available document,
+and to a relation that needs three sentences of context to be intelligible.
+
+## What to do with the reading
+
+**Read it before absorbing it.** The instinct is to write the clarifying
+sentence and move on; the sentence is cheap and the model stays wrong. Ask
+instead which boundary the awkwardness is straddling — the answer is usually
+a distinction that was real and is no longer represented.
+
+**Then fix the model, not the prose.** Split the document, retype the field,
+move the file, add the vocabulary. The clarifying sentence is what you write
+when you have decided the distinction is not worth representing — which is a
+legitimate answer, and a different one from not having noticed.
+
+**Do not add a qualifier to the relation.** That is the failure mode specific
+to the graph half: a condition beside a checked reference is prose in a data
+field, so nothing evaluates it and nothing notices when it stops holding, while
+the edge keeps looking checked. It is escalating emphasis one rung up — which
+is why [#141](https://github.com/dmarx/luria/issues/141) puts `when` expressions among its non-goals and refuses
+precedence between configuration surfaces.
+
+## The corollary
+
+**This only works if the structures are load-bearing.** A tree nobody navigates
+and a graph nobody reads generate no friction, so they report nothing — the
+instrument has to be used to be an instrument. That is the practical argument
+for typed edges over a general "mentions" relation ([ADR-071](../record/decisions.d/ADR-071.md), [ADR-060](../record/decisions.d/ADR-060.md)),
+and for a layout the lint holds ([ADR-021](../record/decisions.d/ADR-021.md)): the checking is what makes the
+awkwardness surface at authoring time instead of at the reader's expense, a
+year later.


### PR DESCRIPTION
Three commits. The first revises a principle; the other two extract claims the record had been relying on without stating — one found by audit, one by following the first commit's own test.

## `72dee9e` — DP-012 v2: one document, one thing

A revision rather than a new principle, per the DP template:

> *A principle stated about one artifact is a principle nobody applies to the next one, and the version is how the next reader can tell that already happened once.*

`DP-012` said "decision" in every sentence. Its test was always general, and it was found by a record with **no decisions in it at all**.

The addition is a second test, one that fires without being asked:

> **An edge whose prose has to name which clause of its target it bears on is reporting that the target is two documents.**

**I had it wrong first.** My initial claim was *"an override needing a qualifier means its target is too coarse"*, on the grounds the edge over-claims. It doesn't — `overrides` already means *where both bear, this wins*, so the overlap is settled by the documents' contents. The wrong version is not in the principle.

**Worked case, carried out.** `PRACTICE-001` carried two claims from one paragraph of the source; `BOUNDARY-003` overrode it and had to say in prose which one it argued with. Split into `PRACTICE-010` — which exposed a second error: `BOUNDARY-003`'s edge to `PRACTICE-005` doesn't hold at all, since that practice licenses acting on what is *established* and explicitly not on what is assumed. Dropped, not repointed.

## `69e2109` — DP-015, and an audit that mostly says "no"

Asked whether the principle set contains restatements that should collapse.

**No merges warranted, and the near-misses are instructive.** `DP-002`, `DP-003` and `DP-004` all end in "so keep one copy" and are three claims:

| | shape | why the remedy doesn't transfer |
|---|---|---|
| `DP-003` | asymmetric — a source and a projection | *derive it* exists only because one side is authoritative |
| `DP-004` | symmetric — two peers | remedy is consolidation; "choose the failure polarity" isn't a move |
| `DP-002` | contention | happens with one copy and zero drift — a shared file serializes every branch regardless |

Checked, not reasoned: every sampled `DP-004` citation invokes divergence-between-implementations. **None** invokes `DP-003`'s ladder. Merging makes the advice a disjunction and costs ~130 citation sites their precision. Demotion to decisions is the wrong instrument here regardless — these are observations with measured rates and remedy ladders, not point-in-time choices.

**What the audit found instead was the opposite shape.** `DP-001`, `DP-003`'s fail-stale rung, `DP-006` and `DP-010` each lean on the word **silent** at the load-bearing moment, and none says why silence is the problem:

> Nothing happening and everything working produce the same observation.

Re-derived four times here, and a fifth independently in another project (`SG-DP-022`). `DP-015` states it; the four now cite it. They stay four principles — shared diagnosis, four different remedies.

## `4b75cfe` — DP-016: the reading DP-009 half-captured

The edge test did sound like a principle we were partway to capturing. We were. `DP-009`'s third job:

> *Affordance inconsistency is a smell to read, not an untidiness to tolerate … the discomfort is usually a distinction the layout has stopped expressing.*

Same claim, one substrate over. Two reasons to extract rather than leave it:

**That clause has never been cited.** All four substantive `DP-009` citations invoke the first two jobs — attention, discovery, the site exclusion. Zero invoke diagnosis. That is `DP-012`'s first symptom — a half with no code of its own — firing on a principle rather than a decision.

**And the reading generalizes past what `DP-009` covers.** `DP-009` is about an artifact *tree*: names, placement, prominence, neighbours. The citation graph is not a tree, and it reports the same fault the same way. Second substrate, so it is time.

`DP-016` states it for both, and adds what neither had: **read the discomfort before absorbing it, then fix the model rather than writing the clarifying sentence** — which is always available and always leaves the model wrong. Plus the graph-specific failure: never resolve it with a qualifier on the relation, for the reason [#141](https://github.com/dmarx/luria/issues/141) already gives.

The corollary is what justifies the typed-edge work: an instrument nobody uses reports nothing, so the graph has to be load-bearing before its awkwardness can be read ([ADR-060](https://github.com/dmarx/luria/blob/main/record/decisions.d/ADR-060.md), [ADR-071](https://github.com/dmarx/luria/blob/main/record/decisions.d/ADR-071.md)).

`DP-009` goes to v2 and hands the clause over rather than keeping a copy. `DP-012`'s edge test cites `DP-016` as its general form.

## Verification

- `python -m pytest -q` — **724 passed**
- `luria lint` clean on the repo and the example
- `ADR-065` cites `DP-012` by title for its *voice*, which the retitle preserves
- `SG-DP-022` resolves through the existing `[luria.remotes.SG]` table

## Noted, not fixed

- `ADR-045`'s consequences say `examples/**` joins the site's exclusions. [#157](https://github.com/dmarx/luria/pull/157) replaced that with `include_records`, so the clause now describes something untrue — a decision record whose *consequence* aged out. Whether that wants a `status_note:` or nothing at all is a judgement about ADRs-as-history I did not want to make in this PR.
- `DP-007`, `DP-008` and `DP-011` have zero citations. `DP-012` says a rule nothing points at is one nobody knows applies to them.
- Still open from the earlier review: `grounds` → `many = true`, `BOUNDARY-001`'s false `grounds: VALUE-003`, the reverse-direction accountability test, and an issue against [#141](https://github.com/dmarx/luria/issues/141) for multi-scheme reference targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YU5DLRYRFax4BSW69LM6YP