### PR TITLE
Read remote codes whole in reference fields; read directives in frontmatter

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -8,8 +8,9 @@ the reason survives, and the report still counts what was acknowledged.
 
 ## Shape
 
-A directive lives in a comment — HTML comments in markdown, `#`, `//`,
-`/* */` or `--` comments in code — and reads:
+A directive lives in a comment — HTML comments in markdown, `#` comments
+in a record document's YAML frontmatter, `#`, `//`, `/* */` or `--`
+comments in code — and reads:
 
 ```
 <!-- inactive-ok: ADR-012 — the rejection is the point being made -->
@@ -27,6 +28,19 @@ Scope is how much text the directive governs:
 | `name:` | its own line and the next line |
 | `name-block:` | the paragraph (blank-line-delimited block) it sits in, or the following block when the comment stands alone |
 | `name-file:` | the whole file |
+
+A citation site can be a frontmatter field: `superseded_by:` naming a
+document that was itself later retired is reported at that line like any
+sentence. The line-scoped form answers it in place, as a YAML comment
+directly above the field:
+
+```yaml
+# inactive-ok: ADR-012 — the successor was itself later rejected; the chain is deliberate
+superseded_by: ADR-012
+```
+
+Only a whole-line `#` comment inside the frontmatter counts; a `#` inside
+a value is data, and a `#` in the body is a heading.
 
 A directive that no longer matches anything — the document went `Active`
 again, the hand-written URL was fixed, the argument has a typo — is itself

--- a/luria/contract.py
+++ b/luria/contract.py
@@ -235,7 +235,22 @@ _REF_CODE_RE = re.compile(
 
 
 def reference_code(value: str) -> str | None:
-    m = _REF_CODE_RE.search(value.strip())
+    """The code a reference field holds: a scheme code, or a remote one.
+
+    Remotes are read first, through the one reader of their anatomy. A uid
+    remote's tail is opaque — `ARXIV-2110.08058`, `DOI:10.1145/3600006` —
+    and the scheme-shaped pattern, tried alone, read `ARXIV-2110` out of
+    the first and nothing out of the second, so a `superseded_by:` naming a
+    paper failed as "names no scheme or remote" while the same code in
+    prose resolved. Any truthy value was never the contract; a remote code
+    always was (`_any_scheme_violations`)."""
+    text = value.strip()
+    from . import remotes
+    if current().remotes:
+        refs = remotes.references(text)
+        if refs:
+            return refs[0].composed
+    m = _REF_CODE_RE.search(text)
     return m.group(1) if m else None
 
 

--- a/luria/directives.py
+++ b/luria/directives.py
@@ -12,6 +12,7 @@ once:
     <!-- inactive-ok-file: ADR-012 — this page is that history -->
     <!-- unexempt-block: codeblock — the snippet below cites real decisions -->
     // inactive-ok: ADR-028 — proposed, but this is what shipped
+    # inactive-ok: ADR-012 — in a note's frontmatter, above the field it excuses
 
 Shape
 -----
@@ -147,7 +148,8 @@ def comment_fragments(path: Path, text: str) -> list[tuple[int, int, str]]:
                 continue
             out.append((text.count("\n", 0, m.start()) + 1, m.start(),
                         m.group(0)[4:-3]))
-        return out
+        out += _frontmatter_comments(text)
+        return sorted(out)
     if suffix == ".py":
         try:
             offsets = _line_offsets(text)
@@ -162,6 +164,39 @@ def comment_fragments(path: Path, text: str) -> list[tuple[int, int, str]]:
     for n, line in enumerate(text.splitlines(), 1):
         for m in COMMENT_MARKER_RE.finditer(line):
             out.append((n, offsets[n - 1] + m.end(), line[m.end():]))
+    return out
+
+
+# A whole-line YAML comment: `#` first on the line. A `#` inside a value is
+# data (`title: 'Issue #12'`), and a `#` in the body is a heading — the scan
+# never leaves the frontmatter, so neither is ever read as a comment.
+_YAML_COMMENT_RE = re.compile(r"^[ \t]*#(.*)$")
+
+
+def _frontmatter_comments(text: str) -> list[tuple[int, int, str]]:
+    """YAML comments in a markdown file's frontmatter, as comment fragments.
+
+    A reference field is a citation site — `superseded_by:` naming a retired
+    document is reported at its line like any sentence would be — but the
+    only comment the markdown scan read was an HTML one, and frontmatter
+    is YAML. The directive that could answer the finding in place had no
+    place to stand, and the file-scoped one was the only spelling left. The
+    frontmatter has its own comment syntax; this reads it, so a line-scoped
+    directive works there the way it does in a `.py` file:
+
+        # inactive-ok: ADR-012 — the successor was itself later retired
+        superseded_by: ADR-012
+    """
+    from . import doc_refs
+    span = doc_refs._frontmatter_span(text)
+    if span is None:
+        return []
+    out = []
+    offsets = _line_offsets(text)
+    for n, line in enumerate(text[:span[1]].splitlines(), 1):
+        m = _YAML_COMMENT_RE.match(line)
+        if m:
+            out.append((n, offsets[n - 1] + m.start(1), m.group(1)))
     return out
 
 
@@ -201,7 +236,7 @@ def _governed(scope: str, line: int, spans: list[tuple[int, int]],
     if scope == FILE:
         return frozenset(range(1, len(text.splitlines()) + 1))
     if scope == LINE:
-        return frozenset({line, line + 1})
+        return frozenset({line} | _entry_below(text, line))
     own = next((s for s in spans if s[0] <= line <= s[1]), (line, line))
     # A directive standing alone between blank lines has no content block of its
     # own, so the block it means is the one it introduces. This is the reading of
@@ -211,6 +246,26 @@ def _governed(scope: str, line: int, spans: list[tuple[int, int]],
         nxt = next((s for s in spans if s[0] > own[1]), None)
         own = nxt if nxt else own
     return frozenset(range(own[0], own[1] + 1))
+
+
+def _entry_below(text: str, line: int) -> set[int]:
+    """The lines "the next line" means: one, in prose — but in frontmatter a
+    field is an entry, and a `superseded_by:` written as a list carries its
+    code on the line after its key. A comment above the key that reached
+    only the key would excuse nothing, and `luria repair` writes exactly
+    that list shape. So inside the frontmatter the line below extends over
+    the entry's continuation lines: indented ones, and `- ` items."""
+    from . import doc_refs
+    lines = text.splitlines()
+    below = {line + 1}
+    span = doc_refs._frontmatter_span(text)
+    if span is None or line + 1 > text.count("\n", 0, span[1]):
+        return below
+    n = line + 1                                  # 1-based; lines[n] is n+1
+    while n < len(lines) and re.match(r"[ \t]+\S|- ", lines[n]):
+        n += 1
+        below.add(n)
+    return below
 
 
 def _directive_only(text: str, span: tuple[int, int], path: Path) -> bool:

--- a/luria/ref_status.py
+++ b/luria/ref_status.py
@@ -30,9 +30,12 @@ Write the reference scheme's full code, never a bare number, inside a comment:
 
     <!-- inactive-ok: ADR-012 — the decision this ADR replaced -->
     // inactive-ok: ADR-028 — proposed, but this is what shipped
+    # inactive-ok: ADR-012 — a YAML comment, for a site in the frontmatter
 
 `inactive-ok:` is **line-scoped**: it covers its own line and the line below, so
-it can sit above the sentence it excuses. `inactive-ok-file:` is
+it can sit above the sentence it excuses — or above the frontmatter field
+(`superseded_by:` naming a document that was itself later retired) that is the
+site. `inactive-ok-file:` is
 **document-scoped** and covers the whole file:
 
     <!-- inactive-ok-file: ADR-012, ADR-020 — this page is supersession history -->

--- a/record/changelog.d/20260905-165752.md
+++ b/record/changelog.d/20260905-165752.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- A remote code in a reference field is read whole. `superseded_by:` naming
+  a uid-remote document — `ARXIV-2110.08058`, `DOI:10.1145/3600006` — was
+  truncated to a scheme-shaped prefix (or to nothing) before the contract
+  check saw it, and failed as "names no scheme or remote" while the same
+  code in prose resolved. The check always meant to admit a remote code;
+  now its reader does.
+
+### Added
+
+- Directives in a record document's frontmatter. A reference field is a
+  citation site, and the only comment the markdown scan read was an HTML
+  one, so a `superseded_by:` naming a document that was itself later
+  retired could be acknowledged only file-wide. A whole-line `#` comment
+  inside the frontmatter is now a comment the directive parser reads, and
+  its line scope reaches the whole YAML entry below it — key and list items
+  or continuation lines — so `# inactive-ok: ADR-012 — …` directly above
+  the field excuses the field.

--- a/record/decisions.d/ADR-tmpn57wd.md
+++ b/record/decisions.d/ADR-tmpn57wd.md
@@ -1,0 +1,94 @@
+---
+status: Active
+title: "Read a note's frontmatter comments as directive comments"
+version: 1
+tags:
+- mechanism
+date: '2026-09-05'
+summary: >-
+  A reference field is a citation site — `superseded_by:` naming a document
+  that was itself later retired is reported at its line — but the markdown
+  scan read only HTML comments, so the finding could be acknowledged only
+  file-wide. Whole-line `#` comments inside the frontmatter are now directive
+  comments, and in frontmatter a line-scoped directive reaches the whole YAML
+  entry below it. Rejected: exempting reference fields from the retired-citation
+  report, which would hide the one edge the report exists to question.
+---
+
+# ADR-tmpn57wd: Read a note's frontmatter comments as directive comments
+
+## Context
+
+`ref_status` scans every line of a record document for citations, and the
+frontmatter is not exempt: `superseded_by:` naming a document that was itself
+later `Rejected` is reported at the field's line, as a sentence citing it
+would be. That is right — a Superseded→Rejected chain is exactly the kind of
+history a reader should be able to find deliberately kept (a downstream
+record's DP says so in as many words) — and it is a judgement call, so the
+answer is a directive at the site.
+
+The directive parser read comments per file type: HTML comments in markdown,
+`#`/`//`/`/* */`/`--` in code. A record document is markdown whose
+frontmatter is YAML, and YAML's comment is `#`. So the one spelling that
+could answer a frontmatter finding *in place* was never read, and the first
+downstream project to hit the case wrote a file-scoped `inactive-ok-file:`
+for a one-line finding — broader than the judgement it recorded.
+
+A second, smaller fact shaped the fix. `luria repair` writes `superseded_by:`
+as a list, which puts the code on the line *after* the key. A line-scoped
+directive above the key, under the rule "this line and the next", covered
+the key and missed the citation; firing the new reader on the real case
+produced a stale-directive report where a warning had been.
+
+## Decision
+
+1. **Whole-line `#` comments inside a markdown file's frontmatter are
+   comment fragments**, read by `directives.find` like any other comment.
+   Only the frontmatter span is scanned: a `#` in the body is a heading, and
+   a `#` inside a YAML value is data; neither is ever a comment.
+2. **In frontmatter, "the line below" is the entry below.** A line-scoped
+   directive there governs its own line, the next line, and that entry's
+   continuation lines — indented lines and `- ` items. In prose the scope
+   is unchanged: its own line and one more.
+
+Nothing about the vocabulary or the other scopes changes. `-block` and
+`-file` mean what they meant; the stale-directive report still fires on a
+directive that reaches no citation.
+
+## Alternatives considered
+
+- **Exempt reference fields from the retired-citation report.** A
+  `superseded_by:` naming a retired document is the field doing its job,
+  so why report it? Because the report's question — *did you mean to point
+  at something retired?* — applies to a successor that was itself retired
+  with more force than to a sentence. A chain nobody noticed is the report's
+  reason to exist; a chain somebody kept is one directive. Exempting the
+  field hides the first to save writing the second.
+- **Keep line scope literal and document "put the comment above the list
+  item".** YAML allows a comment between the key and its first item, so it
+  works. It puts the directive inside the entry it excuses, and it fails
+  silently the first time a repair rewrites the block above it. The entry
+  is the unit a reader sees; the scope should be too.
+- **A new scope suffix, `-entry:`.** Explicit, and one more thing to
+  remember for a distinction that only exists in frontmatter. The scopes
+  are meant to be uniform across directives (see `directives.py`); making
+  "line" mean the natural unit of the syntax it sits in keeps them so.
+- **Status quo.** `inactive-ok-file:` remains the only spelling that
+  reaches a frontmatter site. It works, and it acknowledges every citation
+  in the file rather than the one being judged.
+
+## Consequences
+
+- A directive above a frontmatter field now excuses the field; the
+  downstream record that prompted this can replace its file-scoped
+  acknowledgement with a line-scoped one once it takes this release.
+- `set_status` rewrites the status block by regex and knows nothing of
+  comments. A directive placed between `status:` and `superseded_by:`
+  survives a rewrite but may end up below the field it was written above,
+  at which point the stale-directive report says so. That is the existing
+  guarantee, not a new one.
+- Tests pin: a frontmatter directive is found with entry scope; a
+  directive-shaped heading in the body does not fire; a file with no
+  frontmatter reads no `#` comments; prose keeps one-line scope; and,
+  end-to-end, a `superseded_by:` naming a Rejected document is excused by
+  the comment above it and reported without it.

--- a/record/devlog.d/2026/09/05/165753.md
+++ b/record/devlog.d/2026/09/05/165753.md
@@ -1,0 +1,54 @@
+---
+title: 'A remote code in superseded_by, and a directive with nowhere to stand'
+created: '2026-09-05T16:57:53'
+tags: [mechanism]
+---
+
+**Two findings from the first downstream record to file a paper superseded
+by a paper.** The anthology-of-the-sota record upgraded from 0.4.2 to 0.8.0
+in one step, ran `luria repair`, and met the new `superseded_by:` check on a
+note whose successors were another note (itself later Rejected) and an
+arXiv paper not in the corpus. Both halves of that surfaced a gap.
+
+**The remote code was truncated before the check could see it.**
+`superseded_by: ARXIV-2110.08058` failed as `ARXIV-2110 names no scheme or
+remote`. The check in `_any_scheme_violations` says a value may be "a code
+that resolves in the scheme it names, or a remote code", and calls
+`is_remote` — but on the output of `reference_code`, whose one regex is
+scheme-shaped (`PREFIX-NNN`). It read `ARXIV-2110` out of the arXiv code
+and nothing at all out of a `:`-delimited DOI, so `is_remote` never saw a
+remote. The wrong theory, held for a minute: that the DOI remote's uid
+pattern was at fault. `remotes.parse_code` accepted both strings whole; the
+field reader was the only place they broke. The fix reads remotes first,
+through `remotes.references` — the one reader of a composed code's anatomy
+— and falls back to the scheme pattern. Fired on the real note: the two-item
+list passes, the body's `ARXIV-` link still resolves, and `FAKE-2110.08058`
+is still a finding.
+
+**The directive that could answer the second finding had no place to
+stand.** `ref_status` scans every line of a note, frontmatter included, so
+the Superseded→Rejected chain was reported at `LIT-031.md:3` — the field.
+But `comment_fragments` for markdown read HTML comments only, and
+frontmatter is YAML. A `# inactive-ok:` above the field was invisible; the
+downstream record ended up with a file-scoped directive for a one-line
+finding. Reading whole-line `#` comments inside the frontmatter span fixes
+the spelling, and the guard against reading a heading as a comment is that
+the scan never leaves the frontmatter.
+
+**Then the real case caught the second half.** With the comment above
+`superseded_by:` the warning disappeared and the *stale-directive* report
+fired instead: `nothing in scope cites LIT-041`. The list form puts the
+code on the line after the key, and line scope is "this line and the
+next". The directive covered the key; the citation sat one line further.
+So in frontmatter "the line below" now means the entry below — the key and
+its indented or `- ` continuation lines — because `luria repair` writes
+exactly that list shape and a directive that reaches only the key excuses
+nothing. Prose keeps the one-line reading; the test pins both.
+
+**A non-finding, recorded because I nearly filed it as one.** In that
+intermediate state I read the lint as printing the stale-directive line but
+*not* the retired-citation warning, and started to suspect how `lint`
+composes the two reports. A full `ref_status.scan` showed the site
+unexcused, `flagged` carrying it, and `summary_lines` printing it — the
+warning had been there all along, above the four lines of output I had
+kept. Check the whole report before theorising about the machinery.

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -433,3 +433,56 @@ def test_describe_lists_the_group_with_its_provenance(tmp_path, monkeypatch):
     line, = contract.describe(contract.for_scheme(config.current().schemes["LIT"]))
     assert line.startswith("`source` — at least one of `arxiv`, `doi`, `url`")
     assert "schemes.LIT.field_groups.source" in line
+
+
+# --- remote codes in reference fields --------------------------------------
+
+REMOTES = '''
+[luria.remotes.ARXIV]
+uid = "(\\\\d{4})[.:](\\\\d{4,5})"
+url = "https://arxiv.org/abs/{1}.{2}"
+
+[luria.remotes.DOI]
+uid = "10\\\\.\\\\d{4,9}/[^\\\\s\\\\]\\\\)>,;]+"
+delim = ":"
+url = "https://doi.org/{uid}"
+'''
+
+
+def test_a_remote_code_is_read_whole(tmp_path, monkeypatch):
+    """A uid remote's tail is opaque, so the scheme-shaped pattern read
+    `ARXIV-2110` out of the first and nothing out of the second."""
+    project(tmp_path, monkeypatch, REMOTES)
+    assert contract.reference_code("ARXIV-2110.08058") == "ARXIV-2110.08058"
+    assert contract.reference_code("DOI:10.1145/3600006.3613165") == "DOI:10.1145/3600006.3613165"
+    assert contract.reference_code(
+        "[ARXIV-2110.08058](https://arxiv.org/abs/2110.08058)") == "ARXIV-2110.08058"
+    assert contract.reference_code("LIT-041") == "LIT-041"
+    assert contract.reference_code("[LIT-041](LIT-041.md)") == "LIT-041"
+
+
+def test_a_scheme_code_is_still_read_without_any_remote(tmp_path, monkeypatch):
+    project(tmp_path, monkeypatch)
+    assert contract.reference_code("LIT-041") == "LIT-041"
+    assert contract.reference_code("not a code") is None
+
+
+def test_superseded_by_may_name_remote_documents(tmp_path, monkeypatch):
+    """The docstring always said "or a remote code"; the reader truncated it
+    before the check could see it, so a paper superseded by a paper failed
+    as "names no scheme or remote"."""
+    root = project(tmp_path, monkeypatch, REMOTES)
+    doc(root, "record/literature.d/LIT-001.md", code="LIT-001", tags=["record"],
+        extra="superseded_by:\n- ARXIV-2110.08058\n- DOI:10.1145/3600006.3613165")
+    errors: list[str] = []
+    lint.check_contracts(errors)
+    assert not [e for e in errors if "superseded_by" in e], errors
+
+
+def test_an_undeclared_prefix_in_superseded_by_is_still_a_finding(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, REMOTES)
+    doc(root, "record/literature.d/LIT-001.md", code="LIT-001", tags=["record"],
+        extra="superseded_by: FAKE-2110.08058")
+    errors: list[str] = []
+    lint.check_contracts(errors)
+    assert any("superseded_by" in e and "names no scheme or remote" in e for e in errors), errors

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -166,3 +166,72 @@ def test_shaped_spans_match_examples_too():
     text = "```\n<!-- inactive-ok: RFC-012 -->\n```\n"
     assert directives.shaped_spans(text, {"inactive-ok"})
     assert directives.shaped_spans(text, {"unexempt"}) == []
+
+
+# ── Frontmatter ──────────────────────────────────────────────────────────
+
+
+def test_a_yaml_comment_in_frontmatter_is_a_comment():
+    """A reference field is a citation site, and the frontmatter is YAML —
+    so the comment that answers a finding there is a `#` one, line-scoped
+    like everywhere else: its own line and the field below it."""
+    text = ("---\n"
+            "status: Superseded\n"
+            "# inactive-ok: RFC-012 — the successor was itself later retired\n"
+            "superseded_by: RFC-012\n"
+            "title: 'Issue #12 is data, not a comment'\n"
+            "---\n"
+            "\n"
+            "# RFC-013: A heading is not a comment either\n"
+            "\n"
+            "Body per RFC-012.\n")
+    d, = find(text)
+    assert d.name == "inactive-ok" and d.args == ("RFC-012",)
+    assert d.reason == "the successor was itself later retired"
+    assert d.line == 3 and d.lines == frozenset({3, 4})
+
+
+def test_a_directive_shaped_heading_in_the_body_does_not_fire():
+    """`#` opens a heading outside the frontmatter. The scan never leaves the
+    frontmatter, so prose *about* the syntax stays prose."""
+    assert find("---\ntitle: t\n---\n\n# inactive-ok: RFC-012 — a heading\n") == []
+
+
+def test_no_frontmatter_means_no_yaml_comments():
+    assert find("# inactive-ok: RFC-012 — a heading in a file with no frontmatter\n") == []
+
+
+def test_frontmatter_and_html_comments_are_both_read_in_order():
+    text = ("---\n"
+            "# inactive-ok: RFC-012 — in the frontmatter\n"
+            "status: Active\n"
+            "---\n"
+            "\n"
+            "<!-- inactive-ok: RFC-020 — in the body -->\n"
+            "RFC-020 here.\n")
+    assert [(d.line, d.args) for d in find(text)] == [(2, ("RFC-012",)), (6, ("RFC-020",))]
+
+
+def test_in_frontmatter_the_line_below_is_the_whole_entry():
+    """`luria repair` writes `superseded_by:` as a list, so the code sits on
+    the line after the key; a directive above the key has to reach it."""
+    text = ("---\n"
+            "status: Superseded\n"
+            "# inactive-ok: RFC-012 — the chain is deliberate\n"
+            "superseded_by:\n"
+            "- RFC-012\n"
+            "- RFC-020\n"
+            "status_note: >-\n"
+            "  a folded note\n"
+            "  on two lines\n"
+            "title: t\n"
+            "---\n"
+            "\n"
+            "RFC-012 in the body is not reached.\n")
+    d, = find(text)
+    assert d.lines == frozenset({3, 4, 5, 6})
+
+
+def test_in_prose_the_line_below_is_still_one_line():
+    d, = find("<!-- inactive-ok: RFC-012 — x -->\n- RFC-012\n- RFC-020\n")
+    assert d.lines == frozenset({1, 2})

--- a/tests/test_ref_status.py
+++ b/tests/test_ref_status.py
@@ -314,3 +314,40 @@ def test_a_directive_naming_a_code_is_not_citing_it(project):
     itself and can never go stale."""
     docs, result = scan(project, "<!-- unresolved-ok: ADR-777 — why -->\n")
     assert result.dangling == {}
+
+
+# ── Frontmatter sites ────────────────────────────────────────────────────
+
+
+def test_a_frontmatter_field_is_a_site_that_a_yaml_comment_can_excuse(project):
+    """`superseded_by:` naming a document that was itself later retired is
+    reported at its line like a sentence would be. Before the frontmatter's
+    own comments were read, the only spelling that reached it was the
+    file-scoped one — broader than the finding."""
+    decision(project, 12, "Rejected", "The successor, itself retired")
+    scheme = current().schemes["ADR"]
+    path = scheme.dir / "ADR-013.md"
+    path.write_text(
+        "---\n"
+        "status: Superseded\n"
+        "# inactive-ok: ADR-012 — the successor was itself later rejected; the chain is deliberate\n"
+        "superseded_by: ADR-012\n"
+        "title: 'The replaced one'\n"
+        "tags:\n- record\n"
+        "date: '2026-01-01'\n"
+        "---\n\n# ADR-013: The replaced one\n\nBody.\n")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([path], docs)
+    site, = result.cited["ADR-012"]
+    assert site.line == 4 and site.excused_by is not None
+    assert [d.code for d, _, _ in ref_status.flagged(result, docs)] == []
+
+
+def test_a_frontmatter_site_without_a_comment_is_still_reported(project):
+    decision(project, 12, "Rejected", "The successor, itself retired")
+    path = decision(project, 13, "Superseded", "The replaced one", superseded_by="ADR-012")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([path], docs)
+    site, = result.cited["ADR-012"]
+    assert site.excused_by is None
+    assert [d.code for d, _, _ in ref_status.flagged(result, docs)] == ["ADR-012"]


### PR DESCRIPTION
## Summary

Two gaps met by the first downstream record (dmarx/anthology-of-the-sota#15) to file a paper superseded by a paper, after its 0.4.2 → 0.8.0 upgrade.

### Fix: a remote code in a reference field is read whole

`contract.reference_code` had one regex, scheme-shaped (`PREFIX-NNN`). A uid remote's tail is opaque, so `superseded_by: ARXIV-2110.08058` was read as `ARXIV-2110` and a `:`-delimited `DOI:10.1145/…` as nothing at all — before `_any_scheme_violations` could reach the `is_remote` branch its docstring always promised ("or a remote code"). The same code in prose resolved fine, which is what made it look like a config problem downstream.

Remotes are now read first, through `remotes.references` (the one reader of a composed code's anatomy), with the scheme pattern as the fallback. Linked forms work for both. `FAKE-2110.08058` is still a finding.

### Add: directives in a record document's frontmatter

`ref_status` scans every line, frontmatter included, so `superseded_by:` naming a document that was itself later Rejected is reported at the field's line. But `directives.comment_fragments` read only HTML comments in markdown, and frontmatter is YAML — the directive that could answer the finding in place had nowhere to stand, and the downstream record ended up with an `inactive-ok-file:` for a one-line finding.

- Whole-line `#` comments inside the frontmatter span are now comment fragments. The scan never leaves the frontmatter, so a `#` heading in the body and a `#` inside a YAML value are never comments.
- In frontmatter, a line-scoped directive's "line below" is the entry below: the key plus its indented or `- ` continuation lines. `luria repair` writes `superseded_by:` as a list, so the code sits on the line after the key; firing the first cut on the real case produced a stale-directive report where a warning had been. Prose keeps the one-line reading.

Alternatives (exempting reference fields from the report; a literal line scope with "put the comment above the list item"; an `-entry:` suffix) are in the ADR.

## Record

- Changelog fragment, devlog entry (including a non-finding I nearly filed as one), and `ADR-tmpn57wd` for the frontmatter decision.
- `docs/directives.md` and the `directives` / `ref_status` module docstrings name the new form.

## Verification

- `python -m pytest tests -q`: 739 passed (727 on main; 12 new).
- `luria lint`: clean. It does report one pre-existing legacy spelling on `main` (`ADR-075.md:90`, `ADR-tmpxmnac → ADR-071`) that `luria link --fix` did not upgrade; not touched here.
- Fired on the real case in the downstream record with this branch installed: the two-item `superseded_by:` (a LIT code and an arXiv code) passes the contract check; `# inactive-ok:` above the field excuses it; removing the comment brings the warning back.
- No views regenerated on the branch, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BiTAFKRdSecSkJFR44QuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019BiTAFKRdSecSkJFR44QuZ)_