### PR TITLE
A prose field still saying what the form says is the form's text, not the document's

### DIFF
--- a/luria/lint.py
+++ b/luria/lint.py
@@ -139,6 +139,25 @@ def check_frontmatter(errors: list[str]) -> None:
 
 
 
+def check_form_text(errors: list[str]) -> None:
+    """A prose field still saying what the scheme's `_template.md` says is
+    the form's text, not the document's — a summary that reads "one-paragraph
+    description of the decision" in the index. Write it, or drop the key."""
+    cfg = current()
+    for scheme in cfg.schemes.values():
+        for path in [*scheme.documents().values(),
+                     *scheme.temp_documents().values()]:
+            meta, _ = builder.parse_frontmatter(path.read_text(encoding="utf-8"))
+            for key in templates.form_text(scheme, meta or {}):
+                fallback = (" — the index falls back to the title"
+                            if key == "summary" else "")
+                errors.append(
+                    f"{cfg.rel(path)}: `{key}:` still says what "
+                    f"{cfg.rel(scheme.dir / templates.TEMPLATE_NAME)} says — "
+                    f"the form's words, not this document's; write it, or "
+                    f"drop the key{fallback}")
+
+
 def check_title(errors: list[str], rel: str, meta: dict, body: str) -> None:
     """`title:` is the source of truth, and the body's H1 repeats it.
 
@@ -608,6 +627,7 @@ def run() -> None:
     errors: list[str] = []
     check_docs_index(errors)
     check_frontmatter(errors)
+    check_form_text(errors)
     check_status_vocabulary(errors)
     check_contracts(errors)
     check_view_dirs(errors)

--- a/luria/new.py
+++ b/luria/new.py
@@ -99,6 +99,13 @@ def _sub_line(text: str, field: str, value, many: bool = False) -> str:
     return _append_field(text, replacement)
 
 
+def _drop_field(text: str, field: str) -> str:
+    """Remove a frontmatter field and its continuation lines — the block
+    `_sub_line` would have replaced — leaving the comment above it."""
+    pattern = re.compile(rf"^{field}:.*(?:\n(?:  |- ).*)*\n", re.MULTILINE)
+    return pattern.sub("", text, count=1)
+
+
 def _append_field(text: str, block: str) -> str:
     """Add a field at the end of the frontmatter, where a reader looks for
     what the form did not prompt for."""
@@ -181,6 +188,15 @@ def new_scheme_doc(scheme, fields: dict[str, str]) -> Path:
             text = text.replace(f"# {code}: {old_title}", f"# {code}: {title}")
     for field, value in fields.items():
         text = _sub_line(text, field, value, many=field in plural)
+    # A prose field the caller did not fill still carries the form's own
+    # words — "one-paragraph description of the decision" — which the lint
+    # reports as the form's text, not the document's. Drop the value and keep
+    # the comment above it, which is the instruction; an absent summary falls
+    # back to the title until the author writes one.
+    from .doc_refs import PROSE_KEYS
+    for field in PROSE_KEYS:
+        if field not in fields:
+            text = _drop_field(text, field)
 
     path = scheme.dir / f"{stem}.md"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/luria/templates.py
+++ b/luria/templates.py
@@ -48,6 +48,7 @@ import re
 from .adr_index import parse_frontmatter
 from .config import current
 from .contract import _cite, for_scheme
+from .doc_refs import PROSE_KEYS
 
 TEMPLATE_NAME = "_template.md"
 
@@ -102,3 +103,32 @@ def rows() -> list[str]:
                     f"copied from this form starts with a list where a code "
                     f"belongs {cite}")
     return sorted(found)
+
+
+def _squash(value) -> str:
+    return " ".join(str(value or "").split())
+
+
+def placeholders(scheme) -> dict[str, str]:
+    """What the scheme's form says in each prose field, whitespace squashed —
+    the words a filed document must not still be saying. Empty when the
+    scheme has no form."""
+    path = scheme.dir / TEMPLATE_NAME
+    if not path.exists():
+        return {}
+    meta, _ = parse_frontmatter(path.read_text(encoding="utf-8"))
+    return {k: _squash(meta[k]) for k in PROSE_KEYS
+            if meta and _squash(meta.get(k))}
+
+
+def form_text(scheme, meta: dict) -> list[str]:
+    """The prose keys of one document that still carry the form's own
+    words. A template's `summary:` describes what a summary is for, so a
+    document repeating it verbatim has not written one; the decision index
+    then prints the instruction where the decision should be — which is how
+    two Proposed decisions reached the published site saying "One-paragraph
+    description of the decision". Always wrong, and the mechanical fix is to
+    drop the key: an absent summary falls back to the title."""
+    said = placeholders(scheme)
+    return [k for k in PROSE_KEYS
+            if k in said and _squash(meta.get(k)) == said[k]]

--- a/record/changelog.d/20260906-210813.md
+++ b/record/changelog.d/20260906-210813.md
@@ -1,0 +1,12 @@
+### Added
+
+- `luria lint` reports a prose field (`summary:`, `origin:`, `status_note:`)
+  that still says what the scheme's `_template.md` says — the form's words,
+  not the document's. Write it, or drop the key; an absent summary falls
+  back to the title.
+
+### Changed
+
+- `luria new` no longer copies the form's placeholder into a prose field
+  the caller did not fill (`summary:`, `origin:`, `status_note:`); the key
+  is dropped and the comment above it stays as the instruction.

--- a/record/decisions.d/ADR-084.md
+++ b/record/decisions.d/ADR-084.md
@@ -58,8 +58,20 @@ issue: '#000'
 # frontmatter is data and stays plain. (`origin:` on a principle is
 # prose for the same reason — the generator renders it.)
 summary: >-
-  One-paragraph description of the decision, the cost that motivated it, and the
-  alternatives that lost. Written to be read in a table row.
+  A reference field may declare its `converse`, the field holding the same
+  relation read backwards; a pair is mutual, same-scheme and plural on both
+  sides, and a symmetric relation is its own converse. The declaration is
+  what licenses `luria link --fix` to complete the missing side, and it
+  completes by what changed since HEAD rather than by which side is empty,
+  so a deleted relation removes its back-reference instead of returning. A
+  document naming another in both directions, or two each claiming to come
+  first, is a contradiction reported and never written, and a repair that
+  would break the document it lands in is not applied. The check leaves
+  `broken-chains` for its own class, `one-sided-relations`, because a pair
+  is one-sided whether or not a chain walks it. Rejected: deleting the
+  symmetry check, completing only symmetric relations (what [#178](https://github.com/dmarx/luria/issues/178) shipped),
+  inferring the converse without a declaration, declaring it on the chain,
+  a separate `--prune` flag, and making one side authoritative.
 ---
 
 # ADR-084: A relation declares its converse; symmetry is the self-converse case

--- a/record/decisions.d/ADR-085.md
+++ b/record/decisions.d/ADR-085.md
@@ -58,8 +58,20 @@ issue: '#000'
 # frontmatter is data and stays plain. (`origin:` on a principle is
 # prose for the same reason — the generator renders it.)
 summary: >-
-  One-paragraph description of the decision, the cost that motivated it, and the
-  alternatives that lost. Written to be read in a table row.
+  Where Luria's code states a rule about how a record works, the rule moves
+  to the project's configuration and the code keeps only the role it fills.
+  `status:` is declared like any vocabulary-backed field
+  (`[luria.schemes.ADR.fields.status] vocabulary = "statuses"`),
+  `statuses.yaml` becomes an ordinary vocabulary file, and the bespoke
+  reader, the bespoke validation and the second spelling of the five words
+  are deleted. A missing declaration is an error naming its remedy, not a
+  silent fallback: a default inherited from code cannot be read, so nobody
+  learns it is theirs to change. `luria upgrade statuses` writes the
+  declaration into an existing project and carries a marker so it is
+  removed once the version boundary is crossed. `tags:` stays out of scope
+  until an open vocabulary and groups over a subset of values are each
+  decided. Rejected: leaving `status` built in, defaulting the declaration
+  instead of requiring it, and migrating `tags` at the same time.
 ---
 
 # ADR-085: Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote

--- a/record/devlog.d/2026/09/06/210813.md
+++ b/record/devlog.d/2026/09/06/210813.md
@@ -1,0 +1,36 @@
+---
+title: "The form's own words reached the published index"
+created: '2026-09-06T21:08:13'
+tags: []
+---
+
+**Two Proposed decisions were on the published site with the template's
+instruction where their summary should be.** "One-paragraph description of
+the decision, the cost that motivated it, and the alternatives that lost."
+The index rendered it in the row, the site rendered it under the title,
+and nothing objected: the summary key was present and non-empty, which is
+all any check asked.
+
+**The guard reads the form.** A prose field whose value is what the
+scheme's `_template.md` says in that field is the form's text, not the
+document's. `luria lint` reports it as a violation, not a warning: there
+is no reading under which a document means to say what its blank form
+says, and the mechanical fix is to drop the key, since an absent summary
+falls back to the title. Compared with whitespace squashed, so a reflowed
+placeholder is still the placeholder; a scheme with no form has nothing to
+compare against. Fired once on the real case before the fix: it named the
+two files and nothing else.
+
+**Then it fired a second time, on the scaffolder.** `luria init`'s test
+scaffolds a first document with `luria new` and lints it, and the new
+check refused it: `luria new` copies the form whole, placeholder summary
+included, so every document filed without `--summary` started out saying
+what the form says. A guard that catches the same thing twice is a bug
+report about the workflow, and the workflow was the bug: the scaffolder
+now drops a prose field the caller did not fill and keeps the comment
+above it, which is the instruction. An absent summary falls back to the
+title until the author writes one.
+
+**The two summaries are written**, condensed from the decisions' own bodies
+and alternatives, and are the first thing to read if the condensation lost
+something the author meant.

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -396,3 +396,54 @@ def test_a_project_on_the_workflow_token_fails_on_it(project, capsys):
 def test_a_numbered_code_in_a_workflow_is_fine(project):
     workflow_project(project, "# The shape (ADR-029).\nname: Docs\n")
     assert lint.workflow_temp_code_lines() == []
+
+
+# ── The form's words in a document ───────────────────────────────────────
+
+
+def formed_project(project, template_summary: str) -> None:
+    from luria import config
+    (project / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.schemes.ADR]\ndir = "record/decisions.d"\n'
+        'output = "docs/decisions"\n')
+    config.reset()
+    d = project / "record" / "decisions.d"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "_template.md").write_text(
+        f"---\nstatus: Proposed\ntitle: 'Title'\ntags:\n- record\n"
+        f"summary: >-\n  {template_summary}\n---\n\n# ADR-000: Title\n")
+
+
+def form_text_errors() -> list[str]:
+    found: list[str] = []
+    lint.check_form_text(found)
+    return found
+
+
+def test_a_summary_still_saying_what_the_form_says_is_reported(project):
+    """Two Proposed decisions reached the published index saying
+    "One-paragraph description of the decision" — the template's own
+    instruction, filed as if it were the summary."""
+    formed_project(project, "One-paragraph description of the decision.")
+    from tests import _scheme
+    _scheme.decision(project, 1, "Proposed",
+                     summary="One-paragraph  description of the decision.")
+    errors = form_text_errors()
+    assert len(errors) == 1
+    assert "ADR-001.md" in errors[0] and "`summary:`" in errors[0]
+    assert "falls back to the title" in errors[0]
+
+
+def test_a_summary_of_the_document_s_own_passes(project):
+    formed_project(project, "One-paragraph description of the decision.")
+    from tests import _scheme
+    _scheme.decision(project, 1, "Active", summary="We chose the thing.")
+    _scheme.decision(project, 2, "Active")
+    assert form_text_errors() == []
+
+
+def test_a_scheme_with_no_form_has_nothing_to_compare(project):
+    from tests import _scheme
+    _scheme.decision(project, 1, "Active", summary="Whatever the form said.")
+    assert form_text_errors() == []

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -193,3 +193,31 @@ def test_a_declared_flag_reaches_the_document_through_run(project, capsys):
     new_mod.run(kind="sota", source="LIT-134,LIT-140")
     written = (current().root / capsys.readouterr().out.strip()).read_text()
     assert "source:\n- LIT-134\n- LIT-140\n" in written
+
+
+
+def test_an_unfilled_summary_is_dropped_not_copied_from_the_form(project):
+    """The form's `summary:` explains what a summary is for. A document
+    scaffolded without one used to carry that explanation as its summary,
+    and two Proposed decisions reached the published index saying it. The
+    key goes; the comment above it stays as the instruction."""
+    from luria import config, new
+    (project / "luria.toml").write_text(
+        '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
+        '[luria.schemes.ADR]\ndir = "record/decisions.d"\n'
+        'output = "docs/decisions"\n')
+    config.reset()
+    d = project / "record" / "decisions.d"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "_template.md").write_text(
+        "---\nstatus: Proposed\ntitle: 'Title'\ntags:\n- record\n"
+        "date: '2026-01-01'\n# What the index shows.\nsummary: >-\n"
+        "  One-paragraph description of the decision.\n---\n\n"
+        "# ADR-NNN: Title\n")
+    scheme = config.current().schemes["ADR"]
+    bare = new.new_scheme_doc(scheme, {"title": "Bare"}).read_text()
+    assert "summary:" not in bare
+    assert "# What the index shows." in bare, "the instruction survives"
+    filled = new.new_scheme_doc(scheme, {"title": "Filled",
+                                         "summary": "We chose it."}).read_text()
+    assert "summary: >-\n  We chose it." in filled


### PR DESCRIPTION
Found while checking where the review observations on #172 landed (both are in ADR-082 already, so nothing to refile). ADR-084 and ADR-085 are on `main` and on the published site with the template's own instruction as their summary — "One-paragraph description of the decision, the cost that motivated it, and the alternatives that lost." The index prints it in the row; nothing objected, because the key was present and non-empty, which is all any check asked.

## The guard

`luria lint` reports a prose field (`summary:`, `origin:`, `status_note:`) whose value is what the scheme's `_template.md` says in that field — whitespace squashed, so a reflowed placeholder is still the placeholder; a scheme with no form has nothing to compare against. A violation, not a warning: there is no reading under which a document means to say what its blank form says, and the mechanical fix is to drop the key, since an absent summary falls back to the title. The finding says both.

Fired once on the real case before the fix: it named the two files and nothing else.

## It fired a second time, on the scaffolder

`luria init`'s test scaffolds a first document with `luria new` and lints it, and the new check refused it. `luria new` copies the form whole, placeholder included, so every document filed without `--summary` started out saying what the form says — the upstream hazard, per the working agreement about a guard that catches the same thing twice. The scaffolder now drops a prose field the caller did not fill and keeps the comment above it, which is the instruction. Test added.

## The two summaries

Written for ADR-084 and ADR-085, condensed from each decision's own body and alternatives. They are Proposed decisions from another session, so these are the first thing to read if the condensation lost something you meant.

## Checks

- `python -m pytest tests -q`: 892 passed.
- `luria lint` on this branch, no view written: clean.
- Devlog entry and changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCmBUY14BKhLGbHNKLuP6r)_