### PR TITLE
Say when the statuses upgrade goes, not that it could have gone already

### DIFF
--- a/luria/lint.py
+++ b/luria/lint.py
@@ -395,9 +395,8 @@ def spent_upgrades() -> list[str]:
     for name, entry in upgrade.SUNSET.items():
         writes, lines, _ = upgrade._plan(current().root)
         if not writes and not lines:
-            out.append(f"`luria upgrade {name}` has nothing left to do here "
-                       f"— delete it once every record has run it "
-                       f"({entry.sunset})")
+            out.append(f"`luria upgrade {name}` has nothing left to do "
+                       f"here — remove it at {entry.sunset}")
     return out
 
 

--- a/luria/upgrade.py
+++ b/luria/upgrade.py
@@ -51,9 +51,11 @@ class Upgrade:
 SUNSET = {
     "statuses": Upgrade(
         summary="declare `status:` as the controlled vocabulary it is",
-        sunset="every record that predates #181 has run it. Luria has one "
-               "user today, so: once luria's own record and the anthology "
-               "are both on the release that carries this.",
+        sunset="1.0.0. Both records that predated #181 have run it "
+               "already, but more are coming onto luria before the first "
+               "stable release, and each of them predates #181 too. The "
+               "pin is the version rather than a list of projects because "
+               "a list is never finished at the moment you read it.",
     ),
 }
 

--- a/tests/test_statuses.py
+++ b/tests/test_statuses.py
@@ -781,4 +781,4 @@ def test_a_spent_upgrade_says_it_can_be_deleted(tmp_path, monkeypatch):
     upgrade.run("statuses", root=str(tmp_path))
     config.reset()
     rows = lint.spent_upgrades()
-    assert any("statuses" in r and "delete" in r for r in rows), rows
+    assert any("statuses" in r and "remove it at" in r for r in rows), rows


### PR DESCRIPTION
Split out of the draft [#189](https://github.com/dmarx/luria/pull/189) so the false nag stops now. The removal itself stays pinned there.

`luria upgrade statuses` shipped with this sunset condition:

> every record that predates #181 has run it. Luria has one user today, so: once luria's own record and the anthology are both on the release that carries this.

Which came true **about an hour after it was written** — luria's own record ran it on 0.10.0, and [dmarx/anthology-of-the-sota#25](https://github.com/dmarx/anthology-of-the-sota/pull/25) ran it on the same release. So `spent-upgrades` began reporting a removal that is not going to happen, on every `luria lint` run, in both records.

A marker stating a condition it does not mean is exactly the failure it exists to prevent, one level up.

Repinned to **1.0.0**. More records are coming onto luria before the first stable release — `mathematics-of-meaning` and `strata-g` are next — and each of them predates #181, so the command still has work. The gate is the version rather than a list of projects because a list is never finished at the moment you read it.

The finding also reads better for it:

```
`luria upgrade statuses` has nothing left to do here — remove it at 1.0.0. …
```

rather than the old "delete it once every record has run it (…)", which buried the condition in a parenthesis after asserting the wrong thing.

## Checks

- `python -m pytest tests -q`: **908 passed**.
- `luria lint`: clean; the `spent-upgrades` row now states a condition that is actually open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_