### PR TITLE
Record-line codes carry their titles, and lists get lines

### DIFF
--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-32 entries. [All books](README.md).
+33 entries. [All books](README.md).
 
 ## Contents
 
@@ -38,6 +38,7 @@
 - [7 Sep 00:35 — One fact, one bit: two duplications the record line grew](#20260907003519)
 - [7 Sep 00:58 — Three copies of a region, and a link nobody derived](#20260907005848)
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](#20260907015341)
+- [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](#20260907030258)
 
 ---
 
@@ -2106,3 +2107,79 @@ Twelve test assertions moved from `"**Label** value"` to
 `"| **Label** | value |"`, and three that assumed the blockquote (`> `) it no
 longer is. That count is a fair measure of how load-bearing the shape was —
 worth knowing before changing it again.
+
+---
+
+<a name="20260907030258"></a>
+
+## A title is data, and this record has one that reads as syntax
+
+*2026-09-07 03:02:58 · site · quartz*
+
+Two presentation asks — put each document's title after its code, and give
+multi-valued fields a bulleted list instead of center dots. Both landed. The
+interesting part is what the second one required and what the first one broke.
+
+## Bullets in a table cell need HTML, and that needed checking
+
+A markdown table cell cannot hold a block-level list, so a real bulleted list
+inside one means `<ul><li>`. Whether that survives depends on the renderer,
+and guessing would have shipped a page full of visible angle brackets.
+
+So it was checked rather than assumed: cloned Quartz v4.5.2 — the version
+`actions/site` pins — and built a probe page. Raw HTML passes through, and the
+part that actually mattered is that **markdown inside the `<li>` is still
+parsed**: the links resolve, and `CrawlLinks` rewrites them to internal slugs
+with the right `data-slug`. Then the whole anthology through the same build:
+410 files, 1217 pages emitted, the bullets are a real `<ul>`, and the links
+inside them come out `class="internal alias"`.
+
+That last check is what a fixture cannot give you.
+
+## The title that reads as syntax
+
+Splicing titles in broke `luria site` on this repository, and the failure is a
+good one:
+
+```
+record/decisions.d/ADR-005.md → unresolved in frontmatter: [[CODE]]
+record/decisions.d/ADR-024.md → unresolved in frontmatter: [[CODE]]
+```
+
+[ADR-025](../../record/decisions.d/ADR-025.md) is titled ``Wikilinks: `[[CODE]]` is a typed reference, and typing it
+changes the rules``. Both of those decisions carry `influenced_by: ADR-025`,
+so both of their record lines now contained a literal `[[CODE]]`, and the
+wikilink expander dutifully went looking for a document called `CODE`.
+
+**A title is data, and it was being spliced into two surfaces that read
+syntax**: a markdown table cell, where `|` ends the cell, and a string about
+to be wikilink-expanded, where `[[` opens a reference. Escaping both is the
+fix; markdown renders `\[` as `[`, so it costs the reader nothing.
+
+The backticks around it in the title are not protection — the expander does
+not mask code spans, which is consistent with `ref_status.scan` being
+deliberately unmasked and worth remembering as a general property rather than
+a surprise.
+
+What found it was `test_links_out_of_the_site_go_to_the_repository`, which
+asserts `report.unplaced == []` over the whole real record. A fixture with
+tidy titles would have passed. There is now also a test that names [ADR-025](../../record/decisions.d/ADR-025.md)
+specifically, so the escaping cannot be quietly removed by someone who does
+not know why it is there.
+
+## One more masking property, learned the hard way
+
+The quoted failure above is in a **fenced** block, not an indented one. The
+first draft indented it, and `luria link --fix` rewrote the codes inside it —
+`record/decisions.d/[ADR-005](…).md`. Only fenced spans are masked; a
+four-space indented block is ordinary prose to the scanner. Worth knowing
+before quoting tool output that contains codes.
+
+## Shape notes
+
+Rows changed from `(label, str)` to `(label, list[str])`, which is what lets
+one renderer decide between a plain cell and a list without parsing its own
+output back. Titles are looked up once per `stage()` through
+`ref_status.load_docs()` — the reader that already answers "what documents are
+there and what are they called" — rather than a second one that could
+disagree.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](2026-09.md#20260907030258)
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](2026-09.md#20260907015341)
 - [7 Sep 00:58 — Three copies of a region, and a link nobody derived](2026-09.md#20260907005848)
 - [7 Sep 00:35 — One fact, one bit: two duplications the record line grew](2026-09.md#20260907003519)
@@ -41,9 +42,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-78 entries across 2 books, newest first.
+79 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 32 | 2026-09-03 | 2026-09-07 |
+| [2026-09](2026-09.md) | 33 | 2026-09-03 | 2026-09-07 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/luria/site.py
+++ b/luria/site.py
@@ -507,7 +507,7 @@ def _repeats_an_outbound(edge, held: set[tuple[str, str]]) -> bool:
     return bool(back) and (back, edge.source) in held
 
 
-def _edge_bits(outbound, inbound, scheme=None) -> list[str]:
+def _edge_bits(outbound, inbound, scheme=None, known=None) -> list[tuple[str, list[str]]]:
     """The typed edges as record-line fragments, wikilinks and all.
 
     Supersession and influence already read from the page's own frontmatter
@@ -515,6 +515,7 @@ def _edge_bits(outbound, inbound, scheme=None) -> list[str]:
     reference fields — the one direction the site otherwise loses, since
     frontmatter renders as nothing."""
     labels, order_of = _inbound_labels(scheme)
+    known = titles() if known is None else known
     bits = []
     out: dict[str, list[str]] = {}
     for edge in outbound:
@@ -522,7 +523,7 @@ def _edge_bits(outbound, inbound, scheme=None) -> list[str]:
             out.setdefault(edge.relation, []).append(edge.target)
     for relation, targets in out.items():
         label = relation.replace("_", " ").capitalize()
-        bits.append((label, " · ".join(f"[[{t}]]" for t in targets)))
+        bits.append((label, [_named(c, known) for c in targets]))
     held = {(e.relation, e.target) for e in outbound}
     grouped: dict[str, list[str]] = {}
     for edge in inbound:
@@ -536,8 +537,8 @@ def _edge_bits(outbound, inbound, scheme=None) -> list[str]:
 
     for relation in sorted(grouped, key=order):
         label = labels.get(relation) or f"Cited as `{relation}` by"
-        codes = " · ".join(f"[[{c}]]" for c in sorted(set(grouped[relation])))
-        bits.append((label, codes))
+        bits.append((label, [_named(c, known)
+                             for c in sorted(set(grouped[relation]))]))
     return bits
 
 
@@ -571,9 +572,9 @@ def _vocabulary_bits(meta: dict, source: Path) -> list[str]:
             [] if raw in (None, "") else [raw])
         if not values:
             continue
-        links = " · ".join(
+        links = [
             f"[{v}]({posixpath.relpath((scheme.vocab_dir(vocab.name) / f'{v}.md').as_posix(), source.parent.as_posix())})"
-            for v in values)
+            for v in values]
         bits.append((vocab.field.replace("_", " ").capitalize(), links))
     return bits
 
@@ -598,7 +599,45 @@ def readme_region() -> str:
             f"published by `luria site`.")
 
 
-def _table(rows: list[tuple[str, str]]) -> str:
+def titles() -> dict[str, str]:
+    """`{code: title}` for every referable document in the record.
+
+    Read through `ref_status`, which already loads exactly this — one reader
+    for "what documents are there and what are they called" rather than a
+    second that could disagree (DP-4)."""
+    from . import ref_status
+    return {code: doc.title for code, doc in ref_status.load_docs().items()}
+
+
+def _plain(title: str) -> str:
+    """A title as data, with what the surfaces it lands in would read as
+    syntax escaped.
+
+    Two hazards, both real rather than hypothetical. `|` ends a table cell.
+    And `[[` opens a wikilink the expander then tries to resolve — this
+    project's own ADR-025 is titled ``Wikilinks: `[[CODE]]` is a typed
+    reference``, and splicing it unescaped asked the resolver for a document
+    called `CODE` on every page citing it.
+
+    Markdown renders `\\[` as `[`, so the escape costs the reader nothing."""
+    return title.replace("|", "\\|").replace("[[", "\\[\\[")
+
+
+def _named(code: str, known: dict[str, str]) -> str:
+    """A code as a wikilink, followed by the document's title.
+
+    A code alone asks the reader to already know the record: `LIT-141` says
+    nothing about what it is, and the whole point of a backlink is to be
+    followed by someone who does not yet know where it goes. The title is what
+    makes the line answerable without opening anything.
+
+    Unknown codes render bare rather than guessing — a remote code, or one the
+    lint is already reporting as resolving to nothing."""
+    title = known.get(code, "")
+    return f"[[{code}]] — {_plain(title)}" if title else f"[[{code}]]"
+
+
+def _table(rows: list[tuple[str, list[str]]]) -> str:
     """The record's facts as a two-column table.
 
     They were one line of `**Label** value` separated by center dots, which
@@ -610,14 +649,27 @@ def _table(rows: list[tuple[str, str]]) -> str:
     Header-less on purpose — `| | |` — because "Field" and "Value" name
     nothing a reader did not already know from the rows.
 
-    Multi-valued fields keep the center dot inside their cell: it separates
-    peers there (three sources, two contesting papers), which is the job it
-    was doing badly at the top level and does well one level down."""
+    A field with several values gets a real bulleted list inside its cell —
+    `<ul>`, because a markdown table cell cannot hold a block-level list and
+    Quartz passes raw HTML through (verified against v4.5.2: the markdown
+    links inside the items are still parsed, and `CrawlLinks` still resolves
+    them). One value renders plain: a one-item bullet is a bullet about
+    nothing.
+
+    The center dot is gone from both levels. It was separating peers inside a
+    cell, which it did adequately, but a title after each code makes the items
+    long enough that a line each is the only thing that reads."""
+    def cell(values: list[str]) -> str:
+        if len(values) == 1:
+            return values[0]
+        items = "".join(f"<li>{v}</li>" for v in values)
+        return f"<ul>{items}</ul>"
     return "\n".join(["| | |", "|---|---|"]
-                      + [f"| **{label}** | {value} |" for label, value in rows])
+                      + [f"| **{label}** | {cell(values)} |" for label, values in rows])
 
 
-def record_line(meta: dict, source: Path, outbound=(), inbound=()) -> str:
+def record_line(meta: dict, source: Path, outbound=(), inbound=(),
+                known: dict[str, str] | None = None) -> str:
     """The frontmatter facts, rendered where a reader (and a graph) can see
     them: status, when it was filed, the issue, what influenced it, and the
     typed edges in and out of it.
@@ -625,28 +677,28 @@ def record_line(meta: dict, source: Path, outbound=(), inbound=()) -> str:
     Composed with wikilinks and handed to the resolver rather than spelled
     here — the fixer owns every target in this record, and a second speller
     would be the drift DP-4 names."""
-    bits: list[tuple[str, str]] = []
+    known = titles() if known is None else known
+    bits: list[tuple[str, list[str]]] = []
     if status := statuses.display(statuses.of(meta, _scheme_of(source)),
-                                  link=lambda c: f"[[{c}]]"):
-        bits.append(("Status", status))
+                                  link=lambda c: _named(c, known)):
+        bits.append(("Status", [status]))
     # Shown only when it isn't 1, the same rule the index follows (ADR-016).
     # A version that isn't a number is somebody's mistake, not this function's
     # to interpret — it is shown as written and the lint says so.
     if (version := meta.get("version")) and str(version).strip() != "1":
-        bits.append(("Version", str(version)))
+        bits.append(("Version", [str(version)]))
     if date := str(meta.get("date", "")).strip():
-        bits.append(("Filed", date))
+        bits.append(("Filed", [date]))
     # `issue: '#21, #23'` is a real shape in this record, so the separator is
     # read out of the field rather than assumed to be a space.
     if issues := re.findall(r"#\d+", str(meta.get("issue", ""))):
-        bits.append(("Issue",
-                     " · ".join(f"[[{issue}]]" for issue in issues)))
+        bits.append(("Issue", [f"[[{issue}]]" for issue in issues]))
     influenced = [str(c).strip() for c in (meta.get("influenced_by") or [])]
     if influenced:
-        codes = " · ".join(f"[[{code}]]" for code in influenced if code)
-        bits.append(("Influenced by", codes))
+        bits.append(("Influenced by",
+                     [_named(c, known) for c in influenced if c]))
     bits += _vocabulary_bits(meta, source)
-    bits += _edge_bits(outbound, inbound, _scheme_of(source))
+    bits += _edge_bits(outbound, inbound, _scheme_of(source), known)
     if not bits:
         return ""
     expanded, _ = doc_refs.expand_wikilinks(_table(bits), source)
@@ -820,6 +872,7 @@ def stage(out: Path, cfg=None, nested: bool = True) -> Report:
     # Read once for the whole record: a page's backlinks are somebody else's
     # frontmatter.
     typed = edges.graph()
+    known = titles()
 
     for path in pages:
         text = path.read_text(encoding="utf-8")
@@ -830,7 +883,8 @@ def stage(out: Path, cfg=None, nested: bool = True) -> Report:
             line = record_line(
                 meta, path,
                 outbound=typed.outbound(code) if code else (),
-                inbound=typed.inbound(code) if code else ())
+                inbound=typed.inbound(code) if code else (),
+                known=known)
             if line:
                 body = _insert_after_title(body, line)
                 report.lineage += 1

--- a/record/changelog.d/20260907-030258.md
+++ b/record/changelog.d/20260907-030258.md
@@ -1,0 +1,18 @@
+### Changed
+
+- Every document code in the site's record line now carries the document's
+  title. A code alone asks the reader to already know the record — `LIT-141`
+  says nothing about what it is — and being followed by someone who does not
+  yet know where it goes is the whole point of a backlink.
+- A field with several values gets a bulleted list, one item per line, instead
+  of values separated by center dots. With a title after each code the items
+  are long enough that a line each is the only thing that reads. A single
+  value stays plain: a one-item bullet is a bullet about nothing.
+
+### Fixed
+
+- A title containing markdown syntax is escaped where it is spliced. This
+  project's own [ADR-025](record/decisions.d/ADR-025.md) is titled ``Wikilinks: `[[CODE]]` is a typed
+  reference``, and two decisions cite it — unescaped, both their pages asked
+  the resolver for a document called `CODE`. `|` is escaped too, which would
+  otherwise end the table cell.

--- a/record/devlog.d/2026/09/07/030258.md
+++ b/record/devlog.d/2026/09/07/030258.md
@@ -1,0 +1,75 @@
+---
+title: 'A title is data, and this record has one that reads as syntax'
+created: '2026-09-07T03:02:58'
+tags:
+- site
+- quartz
+---
+
+Two presentation asks — put each document's title after its code, and give
+multi-valued fields a bulleted list instead of center dots. Both landed. The
+interesting part is what the second one required and what the first one broke.
+
+## Bullets in a table cell need HTML, and that needed checking
+
+A markdown table cell cannot hold a block-level list, so a real bulleted list
+inside one means `<ul><li>`. Whether that survives depends on the renderer,
+and guessing would have shipped a page full of visible angle brackets.
+
+So it was checked rather than assumed: cloned Quartz v4.5.2 — the version
+`actions/site` pins — and built a probe page. Raw HTML passes through, and the
+part that actually mattered is that **markdown inside the `<li>` is still
+parsed**: the links resolve, and `CrawlLinks` rewrites them to internal slugs
+with the right `data-slug`. Then the whole anthology through the same build:
+410 files, 1217 pages emitted, the bullets are a real `<ul>`, and the links
+inside them come out `class="internal alias"`.
+
+That last check is what a fixture cannot give you.
+
+## The title that reads as syntax
+
+Splicing titles in broke `luria site` on this repository, and the failure is a
+good one:
+
+```
+record/decisions.d/ADR-005.md → unresolved in frontmatter: [[CODE]]
+record/decisions.d/ADR-024.md → unresolved in frontmatter: [[CODE]]
+```
+
+[ADR-025](../../record/decisions.d/ADR-025.md) is titled ``Wikilinks: `[[CODE]]` is a typed reference, and typing it
+changes the rules``. Both of those decisions carry `influenced_by: ADR-025`,
+so both of their record lines now contained a literal `[[CODE]]`, and the
+wikilink expander dutifully went looking for a document called `CODE`.
+
+**A title is data, and it was being spliced into two surfaces that read
+syntax**: a markdown table cell, where `|` ends the cell, and a string about
+to be wikilink-expanded, where `[[` opens a reference. Escaping both is the
+fix; markdown renders `\[` as `[`, so it costs the reader nothing.
+
+The backticks around it in the title are not protection — the expander does
+not mask code spans, which is consistent with `ref_status.scan` being
+deliberately unmasked and worth remembering as a general property rather than
+a surprise.
+
+What found it was `test_links_out_of_the_site_go_to_the_repository`, which
+asserts `report.unplaced == []` over the whole real record. A fixture with
+tidy titles would have passed. There is now also a test that names [ADR-025](../../record/decisions.d/ADR-025.md)
+specifically, so the escaping cannot be quietly removed by someone who does
+not know why it is there.
+
+## One more masking property, learned the hard way
+
+The quoted failure above is in a **fenced** block, not an indented one. The
+first draft indented it, and `luria link --fix` rewrote the codes inside it —
+`record/decisions.d/[ADR-005](…).md`. Only fenced spans are masked; a
+four-space indented block is ordinary prose to the scanner. Worth knowing
+before quoting tool output that contains codes.
+
+## Shape notes
+
+Rows changed from `(label, str)` to `(label, list[str])`, which is what lets
+one renderer decide between a plain cell and a list without parsing its own
+output back. Titles are looked up once per `stage()` through
+`ref_status.load_docs()` — the reader that already answers "what documents are
+there and what are they called" — rather than a second one that could
+disagree.

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -185,14 +185,14 @@ def test_the_record_line_names_what_a_decision_supersedes():
     where = current().schemes["ADR"].dir / "ADR-011.md"
     inbound = [edges.Edge("ADR-010", "superseded_by", "ADR-011", "status")]
     line = site.record_line({"status": "Active"}, where, inbound=inbound)
-    assert "| **Supersedes** | [ADR-010](ADR-010.md) |" in line
+    assert "| **Supersedes** | [ADR-010](ADR-010.md) — " in line
 
 
 def test_the_record_line_names_what_a_decision_influenced():
     where = current().schemes["ADR"].dir / "ADR-035.md"
     inbound = [edges.Edge("DP-010", "influenced_by", "ADR-035", "frontmatter")]
     line = site.record_line({"status": "Active"}, where, inbound=inbound)
-    assert "| **Influenced** | [DP-010](../../docs/design-principles.md#dp-10) |" in line
+    assert "| **Influenced** | [DP-010](../../docs/design-principles.md#dp-10) — " in line
 
 
 def test_the_record_line_carries_a_declared_reference_both_ways(
@@ -202,9 +202,9 @@ def test_the_record_line_carries_a_declared_reference_both_ways(
     sota = doc(root, "record/practices.d/SOTA-001.md", code="SOTA-001",
                extra="source: LIT-001")
     out = [edges.Edge("SOTA-001", "source", "LIT-001", "frontmatter `source:`")]
-    assert "| **Source** | [LIT-001](../literature.d/LIT-001.md) |" in \
+    assert "| **Source** | [LIT-001](../literature.d/LIT-001.md) — Entry LIT-001 |" in \
         site.record_line({"status": "Active"}, sota, outbound=out)
-    assert "| **Cited as `source` by** | [SOTA-001](../practices.d/SOTA-001.md) |" in \
+    assert "| **Cited as `source` by** | [SOTA-001](../practices.d/SOTA-001.md) — Entry SOTA-001 |" in \
         site.record_line({"status": "Active"}, lit, inbound=out)
 
 
@@ -214,7 +214,7 @@ def test_a_staged_page_carries_its_inbound_edges(project):
     out = project / "build" / "site"
     site.stage(out)
     staged = (out / "content" / "record" / "decisions.d" / "ADR-001.md").read_text()
-    assert "| **Supersedes** | [ADR-002](ADR-002.md) |" in staged
+    assert "| **Supersedes** | [ADR-002](ADR-002.md) — " in staged
 
 
 # --- one edge per code in a plural reference ------------------------------
@@ -292,7 +292,7 @@ def test_a_stored_converse_is_not_also_rendered_as_a_backlink(
     back = [edges.Edge("SOTA-002", "extends", "SOTA-001", "frontmatter")]
     line = site.record_line({"status": "Active"}, trunk,
                             outbound=out, inbound=back)
-    assert "| **Extended by** | [SOTA-002](SOTA-002.md) |" in line
+    assert "| **Extended by** | [SOTA-002](SOTA-002.md) — Entry SOTA-002 |" in line
     assert "Cited as" not in line
 
 
@@ -306,7 +306,7 @@ def test_a_backlink_with_no_stored_converse_still_renders(
     doc(root, "record/practices.d/SOTA-001.md", code="SOTA-001",
         extra="source: LIT-001")
     back = [edges.Edge("SOTA-001", "source", "LIT-001", "frontmatter")]
-    assert "| **Cited as `source` by** | [SOTA-001](../practices.d/SOTA-001.md) |" \
+    assert "| **Cited as `source` by** | [SOTA-001](../practices.d/SOTA-001.md) — Entry SOTA-001 |" \
         in site.record_line({"status": "Active"}, lit, inbound=back)
 
 
@@ -320,5 +320,5 @@ def test_an_unwritten_converse_still_renders_as_a_backlink(
     doc(root, "record/practices.d/SOTA-002.md", code="SOTA-002",
         extra="extends:\n- SOTA-001")
     back = [edges.Edge("SOTA-002", "extends", "SOTA-001", "frontmatter")]
-    assert "| **Cited as `extends` by** | [SOTA-002](SOTA-002.md) |" in \
+    assert "| **Cited as `extends` by** | [SOTA-002](SOTA-002.md) — Entry SOTA-002 |" in \
         site.record_line({"status": "Active"}, trunk, inbound=back)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -530,3 +530,21 @@ def test_an_orphan_in_a_nested_view_directory_is_an_orphan(tmp_path, monkeypatch
         "an unrendered file in a nested record's view directory went unreported"
     )
 
+
+def test_a_title_that_looks_like_syntax_is_escaped():
+    """A title is data spliced into a markdown table cell that is then
+    wikilink-expanded, so anything in it that reads as syntax has to be
+    escaped. This project's ADR-025 is titled ``Wikilinks: `[[CODE]]` is a
+    typed reference``, and two decisions cite it through `influenced_by:` —
+    unescaped, every one of their pages asked the resolver for a document
+    called `CODE`."""
+    assert site._plain("a | b") == r"a \| b"
+    assert "[[" not in site._plain(site.titles()["ADR-025"])
+
+
+def test_staging_leaves_no_unresolved_wikilink():
+    """The whole record, not a fixture: the escaping above was found by this
+    assertion failing on two real pages, and it is what keeps it found."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        assert site.stage(Path(d)).unplaced == []

--- a/tests/test_vocabularies.py
+++ b/tests/test_vocabularies.py
@@ -361,7 +361,9 @@ def test_the_record_line_shows_the_written_values_not_the_default(tmp_path, monk
     root = world(tmp_path, monkeypatch)
     path = scene(root, 1, "worlds:\n- A\n- C")
     line = site.record_line({"status": "Active", "worlds": ["A", "C"]}, path)
-    assert "| **Worlds** | [A](../../docs/scenes/worlds/A.md) · [C](../../docs/scenes/worlds/C.md) |" in line
+    assert ("| **Worlds** | <ul>"
+            "<li>[A](../../docs/scenes/worlds/A.md)</li>"
+            "<li>[C](../../docs/scenes/worlds/C.md)</li></ul> |") in line
     quiet = site.record_line({"status": "Active"}, scene(root, 2))
     assert "Worlds" not in quiet
 


### PR DESCRIPTION
`SOTA-136`, staged and then rendered through real Quartz:

| | |
|---|---|
| **Status** | Proposed |
| **Filed** | 2026-09-05 |
| **Consensus** | contested |
| **Source** | LIT-140 — mHC: Manifold-Constrained Hyper-Connections |
| **Extends** | SOTA-137 — Widen the residual stream into several streams with freely learned mixing (hyper-connections) |
| **Compared against** | SOTA-133 — Replace fixed residual accumulation with learned attention over preceding layers |
| **Contested by** | <ul><li>LIT-151 — oHC: Orthogonal Hyper-Connections on SO(4) via Quaternions</li><li>LIT-181 — Beyond the Birkhoff Polytope: Spectral-Sphere-Constrained Hyper-Connections</li></ul> |
| **Supersedes** | SOTA-137 — Widen the residual stream into several streams with freely learned mixing (hyper-connections) |

A code alone asks the reader to already know the record — `LIT-141` says nothing about what it is, and being followed by someone who *doesn't* yet know where it goes is the whole point of a backlink. That makes the items long enough that the center dot stops working, so several values become a real bulleted list, one per line. A single value stays plain: a one-item bullet is a bullet about nothing.

## Bullets in a table cell need HTML, so I checked rather than guessed

A markdown table cell can't hold a block-level list, so this is `<ul><li>` — which only works if the renderer passes raw HTML through, and guessing would ship a page full of visible angle brackets.

Cloned Quartz **v4.5.2** (what `actions/site` pins) and built a probe. Raw HTML passes through, and the part that actually mattered is that **markdown inside the `<li>` is still parsed**:

```html
<td><ul><li><a href="../literature.d/LIT-151" class="internal alias"
    data-slug="record/literature.d/LIT-151">LIT-151</a> — oHC…</li></ul></td>
```

Then the whole anthology through the same build — 410 files, **1217 pages emitted**, bullets are a real `<ul>`, links inside them come out `class="internal alias"`, and **zero pages contain an unexpanded `[[`**. That last check is what a fixture can't give you.

## The title that reads as syntax

Splicing titles in broke `luria site` on *this* repository:

```
record/decisions.d/ADR-005.md → unresolved in frontmatter: [[CODE]]
record/decisions.d/ADR-024.md → unresolved in frontmatter: [[CODE]]
```

ADR-025 is titled ``Wikilinks: `[[CODE]]` is a typed reference, and typing it changes the rules``. Both those decisions carry `influenced_by: ADR-025`, so both record lines now contained a literal `[[CODE]]`, and the expander went looking for a document called `CODE`.

**A title is data being spliced into two surfaces that read syntax** — a table cell where `|` ends the cell, and a string about to be wikilink-expanded where `[[` opens a reference. Both are escaped now; markdown renders `\[` as `[`, so it costs the reader nothing.

Worth noting: the backticks around it in the title are *not* protection — the expander doesn't mask code spans, consistent with `ref_status.scan` being deliberately unmasked.

What caught it was `test_links_out_of_the_site_go_to_the_repository`, which asserts `report.unplaced == []` over the whole real record. A fixture with tidy titles passes either way. There's now also a test naming ADR-025 specifically, so the escaping can't be quietly removed by someone who doesn't know why it's there.

## Shape

Rows changed from `(label, str)` to `(label, list[str])` — that's what lets one renderer choose between a plain cell and a list without parsing its own output back. Titles are read once per `stage()` through `ref_status.load_docs()`, the reader that already answers "what documents are there and what are they called", rather than a second one that could disagree.

## Checks

`python -m pytest tests -q` → **926 passed**. `luria link --fix`, `luria index`, `luria lint` → clean. Plus the real Quartz build above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_