### PR TITLE
A remote prefix scopes an issue number too

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,7 @@ different pair of lines, not a different subsystem.
 |---|---|---|
 | `prefix` | `str` | *the table's own name* |
 | `repo` | `str` | *unset* |
+| `issue_url` | `str` | *unset* |
 | `ref` | `str` | `"main"` |
 | `dir` | `str` | `"record/decisions.d"` |
 | `name` | `str` | *unset* |

--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-33 entries. [All books](README.md).
+34 entries. [All books](README.md).
 
 ## Contents
 
@@ -39,6 +39,7 @@
 - [7 Sep 00:58 — Three copies of a region, and a link nobody derived](#20260907005848)
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](#20260907015341)
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](#20260907030258)
+- [7 Sep 04:40 — The link that resolved to the wrong project](#20260907044002)
 
 ---
 
@@ -2183,3 +2184,63 @@ output back. Titles are looked up once per `stage()` through
 `ref_status.load_docs()` — the reader that already answers "what documents are
 there and what are they called" — rather than a second one that could
 disagree.
+
+---
+
+<a name="20260907044002"></a>
+
+## The link that resolved to the wrong project
+
+*2026-09-07 04:40:02 · remotes · references*
+
+`LU-ADR-076` has always resolved to luria's [ADR-076](../../record/decisions.d/ADR-076.md). `LU-#193` resolved to the
+citing project's issue 193.
+
+The prefix was doing nothing. `ISSUE_RE` matched the `#193`, the local
+`issue_url` formatted it, and `link --fix` wrote a link that was correct in
+every mechanical sense and pointed at the wrong repository.
+
+## Why it survived
+
+Every check passed, and each for a good reason.
+
+`broken-targets` verifies that a target resolves — and it did, to a real
+issue. `hand-written-urls` was satisfied because nothing was hand-written. The
+lint's whole model of a bad link is one that goes nowhere, and this one went
+somewhere.
+
+It had already shipped. `dmarx/anthology-of-the-sota` [ADR-015](../../record/decisions.d/ADR-015.md) carried
+`LU-[#173](…/anthology-of-the-sota/issues/173)`, written meaning luria's
+issue 173, pointing at the anthology's own. It survived review, `link --fix`,
+`lint` and a merge to `main`, and was found only because the same mistake was
+made a second time and noticed by eye.
+
+That is the shape worth remembering: **a guard that only asks "does this
+resolve" cannot see a reference that resolves to the wrong thing.** The
+`unresolved-codes` class has the same blind spot by construction, and
+`source-mismatch` exists because the same question came up for titles.
+
+## The fix, in two halves
+
+Construction was the easy half: `remotes.issue_link`, defaulting to GitHub's
+convention for a remote with a `repo`, overridable with `issue_url` for
+another forge — the same bargain the `uris` table already makes for documents.
+
+**Scanning was the actual bug.** The local issue pattern read `#193` out of
+the middle of `LU-#193`, so even a correct constructor would not have been
+reached. The remote reference has to claim its whole span first, which is
+exactly what `find_refs` already does for `LU-ADR-013` and says so in a
+comment written for that case. The pattern is built from the declared
+remotes, so an undeclared prefix stays ordinary prose followed by a local
+issue number.
+
+## Where it deliberately does nothing
+
+A remote with no `repo` and no `issue_url` — `ARXIV`, `FX` — resolves to
+nothing, and the reference is left bare. Inventing a tracker for a remote
+reached by a `url` template would move the silent wrongness somewhere new
+rather than remove it.
+
+Fired against the anthology's real configuration rather than a fixture:
+`LU-#194` to luria's tracker, a bare `#17` still to the anthology's, `ARXIV`
+and `FX` to nothing.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [7 Sep 04:40 — The link that resolved to the wrong project](2026-09.md#20260907044002)
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](2026-09.md#20260907030258)
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](2026-09.md#20260907015341)
 - [7 Sep 00:58 — Three copies of a region, and a link nobody derived](2026-09.md#20260907005848)
@@ -42,9 +43,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-79 entries across 2 books, newest first.
+80 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 33 | 2026-09-03 | 2026-09-07 |
+| [2026-09](2026-09.md) | 34 | 2026-09-03 | 2026-09-07 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/luria/config.py
+++ b/luria/config.py
@@ -714,6 +714,11 @@ class Remote:
     different pair of lines, not a different subsystem."""
     prefix: str
     repo: str = ""
+    # Where the remote's *issues* live. Defaults to the GitHub convention for
+    # a remote with a `repo`, and stays empty for one reached by a `url`
+    # template alone — an arXiv identifier or a ticket key has no tracker, and
+    # guessing one would put the silent wrongness of #194 in a new place.
+    issue_url: str = ""
     ref: str = "main"
     dir: str = "record/decisions.d"
     name: str = ""
@@ -1592,6 +1597,7 @@ def load(root: Path | None = None, text: str | None = None,
             prefix.upper(): Remote(
                 prefix.upper(),
                 repo=spec.get("repo", ""),
+                issue_url=spec.get("issue_url", ""),
                 ref=spec.get("ref", "main"),
                 dir=spec.get("dir", "record/decisions.d"),
                 name=spec.get("name", ""),

--- a/luria/doc_refs.py
+++ b/luria/doc_refs.py
@@ -75,6 +75,18 @@ ADR_RE = re.compile(r"\bADR[- ](?P<num>\d{1,4})\b")
 # 1–4 digits keeps six-digit hex colours out; `(?!\w)` keeps `#123abc` out.
 ISSUE_RE = re.compile(r"(?<![\w&#/])#(?P<num>\d{1,4})(?!\w)")
 
+# `LU-#193` — one of a REMOTE's issues. Composed like `LU-ADR-013`: the
+# prefix says whose namespace, and without it the number resolved through the
+# citing project's own `issue_url` and silently named a different project's
+# issue (#194). Built from the declared remotes, so an undeclared prefix is
+# still ordinary prose followed by a local issue number.
+def remote_issue_re() -> re.Pattern | None:
+    prefixes = sorted(current().remotes, key=len, reverse=True)
+    if not prefixes:
+        return None
+    alt = "|".join(re.escape(p) for p in prefixes)
+    return re.compile(rf"(?<![\w-])(?P<prefix>{alt})-#(?P<num>\d{{1,4}})(?!\w)")
+
 # A low `#N` is ambiguous: the docs also number principles, an ADR's open
 # questions, user stories and gotchas the same way ("the dual of #1", "open
 # question #3", "story #2", "gotcha #2"). Above the highest principle number the
@@ -467,6 +479,8 @@ def find_refs(text: str, path: Path = ANY_MD) -> list[Ref]:
     # can outlive its scheme's dial via an `formerly:` alias, and a reference's
     # validity shouldn't depend on a setting that may have changed since.
     patterns += [("scheme", s.prefix, s.temp_pattern) for s in schemes.values()]
+    if (remote_issues := remote_issue_re()) is not None:
+        patterns += [("remote-issue", "", remote_issues)]
     patterns += [("issue", "", ISSUE_RE)]
 
     for kind, prefix, regex in patterns:
@@ -477,6 +491,11 @@ def find_refs(text: str, path: Path = ANY_MD) -> list[Ref]:
             for i in range(start, end):
                 claimed[i] = True
             tail = m.groupdict().get("tail") or ""
+            if kind == "remote-issue":
+                refs.append(Ref(kind, int(m.group("num")), start, end,
+                                text[start:end], line_of(start),
+                                remote=m.group("prefix")))
+                continue
             refs.append(Ref(kind, 0 if tail else int(m.group("num")), start,
                             end, text[start:end], line_of(start),
                             prefix=prefix, code=tail))
@@ -781,6 +800,11 @@ def resolve(ref: Ref, source: Path, adrs: dict[int, Path],
         # A URL, never a relative path — it is a different repository, so no
         # `link_base` applies and the same target is right from every file.
         return remotes.resolve(ref.remote, ref.code) or None
+    if ref.kind == "remote-issue":
+        # Empty when the remote has no tracker — an arXiv id or a ticket key
+        # has no issues, and `None` leaves it bare rather than pointing it at
+        # this project's own (#194).
+        return remotes.issue_link(ref.remote, ref.num) or None
     if ref.kind == "issue":
         if text is not None and is_ambiguous_issue(ref, text, anchors):
             return None

--- a/luria/remotes.py
+++ b/luria/remotes.py
@@ -224,6 +224,28 @@ def link(remote: Remote, code: str) -> str:
     return construct(remote, code, "read")
 
 
+def issue_link(remote_prefix: str, number: int) -> str:
+    """The URL for one of a remote's issues, or `""` when it has no tracker.
+
+    `LU-#193` means luria's issue 193. Before this it meant nothing: the
+    prefix was inert prose and the number resolved through the *citing*
+    project's `issue_url`, producing a well-formed link to a different
+    project's issue of the same number (#194). Nothing could catch it — the
+    target resolved, so the link checker was satisfied.
+
+    Empty for a remote with no `repo` and no explicit `issue_url`. A remote
+    reached by a `url` template — an arXiv identifier, a ticket key — has no
+    issue tracker, and inventing one would move the same silent wrongness
+    somewhere new rather than remove it."""
+    remote = current().remotes.get(remote_prefix.upper())
+    if remote is None:
+        return ""
+    if remote.issue_url:
+        return remote.issue_url.format(n=number)
+    return (f"https://github.com/{remote.repo}/issues/{number}"
+            if remote.repo else "")
+
+
 def resolve(remote_prefix: str, code: str) -> str:
     remote = current().remotes.get(remote_prefix.upper())
     return link(remote, code) if remote else ""

--- a/record/changelog.d/20260907-044001.md
+++ b/record/changelog.d/20260907-044001.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- `LU-#193` linked to the *citing* project's issue 193, not the remote's. The
+  prefix was inert prose and the number resolved through the local
+  `issue_url`, producing a well-formed link to a different project's issue of
+  the same number — which in a mature tracker exists and is about something
+  else. No check could see it: the target resolved, so `broken-targets` was
+  satisfied ([#194](https://github.com/dmarx/luria/issues/194)).
+
+### Added
+
+- `[luria.remotes.X] issue_url`, defaulting to the GitHub convention for a
+  remote with a `repo`. A remote reached by a `url` template alone — an arXiv
+  identifier, a ticket key — has no tracker, so its `X-#7` resolves to nothing
+  and is left bare rather than pointed at the local one.

--- a/record/devlog.d/2026/09/07/044002.md
+++ b/record/devlog.d/2026/09/07/044002.md
@@ -1,0 +1,59 @@
+---
+title: 'The link that resolved to the wrong project'
+created: '2026-09-07T04:40:02'
+tags:
+- remotes
+- references
+---
+
+`LU-ADR-076` has always resolved to luria's [ADR-076](../../record/decisions.d/ADR-076.md). `LU-#193` resolved to the
+citing project's issue 193.
+
+The prefix was doing nothing. `ISSUE_RE` matched the `#193`, the local
+`issue_url` formatted it, and `link --fix` wrote a link that was correct in
+every mechanical sense and pointed at the wrong repository.
+
+## Why it survived
+
+Every check passed, and each for a good reason.
+
+`broken-targets` verifies that a target resolves — and it did, to a real
+issue. `hand-written-urls` was satisfied because nothing was hand-written. The
+lint's whole model of a bad link is one that goes nowhere, and this one went
+somewhere.
+
+It had already shipped. `dmarx/anthology-of-the-sota` [ADR-015](../../record/decisions.d/ADR-015.md) carried
+`LU-[#173](…/anthology-of-the-sota/issues/173)`, written meaning luria's
+issue 173, pointing at the anthology's own. It survived review, `link --fix`,
+`lint` and a merge to `main`, and was found only because the same mistake was
+made a second time and noticed by eye.
+
+That is the shape worth remembering: **a guard that only asks "does this
+resolve" cannot see a reference that resolves to the wrong thing.** The
+`unresolved-codes` class has the same blind spot by construction, and
+`source-mismatch` exists because the same question came up for titles.
+
+## The fix, in two halves
+
+Construction was the easy half: `remotes.issue_link`, defaulting to GitHub's
+convention for a remote with a `repo`, overridable with `issue_url` for
+another forge — the same bargain the `uris` table already makes for documents.
+
+**Scanning was the actual bug.** The local issue pattern read `#193` out of
+the middle of `LU-#193`, so even a correct constructor would not have been
+reached. The remote reference has to claim its whole span first, which is
+exactly what `find_refs` already does for `LU-ADR-013` and says so in a
+comment written for that case. The pattern is built from the declared
+remotes, so an undeclared prefix stays ordinary prose followed by a local
+issue number.
+
+## Where it deliberately does nothing
+
+A remote with no `repo` and no `issue_url` — `ARXIV`, `FX` — resolves to
+nothing, and the reference is left bare. Inventing a tracker for a remote
+reached by a `url` template would move the silent wrongness somewhere new
+rather than remove it.
+
+Fired against the anthology's real configuration rather than a fixture:
+`LU-#194` to luria's tracker, a bare `#17` still to the anthology's, `ARXIV`
+and `FX` to nothing.

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -528,3 +528,61 @@ def test_scheme_level_uris_scope_to_the_family(project):
     assert remotes.resolve("UP", "VP-18") == "https://up.example/values/18"
     assert remotes.resolve("UP", "ADR-032").endswith(
         "record/decisions.d/ADR-032.md")
+
+
+# ── A remote's issue tracker (#194) ──────────────────────────────────────
+
+def test_a_remote_issue_links_to_the_remote_tracker(project):
+    """`UP-#7` means upstream's issue 7.
+
+    Before this, the `UP-` was inert prose and the `#7` resolved through the
+    *citing* project's `issue_url` — a well-formed link to a completely
+    different project's issue 7, which in a mature tracker exists and is about
+    something else. Nothing could catch it: the target resolves, so
+    `broken-targets` was satisfied."""
+    with_remote(project)
+    assert remotes.issue_link("UP", 7) == "https://github.com/o/r/issues/7"
+
+
+def test_an_explicit_issue_url_wins(project):
+    """A forge that is not GitHub is a line of config, not a subsystem —
+    the same bargain the `uris` table already makes for documents."""
+    with_remote(project,
+                'issue_url = "https://gitlab.test/o/r/-/issues/{n}"\n')
+    assert remotes.issue_link("UP", 7) == "https://gitlab.test/o/r/-/issues/7"
+
+
+def test_a_remote_with_no_repo_has_no_tracker(project):
+    """`ARXIV-#5` names nothing. A remote reached by a `url` template has no
+    issues, and guessing one would be the same silent wrongness in a new
+    place — so it resolves to nothing and the caller reports it."""
+    with_remote(project, '[luria.remotes.ARXIV]\n'
+                         'uid = "(\\\\d{4})\\\\.(\\\\d{4,5})"\n'
+                         'url = "https://arxiv.org/abs/{1}.{2}"\n')
+    assert remotes.issue_link("ARXIV", 5) == ""
+
+
+def test_the_prefix_claims_the_whole_span(project):
+    """The bug was one of scanning, not only of construction: the local issue
+    pattern read `#7` out of the middle of `UP-#7`. The remote reference has
+    to claim its span first, exactly as `UP-ADR-013` already does."""
+    with_remote(project)
+    refs = doc_refs.find_refs("See UP-#7 for the upstream discussion.",
+                              doc_refs.ANY_MD)
+    kinds = [(r.kind, r.text) for r in refs]
+    assert ("remote-issue", "UP-#7") in kinds
+    assert not any(k == "issue" for k, _ in kinds)
+
+
+def test_a_bare_issue_still_links_locally(project):
+    """The narrow fix stays narrow: an unprefixed `#7` is this project's."""
+    with_remote(project)
+    refs = doc_refs.find_refs("See #7 for the discussion.", doc_refs.ANY_MD)
+    assert [(r.kind, r.num) for r in refs] == [("issue", 7)]
+
+
+def test_a_remote_issue_is_written_as_a_link(project):
+    with_remote(project)
+    out, n = doc_refs.linkify("See UP-#7.", doc_refs.ANY_MD)
+    assert n == 1
+    assert out == "See [UP-#7](https://github.com/o/r/issues/7)."


### PR DESCRIPTION
Closes #194.

`LU-ADR-076` has always resolved to luria's ADR-076. `LU-#193` resolved to the **citing project's** issue 193 — the prefix was inert prose, the local `issue_url` formatted the number, and `link --fix` wrote a link that was correct in every mechanical sense and pointed at the wrong repository.

## Why nothing caught it

Every check passed, each for a good reason.

`broken-targets` asks whether a target *resolves* — and it did, to a real issue in a different project. `hand-written-urls` was satisfied because nothing was hand-written. **The lint's whole model of a bad link is one that goes nowhere, and this one went somewhere.**

It had already shipped: `dmarx/anthology-of-the-sota` ADR-015 carried `LU-[#173](…/anthology-of-the-sota/issues/173)`, written meaning luria's #173 and pointing at the anthology's own. Through review, `link --fix`, `lint` and a merge to `main` — found only because the same mistake was made a second time and noticed by eye.

## Two halves, and the second was the actual bug

**Construction** — `remotes.issue_link`, defaulting to GitHub's convention for a remote with a `repo`, overridable with a new `[luria.remotes.X] issue_url` for another forge. Same bargain the `uris` table already makes for documents: a different forge is a line of config, not a subsystem.

**Scanning** — this is where the bug actually lived. `ISSUE_RE` read `#193` out of the middle of `LU-#193`, so even a correct constructor would never have been reached. The remote reference now claims its whole span first, which is exactly what `find_refs` already does for `LU-ADR-013` and explains in a comment written for that case:

> Remotes first: `LU-ADR-013` must claim its whole span before the local ADR pattern reads the tail out of the middle of it.

The pattern is built from the declared remotes, so an undeclared prefix stays ordinary prose followed by a local issue number — `FOO-#5` is unchanged.

## Where it deliberately does nothing

A remote with no `repo` and no `issue_url` — `ARXIV`, `FX` — resolves to nothing, and the reference is left **bare**. An arXiv identifier has no issue tracker, and inventing one would move the silent wrongness somewhere new rather than remove it.

## Fired on the real corpus

Against the anthology's actual `luria.toml`, not a fixture:

```
issue_link('LU', 194)   -> https://github.com/dmarx/luria/issues/194
issue_link('ARXIV', 5)  -> ''
issue_link('FX', 5)     -> ''

linkify: Filed upstream as [LU-#194](https://github.com/dmarx/luria/issues/194),
         and locally as [#17](https://github.com/dmarx/anthology-of-the-sota/issues/17).
```

## The shape worth remembering

A guard that only asks *"does this resolve"* cannot see a reference that resolves to the **wrong thing**. `unresolved-codes` has the same blind spot by construction, and `source-mismatch` exists because the same question came up for titles. That's in the devlog.

## Checks

`python -m pytest tests -q` → **932 passed** (6 new). `luria link --fix`, `luria index`, `luria lint` → clean.

After this releases, the anthology's two hand-written workarounds can go back to `LU-#173` / `LU-#193` and be spelled by the fixer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_