### PR TITLE
A temporary code is a code the status checker can see

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ a paragraph, and re-derived cold it costs a session.
   changelog line: the root cause, the approach that failed, the trap you
   fell into.
 - `luria new adr --title "…"` — a decision document, when you chose
-  between real alternatives. It gets a temporary code (`ADR-tmpxxxxx`);
+  between real alternatives. It gets a temporary code <!-- unresolved-ok: ADR-tmpxxxxx — a placeholder tail, not a document -->
+  (`ADR-tmpxxxxx`);
   CI assigns the real number when the merge serializes on `main`, so
   parallel branches never collide on one.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ drift from their sources.
 
 <!-- luria:badges -->
 [![needs decision: 3](https://img.shields.io/badge/needs%20decision-3-orange)](docs/reports/pending-decisions.md)
-[![cited, not in force: 0](https://img.shields.io/badge/cited,%20not%20in%20force-0-brightgreen)](docs/reports/reference-status.md)
+[![cited, not in force: 1](https://img.shields.io/badge/cited,%20not%20in%20force-1-orange)](docs/reports/reference-status.md)
 <!-- /luria:badges -->
 
 <!-- luria:site -->
@@ -71,6 +71,7 @@ Python 3.11+. Two runtime dependencies (PyYAML, fire).
 
 ## Sixty seconds
 
+<!-- unresolved-ok-block: ADR-tmp3kf9x — the transcript's minted temporary code -->
 ```console
 $ luria init --dry-run                      # what would it add?
 $ luria init                                # issue_url comes from your remote

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -314,6 +314,7 @@ scheduled CI job wants.
 luria concretize [--check]
 ```
 
+<!-- unresolved-ok-block: ADR-tmp3kf9x — an illustrative temporary code, not a citation -->
 For schemes with `allocate = "merge"`: assign each temporary code
 (`ADR-tmp3kf9x`) the next real number, rename the file, rewrite every
 reference in docs and scanned code, and record the old spelling under

--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-34 entries. [All books](README.md).
+35 entries. [All books](README.md).
 
 ## Contents
 
@@ -40,6 +40,7 @@
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](#20260907015341)
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](#20260907030258)
 - [7 Sep 04:40 — The link that resolved to the wrong project](#20260907044002)
+- [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](#20260907053505)
 
 ---
 
@@ -2244,3 +2245,68 @@ rather than remove it.
 Fired against the anthology's real configuration rather than a fixture:
 `LU-#194` to luria's tracker, a bare `#17` still to the anthology's, `ARXIV`
 and `FX` to nothing.
+
+---
+
+<a name="20260907053505"></a>
+
+## A temporary code is a code to link, and was not one to check
+
+*2026-09-07 05:35:05*
+
+Two blind spots, both of which had to hold for the finding to stay hidden.
+
+`Scheme.documents()` keys by number and skips any file it cannot get one
+from, so a `SOTA-tmpauaby.md` never reached `ref_status.load_docs()` —
+even though the file carried `status: Proposed` in its own frontmatter the
+whole time. And `ref_status.CODE_RE` required digits, so the citing site
+was not a site. A `Proposed` document could be cited as settled
+architecture from a sibling filed on the same branch, and the lint said
+nothing until `luria concretize` gave both real numbers.
+
+The issue floated widening `documents()` to a union return type, which
+five call sites had deliberately been consolidated onto. It turned out not
+to be needed: `adr_index.load_scheme(scheme)` already returns numbered
+documents plus temporary ones, and `Adr.code` already spells either. The
+fix is to ask that function the question instead of re-deriving it —
+`documents()` still answers "every numbered document", which is a
+different question and still the right one for its callers.
+
+## What it found on its first run
+
+Five comments across `config.py`, `contract.py`, `init.py`, `site.py` and
+`statuses.py` cited `ADR-tmpstat1`. No document has ever answered to that
+tail — it is not a minted one, and it is in no `formerly:` list. It was
+hand-written as a placeholder for the decision that became [ADR-085](../../record/decisions.d/ADR-085.md), and
+because nothing scanned temporary codes, five source files claimed a
+decision explained them and nothing said the claim resolved nowhere.
+
+Correcting them to `ADR-085` then raised the *real* finding underneath:
+[ADR-085](../../record/decisions.d/ADR-085.md) is `Proposed`, and the code that implements it ships on the trunk
+citing it as settled. That is the drift the module exists to report, left
+visible rather than acknowledged — an `inactive-ok:` here would go stale
+the moment the decision is accepted.
+
+## The one-time cost, and where it lands
+
+The check is unmasked by design, so an *illustration* of the temporary
+shape reads as a citation: `ADR-tmp47fje` in [ADR-049](../../record/decisions.d/ADR-049.md)'s prose, `ADR-tmp3kf9x`
+in the README transcript, fixture tails in the tests. Eleven sites here,
+cleared with nine `unresolved-ok` acknowledgements. Placement caught me
+twice, both times the scope rule doing its job: a directive inside a module
+*docstring* is not a comment and does not fire, and a directive one line
+above a comment run needs `-block`, not line scope.
+
+Every record that documents merge allocation pays the same cost once. The
+anthology has exactly one — `LIT-tmp3kf9x` in its [ADR-013](../../record/decisions.d/ADR-013.md) — and the
+acknowledgement has to be filed *with* the version bump: on the older
+luria the code is not scanned, so the directive excuses nothing and gets
+reported as stale.
+
+## Fired before trusting
+
+Beyond the five unit tests: on this record, where it found the
+`ADR-tmpstat1` comments; and on `anthology-of-the-sota`, where filing a
+`Proposed` practice with `luria new sota` and citing it from SOTA-145
+produced `SOTA-tmp14p3h is Proposed, cited 1× in 1 file(s)` — the finding
+[#203](https://github.com/dmarx/luria/issues/203) says arrived a merge too late.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](2026-09.md#20260907053505)
 - [7 Sep 04:40 — The link that resolved to the wrong project](2026-09.md#20260907044002)
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](2026-09.md#20260907030258)
 - [7 Sep 01:53 — The properties panel cannot show what the record line is for](2026-09.md#20260907015341)
@@ -43,9 +44,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-80 entries across 2 books, newest first.
+81 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 34 | 2026-09-03 | 2026-09-07 |
+| [2026-09](2026-09.md) | 35 | 2026-09-03 | 2026-09-07 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/docs/project-memory.md
+++ b/docs/project-memory.md
@@ -328,7 +328,7 @@ reported and enforced, per class, without ever silencing the account.
 
 ## Numbering without collisions
 
-<!-- unresolved-ok: ADR-158 — an illustrative collision, not a citation -->
+<!-- unresolved-ok-block: ADR-158, ADR-tmp3kf9x — illustrative codes, not citations -->
 Sequential numbers collide: two branches both file `ADR-158`, and one of
 them is renumbering after the merge. A scheme with `allocate = "merge"`
 sidesteps this — `luria new` mints a **temporary code**

--- a/docs/reports/pending-decisions.md
+++ b/docs/reports/pending-decisions.md
@@ -9,12 +9,12 @@
 
 | Open since | Status | Code | Cited | Unack. | Title |
 |---|---|---|--:|--:|---|
+| 2026-09-06 | Proposed | [ADR-085](../../record/decisions.d/ADR-085.md) | 5 | 5 | Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote |
 | 2026-09-06 | Proposed | [ADR-084](../../record/decisions.d/ADR-084.md) | 0 | 0 | A relation declares its converse; symmetry is the self-converse case |
-| 2026-09-06 | Proposed | [ADR-085](../../record/decisions.d/ADR-085.md) | 0 | 0 | Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote |
 | 2026-09-07 | Proposed | [ADR-086](../../record/decisions.d/ADR-086.md) | 0 | 0 | A marked region is how the README carries a derived fact |
 
 The citation count is the second axis, and it flips the priority: an old proposal nothing references is a stalled idea worth closing, while an old proposal many files cite is a decision the codebase has already made and hasn't written down.
 
 This count and the reference-status report's will differ, and that is not an off-by-one. That report covers documents something actually **cites** and hasn't acknowledged; this one covers every **undecided** document. One here is missing from there for exactly one of two reasons: nothing cites it, or every citation carries an `inactive-ok` annotation.
 
-**Cited nowhere at all** (3): [ADR-084](../../record/decisions.d/ADR-084.md), [ADR-085](../../record/decisions.d/ADR-085.md), [ADR-086](../../record/decisions.d/ADR-086.md) — these are the cheapest to close, since nothing depends on the answer.
+**Cited nowhere at all** (2): [ADR-084](../../record/decisions.d/ADR-084.md), [ADR-086](../../record/decisions.d/ADR-086.md) — these are the cheapest to close, since nothing depends on the answer.

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -9,7 +9,7 @@ Every reference in the record is a claim — "this is why things are the way the
 
 Only an `Active` document is in force. `Proposed` and `Deferred` mean *not in force yet* — an open question, being cited as if it were settled — while `Superseded` and `Rejected` mean *no longer in force*, which is often a perfectly good thing to cite: history, or a rejection worth pointing at. Either way the citation should be deliberate, and this section lists the ones nobody has vouched for yet.
 
-**0 documents cited without acknowledgement.** Not listed: 52 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
+**1 document cited without acknowledgement.** Not listed: 52 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
 
 To vouch for one, put the reason where the citation is — `inactive-ok:` covers its own line and the line below it, `inactive-ok-block:` its paragraph, `inactive-ok-file:` the whole page:
 
@@ -17,17 +17,28 @@ To vouch for one, put the reason where the citation is — `inactive-ok:` covers
 <!-- inactive-ok: ADR-012 — why this citation is right -->
 ```
 
-Nothing unacknowledged. ✅
+### [ADR-085](../../record/decisions.d/ADR-085.md) — Proposed
+
+Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote
+
+5 citations in 5 files await a look.
+
+- [`luria/config.py:399`](../../luria/config.py)
+- [`luria/contract.py:156`](../../luria/contract.py)
+- [`luria/init.py:383`](../../luria/init.py)
+- [`luria/site.py:477`](../../luria/site.py)
+- [`luria/statuses.py:47`](../../luria/statuses.py)
+
 ## Codes that resolve to no document
 
 A reference the reader cannot follow: the code names no document in this record. A typo, a number carried in from another project, and an illustrative code in an example all look identical from here — telling them apart takes a human, so this is a report, not an error.
 
-**1 code unaccounted for.** Not listed: 58 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
+**1 code unaccounted for.** Not listed: 87 mentions marked deliberate with an `unresolved-ok:` comment (same syntax and scopes as `inactive-ok:` above).
 
 
 ### ADR-000 — resolves to nothing (1 unmarked site · 2 other mentions marked deliberate)
 
-- [`tests/test_lint.py:417`](../../tests/test_lint.py)
+- [`tests/test_lint.py:420`](../../tests/test_lint.py)
 
 ## Files that opt out of reference checking
 

--- a/luria/adr_index.py
+++ b/luria/adr_index.py
@@ -50,6 +50,7 @@ import yaml
 
 from .config import current
 
+# unresolved-ok: ADR-tmp47fje — ADR-049's example of the shape, not a document
 # The tail accepts a temporary code (`ADR-tmp47fje`, ADR-049) as well as a
 # number: both are codes a heading legitimately carries.
 TITLE_RE = re.compile(r"^#\s*[A-Z]+-[A-Za-z0-9]+\s*(?::|—|-)\s*")

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -40,8 +40,9 @@ always wrong and mechanically fixable — run this command — so it fails
 outright, which is ADR-035's bar for a check that may fail a build.
 """
 
-# unresolved-ok-file: ADR-123 — a demonstration code in the docstring above,
-# standing in for the number a temporary code concretizes onto
+# unresolved-ok-file: ADR-tmp47fje, ADR-123 — demonstration codes in the
+# docstring above: ADR-049's worked example of the temporary shape, and the
+# number it stands in for once concretized. Neither names a document.
 
 from __future__ import annotations
 

--- a/luria/config.py
+++ b/luria/config.py
@@ -190,6 +190,7 @@ def _merge(base: dict, override: dict) -> dict:
     return out
 
 
+# unresolved-ok-block: ADR-tmp47fje — ADR-049's example of the shape, not a document
 # A temporary code's tail: a literal `tmp` sentinel plus five base-36
 # characters — `ADR-tmp47fje`. The alphabetic start keeps the numeric and
 # temporary patterns disjoint by construction, and the spelled-out sentinel
@@ -395,7 +396,7 @@ class Scheme:
     prefix: str
     dir: Path
     active: str = "Active"
-    # The retirement pair, defaults rather than laws (ADR-tmpstat1). A
+    # The retirement pair, defaults rather than laws (ADR-085). A
     # project whose decisions are `Supplanted` and point at their
     # replacement through `supplanted_by:` says so here, and every check,
     # edge and rendering follows its words. `active` set the precedent long
@@ -421,6 +422,7 @@ class Scheme:
     # behaviour: `luria new` takes the next free number on the spot — right
     # for a single-writer record, and a distributed claim on a global counter
     # the moment branches are concurrent. "merge" issues a temporary code
+    # unresolved-ok: ADR-tmp47fje — ADR-049's example of the shape
     # instead (`ADR-tmp47fje`, visibly provisional and never a number), and
     # `luria concretize` — run wherever merges serialize — assigns the real
     # numbers in merge order and records each temporary code as a permanent

--- a/luria/contract.py
+++ b/luria/contract.py
@@ -153,7 +153,7 @@ def built_in(scheme) -> tuple[Field, ...]:
     """The fields a scheme gets without asking — today, the one naming what
     replaced a retired document.
 
-    A **default**, not a law (ADR-tmpstat1). The field's name and the status
+    A **default**, not a law (ADR-085). The field's name and the status
     that demands it come from the scheme (`successor` and `retires_on`,
     themselves defaulting to `superseded_by` and `Superseded`), and a scheme
     declaring the field in its own `references` table replaces this outright

--- a/luria/doc_refs.py
+++ b/luria/doc_refs.py
@@ -474,6 +474,7 @@ def find_refs(text: str, path: Path = ANY_MD) -> list[Ref]:
     patterns: list[tuple[str, str, re.Pattern]] = [("scheme", dp_prefix, DP_RE)] \
         if dp_prefix else []
     patterns += [("scheme", s.prefix, s.pattern) for s in schemes.values()]
+    # unresolved-ok: ADR-tmp47fje — ADR-049's example of the shape
     # Temporary codes (ADR-049): `ADR-tmp47fje`, the merge-allocated shape.
     # Matched for every scheme, not just merge-allocated ones — a temp code
     # can outlive its scheme's dial via an `formerly:` alias, and a reference's

--- a/luria/init.py
+++ b/luria/init.py
@@ -380,7 +380,7 @@ def _scheme_files(scheme: Scheme) -> dict[Path, str]:
 
 
 # What each status means, written into the scaffold rather than inherited
-# from the code (ADR-tmpstat1). The five are a default, and a default nobody
+# from the code (ADR-085). The five are a default, and a default nobody
 # can read is the trap `template-drift` and `inert-status` were both filed
 # about: a capability that is live, enforced and invisible. Editing this file
 # changes what the lint accepts — that is the point of writing it.

--- a/luria/ref_status.py
+++ b/luria/ref_status.py
@@ -70,7 +70,7 @@ from typing import Callable
 
 from . import adr_index as builder
 from . import directives, doc_refs, remotes
-from .config import current
+from .config import TEMP_TAIL, current, is_temp_tail
 
 DEFAULT_SITES = 5
 
@@ -106,13 +106,19 @@ def _load_scheme(scheme) -> dict[str, Doc]:
     """Every document in one scheme's directory, with its status.
 
     Frontmatter-with-a-`status:` is the only contract a scheme has to meet, so
-    a second scheme is a directory and a prefix — not a code change (ADR-006)."""
+    a second scheme is a directory and a prefix — not a code change (ADR-006).
+
+    Merge-allocated documents (ADR-049) are loaded alongside the numbered
+    ones. Reading the directory by number skipped them, and a document the
+    checker holds no record of reads as a code that names nothing — so a
+    `Proposed` decision could be cited as settled and nothing said so until
+    `luria concretize` gave it a number, on `main`, in a file nobody had
+    touched (#203). Its status was in its frontmatter the whole time."""
     docs: dict[str, Doc] = {}
-    for number, path in scheme.documents().items():
-        doc = builder.Adr(path, scheme)
+    for doc in builder.load_scheme(scheme):
         status = doc.status_value
-        code = scheme.code(number)
-        docs[code] = Doc(code, status, doc.title, path, status == scheme.active)
+        docs[doc.code] = Doc(doc.code, status, doc.title, doc.path,
+                             status == scheme.active)
     return docs
 
 
@@ -132,7 +138,7 @@ def load_docs() -> dict[str, Doc]:
 # Full codes only — a bare number is rejected. It reads as an ADR here and as
 # something else in the next repo that borrows this; requiring the prefix is
 # what lets one vocabulary serve more than one reference scheme.
-CODE_RE = re.compile(r"\b([A-Za-z]{2,10})-(\d{1,4})\b")
+CODE_RE = re.compile(rf"\b([A-Za-z]{{2,10}})-(\d{{1,4}}|{TEMP_TAIL})\b")
 BARE_NUMBER_RE = re.compile(r"(?<![\w-])\d{1,4}(?![\w-])")
 URL_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s<>)\]\"']+", re.IGNORECASE)
 DIRECTIVE = "inactive-ok"
@@ -153,7 +159,8 @@ def _codes(spec: str) -> tuple[set[str], str]:
         codes.add(ref.composed)
     for ref in sorted(refs, key=lambda r: r.start, reverse=True):
         spec = spec[:ref.start] + " " * (ref.end - ref.start) + spec[ref.end:]
-    codes |= {f"{p.upper()}-{int(n):03d}" for p, n in CODE_RE.findall(spec)}
+    codes |= {f"{p.upper()}-{n}" if is_temp_tail(n) else f"{p.upper()}-{int(n):03d}"
+              for p, n in CODE_RE.findall(spec)}
     return codes, spec
 
 
@@ -335,6 +342,8 @@ def scan(files: list[Path] | None = None, docs: dict[str, Doc] | None = None) ->
             for scheme in schemes().values():
                 codes |= {scheme.code(m.group("num"))
                           for m in scheme.pattern.finditer(bare)}
+                codes |= {f"{scheme.prefix}-{m.group('tail')}"
+                          for m in scheme.temp_pattern.finditer(bare)}
             for code in codes:
                 if own.get(path) == code:
                     continue

--- a/luria/site.py
+++ b/luria/site.py
@@ -474,7 +474,7 @@ def _alias(path: Path, cfg) -> str | None:
 # How an inbound edge reads on the page it lands on. A declared reference
 # field has no built-in inverse, so it is named for the field.
 #
-# The successor field is the scheme's to name (ADR-tmpstat1), so the label
+# The successor field is the scheme's to name (ADR-085), so the label
 # follows the role rather than the word: a project retiring documents into
 # `supplanted_by:` still reads "Supersedes" on the page that replaced one,
 # because that is what the edge means.

--- a/luria/statuses.py
+++ b/luria/statuses.py
@@ -44,7 +44,7 @@ from dataclasses import dataclass
 
 import yaml
 
-# ADR-003's five, kept as the DEFAULT rather than the law (ADR-tmpstat1).
+# ADR-003's five, kept as the DEFAULT rather than the law (ADR-085).
 # A project whose decisions are `Accepted` and `Withdrawn` says so in its own
 # `statuses.yaml`, and every check follows its words. What generic code needs
 # is not a word but a role: which status means *in force*, and that is

--- a/record/changelog.d/20260907-053505.md
+++ b/record/changelog.d/20260907-053505.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- `luria lint` checks the standing of references to merge-allocated
+  documents. `ref_status` loaded a scheme by number and matched codes by
+  digits, so a temporary code ([ADR-049](record/decisions.d/ADR-049.md)) was neither a document nor a citation
+  site: for the whole life of the pull request that files them, citations
+  among merge-allocated documents went unchecked, and the findings surfaced
+  only after the merge that concretized the codes — on the trunk, in files
+  nobody was editing ([#203](https://github.com/dmarx/luria/issues/203)). `luria link --fix` had handled temporary codes
+  all along; the two halves of the reference system disagreed about whether a
+  temporary code is a code, and only one of them said so.
+
+### Changed
+
+- Five source comments cited `ADR-tmpstat1`, a temporary code that never
+  named a document; the decision they meant is [ADR-085](record/decisions.d/ADR-085.md). The checker above
+  found them on its first run.
+
+  A record that spells out the temporary shape in prose — a decision that
+  defines it, a README transcript, a CLI page — has illustrative codes that
+  now resolve to nothing, and each wants an `unresolved-ok:` acknowledgement
+  once. File them with the upgrade, not before: on the older version the
+  directive excuses nothing and is reported stale.

--- a/record/decisions.d/ADR-049.md
+++ b/record/decisions.d/ADR-049.md
@@ -41,6 +41,8 @@ summary: >-
 
 # ADR-049: Temporary codes at filing; concretized and aliased at the serialization point
 
+<!-- unresolved-ok-file: ADR-tmp47fje — the worked example of the shape this decision defines; it names no document anywhere, on purpose -->
+
 ## Context
 
 A sequential code is a claim on a global counter, and filing-time numbering

--- a/record/devlog.d/2026/09/07/053505.md
+++ b/record/devlog.d/2026/09/07/053505.md
@@ -1,0 +1,62 @@
+---
+title: 'A temporary code is a code to link, and was not one to check'
+created: '2026-09-07T05:35:05'
+tags: []
+---
+
+Two blind spots, both of which had to hold for the finding to stay hidden.
+
+`Scheme.documents()` keys by number and skips any file it cannot get one
+from, so a `SOTA-tmpauaby.md` never reached `ref_status.load_docs()` —
+even though the file carried `status: Proposed` in its own frontmatter the
+whole time. And `ref_status.CODE_RE` required digits, so the citing site
+was not a site. A `Proposed` document could be cited as settled
+architecture from a sibling filed on the same branch, and the lint said
+nothing until `luria concretize` gave both real numbers.
+
+The issue floated widening `documents()` to a union return type, which
+five call sites had deliberately been consolidated onto. It turned out not
+to be needed: `adr_index.load_scheme(scheme)` already returns numbered
+documents plus temporary ones, and `Adr.code` already spells either. The
+fix is to ask that function the question instead of re-deriving it —
+`documents()` still answers "every numbered document", which is a
+different question and still the right one for its callers.
+
+## What it found on its first run
+
+Five comments across `config.py`, `contract.py`, `init.py`, `site.py` and
+`statuses.py` cited `ADR-tmpstat1`. No document has ever answered to that
+tail — it is not a minted one, and it is in no `formerly:` list. It was
+hand-written as a placeholder for the decision that became [ADR-085](../../record/decisions.d/ADR-085.md), and
+because nothing scanned temporary codes, five source files claimed a
+decision explained them and nothing said the claim resolved nowhere.
+
+Correcting them to `ADR-085` then raised the *real* finding underneath:
+[ADR-085](../../record/decisions.d/ADR-085.md) is `Proposed`, and the code that implements it ships on the trunk
+citing it as settled. That is the drift the module exists to report, left
+visible rather than acknowledged — an `inactive-ok:` here would go stale
+the moment the decision is accepted.
+
+## The one-time cost, and where it lands
+
+The check is unmasked by design, so an *illustration* of the temporary
+shape reads as a citation: `ADR-tmp47fje` in [ADR-049](../../record/decisions.d/ADR-049.md)'s prose, `ADR-tmp3kf9x`
+in the README transcript, fixture tails in the tests. Eleven sites here,
+cleared with nine `unresolved-ok` acknowledgements. Placement caught me
+twice, both times the scope rule doing its job: a directive inside a module
+*docstring* is not a comment and does not fire, and a directive one line
+above a comment run needs `-block`, not line scope.
+
+Every record that documents merge allocation pays the same cost once. The
+anthology has exactly one — `LIT-tmp3kf9x` in its [ADR-013](../../record/decisions.d/ADR-013.md) — and the
+acknowledgement has to be filed *with* the version bump: on the older
+luria the code is not scanned, so the directive excuses nothing and gets
+reported as stale.
+
+## Fired before trusting
+
+Beyond the five unit tests: on this record, where it found the
+`ADR-tmpstat1` comments; and on `anthology-of-the-sota`, where filing a
+`Proposed` practice with `luria new sota` and citing it from SOTA-145
+produced `SOTA-tmp14p3h is Proposed, cited 1× in 1 file(s)` — the finding
+[#203](https://github.com/dmarx/luria/issues/203) says arrived a merge too late.

--- a/tests/test_concretize.py
+++ b/tests/test_concretize.py
@@ -8,8 +8,8 @@ of this machinery found a crash (`render_categories` formatting a number that
 temp docs don't have) that no unit test of the minter would have seen.
 """
 
-# unresolved-ok-file: ADR-000 — the assertion below matches on the string
-# `[ADR-0`, which the reference scanner reads as a code
+# unresolved-ok-file: ADR-000, ADR-tmpab123 — the first is the string `[ADR-0`,
+# which the reference scanner reads as a code; the second is a fixture tail
 import re
 import subprocess
 from pathlib import Path

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -12,6 +12,9 @@ remedy available here is rung 2 — keep the copy, guard the property that they
 agree. So the guard needs firing, not just provisioning
 ([DP-6](../docs/design-principles.md#dp-6)).
 """
+
+# unresolved-ok-file: ADR-tmpabcde — a fixture temporary code, deliberately
+# naming no document: what is under test is the shape reaching a workflow file.
 import sys
 
 import pytest

--- a/tests/test_ref_status.py
+++ b/tests/test_ref_status.py
@@ -14,7 +14,8 @@ from _scheme import decision
 from luria import ref_status
 from luria.config import current
 
-# unresolved-ok-file: ADR-920 ADR-777 — fixture codes, deliberately not real
+# unresolved-ok-file: ADR-920 ADR-777 ADR-tmpab12c — fixture codes,
+# deliberately not real
 REPO = Path(__file__).resolve().parents[1]
 
 
@@ -351,3 +352,75 @@ def test_a_frontmatter_site_without_a_comment_is_still_reported(project):
     site, = result.cited["ADR-012"]
     assert site.excused_by is None
     assert [d.code for d, _, _ in ref_status.flagged(result, docs)] == ["ADR-012"]
+
+
+# ── Merge-allocated documents have standing too (#203) ───────────────────
+
+def temp_decision(root: Path, tail: str, status: str,
+                  title: str = "A decision") -> Path:
+    """A merge-allocated document, before `luria concretize` numbers it."""
+    scheme = current().schemes["ADR"]
+    path = scheme.dir / f"ADR-{tail}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nstatus: {status}\ntitle: {title!r}\ntags:\n- record\n"
+                    f"date: '2026-01-01'\n---\n\n# ADR-{tail}: {title}\n\nBody.\n")
+    return path
+
+
+def test_a_temp_coded_document_is_loaded_with_its_status(project):
+    """It was not, and the file carried a status the whole time.
+
+    `Scheme.documents()` keys by number and skips a file it cannot get one
+    from, so a merge-allocated document never reached `load_docs()` and the
+    status checker held no record of it — not "no status", no document."""
+    temp_decision(project, "tmpab12c", "Proposed")
+    docs = ref_status.load_docs()
+    assert "ADR-tmpab12c" in docs
+    assert docs["ADR-tmpab12c"].status == "Proposed"
+    assert docs["ADR-tmpab12c"].active is False
+
+
+def test_a_temp_code_is_a_citation_site(project):
+    """The other half. `CODE_RE` required digits, so the citing text was not
+    a site either — both blind spots had to hold, and both did."""
+    temp_decision(project, "tmpab12c", "Proposed")
+    decision(project, 1, "Active")
+    (project / "notes.md").write_text("see ADR-tmpab12c for the argument\n")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([project / "notes.md"], docs)
+    assert "ADR-tmpab12c" in result.cited
+
+
+def test_citing_a_proposed_temp_document_is_reported(project):
+    """The finding the anthology only saw after its merge concretized the
+    codes, on `main`, in a file nobody was editing."""
+    temp_decision(project, "tmpab12c", "Proposed")
+    decision(project, 1, "Active")
+    (project / "notes.md").write_text("see ADR-tmpab12c for the argument\n")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([project / "notes.md"], docs)
+    assert [d.code for d, _, _ in ref_status.flagged(result, docs)] \
+        == ["ADR-tmpab12c"]
+
+
+def test_an_acknowledgement_covers_a_temp_code(project):
+    """Whatever the checker can report, a directive has to be able to
+    excuse — otherwise the finding is one nobody can clear."""
+    temp_decision(project, "tmpab12c", "Proposed")
+    decision(project, 1, "Active")
+    (project / "notes.md").write_text(
+        "<!-- inactive-ok: ADR-tmpab12c — deliberate -->\n"
+        "see ADR-tmpab12c for the argument\n")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([project / "notes.md"], docs)
+    assert ref_status.flagged(result, docs) == []
+
+
+def test_an_active_temp_document_is_not_flagged(project):
+    """Being temporary is not being retired."""
+    temp_decision(project, "tmpab12c", "Active")
+    decision(project, 1, "Active")
+    (project / "notes.md").write_text("see ADR-tmpab12c\n")
+    docs = ref_status.load_docs()
+    result = ref_status.scan([project / "notes.md"], docs)
+    assert ref_status.flagged(result, docs) == []


### PR DESCRIPTION
Closes #203.

Options (1)+(2) from the issue. `luria link --fix` has always treated a merge-allocated code as a code; `ref_status` never did, and the halves disagreeing was the bug.

## The fix

The issue worried that (1) means widening `documents()`, whose `dict[int, Path]` return five call sites were deliberately consolidated onto. It doesn't. `adr_index.load_scheme(scheme)` already returns numbered documents *plus* temporary ones, and `Adr.code` already spells either — so `ref_status._load_scheme` asks that function instead of re-deriving the answer, and `documents()` keeps answering "every *numbered* document", which is a different question and still the right one for its callers.

- `CODE_RE` composes `config.TEMP_TAIL` rather than restating the shape.
- The scan loop runs each scheme's `temp_pattern` alongside its numeric one.
- `_codes()` (which parses a directive's arguments) keeps temporary tails whole instead of `int()`-ing them, so an acknowledgement can name one.

Five tests, written first, three of which failed for the right reasons before the change.

## What it found on its first run here

**Five source comments cited `ADR-tmpstat1`** — in `config.py`, `contract.py`, `init.py`, `site.py` and `statuses.py`. No document has ever answered to that tail: it is not a minted one and it is in no `formerly:` list. It was hand-written as a placeholder for the decision that became ADR-085, and because nothing scanned temporary codes, five source files claimed a decision explained them while the claim resolved nowhere. Corrected to `ADR-085`.

**That surfaced the finding underneath, which this PR leaves visible:**

```
luria: 1 warning(s) — retired documents cited unacknowledged from current docs/code
  ADR-085 is Proposed, cited 5× in 5 file(s) — Status is an ordinary controlled
  vocabulary; a built-in is a declaration nobody wrote
```

ADR-085 shipped; it is still `Proposed`. That is exactly the drift the module exists to report, so it is not acknowledged — an `inactive-ok:` would go stale the moment the decision is accepted. `pending-documents` now reads *"3 undecided document(s), oldest 1 days, 1 with unacknowledged references"*. Accepting ADR-085 (and 084, 086) clears it. Warning class, so CI is unaffected.

## The one-time cost

The check is unmasked by design, so an *illustration* of the temporary shape reads as a citation. Eleven sites here — ADR-049's prose, the README transcript, the CLI page, `CONTRIBUTING.md`, fixture tails in three test files — cleared with nine `unresolved-ok` acknowledgements.

**Every record that documents merge allocation pays this once.** `anthology-of-the-sota` has exactly one (`LIT-tmp3kf9x`, in its ADR-013), and the acknowledgement has to be filed *with* the version bump: on the older luria the code is not scanned, so the directive excuses nothing and gets reported stale.

## Fired before trusting (DP-6)

- On this record, where it found the `ADR-tmpstat1` comments.
- On `anthology-of-the-sota`: filed a `Proposed` practice with `luria new sota`, cited it from SOTA-145, and got `SOTA-tmp14p3h is Proposed, cited 1× in 1 file(s)` — the finding #203 says arrived a merge too late. Probe reverted.

`python -m pytest tests -q` → 937 passed. `luria lint` → the ADR-085 warning above, otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_