### PR TITLE
A chain step renders under the parent it extends

### DIFF
--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-35 entries. [All books](README.md).
+36 entries. [All books](README.md).
 
 ## Contents
 
@@ -41,6 +41,7 @@
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](#20260907030258)
 - [7 Sep 04:40 — The link that resolved to the wrong project](#20260907044002)
 - [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](#20260907053505)
+- [7 Sep 16:55 — The chain page encoded depth but not parentage](#20260907165522)
 
 ---
 
@@ -2310,3 +2311,62 @@ Beyond the five unit tests: on this record, where it found the
 `Proposed` practice with `luria new sota` and citing it from SOTA-145
 produced `SOTA-tmp14p3h is Proposed, cited 1× in 1 file(s)` — the finding
 [#203](https://github.com/dmarx/luria/issues/203) says arrived a merge too late.
+
+---
+
+<a name="20260907165522"></a>
+
+## The chain page encoded depth but not parentage
+
+*2026-09-07 16:55:22*
+
+`lines_of` returned the spine sorted by `(depth, code)` and `_render`
+indented by depth. Nothing anywhere recorded which parent a step nests
+*under*, because for the chains that existed when the feature shipped it did
+not need to: one root, one parent per step, and a depth sort is a valid
+pre-order.
+
+Both assumptions broke the first time a consumer declared a real DAG.
+`anthology-of-the-sota` filed Gated DeltaNet as extending both Mamba-2 and
+DeltaNet — two parents, and therefore two roots in one weakly-connected
+group. Sorted by `(depth, code)` that group came out
+
+    LIT-161 (0)  LIT-195 (0)  LIT-162 (1)  LIT-137 (2)  LIT-165 (2)  LIT-133 (3)
+
+and indented by depth it reads as: Mamba-2 descends from DeltaNet, and Kimi
+Linear descends from Mamba-3. Neither is declared anywhere. Both are stated,
+confidently, in a generated file.
+
+## What makes this worth an entry
+
+The failure is silent and it is in a *view*. The sources were correct the
+whole time — `extends:` said exactly the right thing on every document — and
+`luria lint` was clean, because nothing checks that a rendering preserves the
+relation it renders. A reader would have had to open two notes and compare
+them against the page to notice, which is precisely the work the page exists
+to save.
+
+It is also a failure that gets *more* likely as a record gets better. Every
+chain is a tree until someone declares the second parent, and declaring the
+second parent is the thing you do when you understand the lineage properly.
+So the feature worked for as long as the records using it were thin.
+
+## The fix, and the part that is a judgement
+
+Emit each subtree depth-first from its root, so a step always follows the
+parent it nests under. Where a step has several parents, nest it under the
+**deepest** — it should sit beneath the most specific thing it extends, not
+the most ancestral — and name the rest inline: `— also extends LIT-195`.
+
+That last part is the judgement. A tree layout can draw one parent per node,
+so a DAG loses edges to the layout no matter how the order is chosen. The
+alternatives were to render the node once per parent (which duplicates
+subtrees and inflates the page) or to say nothing (which drops a declared
+fact from the only view that claims to show the line). Naming them is the
+cheap honest option: the page holds every edge, and only the *drawing* is a
+tree.
+
+Cycle members are appended after the depth-first walk rather than dropped.
+They are unreachable from any root by construction, and `rows()` already
+reports them; silently omitting them here would hide a finding behind a
+layout change.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [7 Sep 16:55 — The chain page encoded depth but not parentage](2026-09.md#20260907165522)
 - [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](2026-09.md#20260907053505)
 - [7 Sep 04:40 — The link that resolved to the wrong project](2026-09.md#20260907044002)
 - [7 Sep 03:02 — A title is data, and this record has one that reads as syntax](2026-09.md#20260907030258)
@@ -44,9 +45,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-81 entries across 2 books, newest first.
+82 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 35 | 2026-09-03 | 2026-09-07 |
+| [2026-09](2026-09.md) | 36 | 2026-09-03 | 2026-09-07 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/luria/chains.py
+++ b/luria/chains.py
@@ -67,6 +67,12 @@ class Line:
     alongside: list[Adr] = field(default_factory=list)
     # Each spine member's distance from a root, for the rendered nesting.
     depth: dict[str, int] = field(default_factory=dict)
+    # The parent each step renders *under*. The page indents by depth, so
+    # nesting only reads correctly when a step is emitted directly after
+    # this one; `_order` is what guarantees that. A step with several
+    # parents renders under one of them and names the rest.
+    under: dict[str, str] = field(default_factory=dict)
+    also: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def members(self) -> list[Adr]:
@@ -140,6 +146,52 @@ def _depths(group: list[str], spine: dict[str, list[str]]) -> dict[str, int]:
     return depth
 
 
+def _order(group: list[str], spine: dict[str, list[str]],
+           depth: dict[str, int]) -> tuple[list[str], dict[str, str],
+                                           dict[str, list[str]]]:
+    """The spine in render order: every step immediately after the parent it
+    nests under.
+
+    Sorting by `(depth, code)` is not enough, and the way it fails is silent.
+    The page carries nesting as indentation, so a step at depth d+1 reads as
+    a child of whatever step at depth d preceded it — which, under a plain
+    sort, is whichever one happened to sort last. One group with two roots,
+    or one step with two parents, and the page asserts a descent nobody
+    declared. Found in `anthology-of-the-sota`, where Kimi Linear rendered
+    as a descendant of Mamba-3 because Gated DeltaNet has two parents.
+
+    So: choose one parent per step — the deepest, ties broken by code, so a
+    step nests under the most specific thing it extends — and emit each
+    subtree depth-first from its root. The other parents are real and are
+    returned to be named rather than dropped."""
+    kids: dict[str, list[str]] = {c: [] for c in group}
+    under: dict[str, str] = {}
+    also: dict[str, list[str]] = {}
+    for code in sorted(group):
+        parents = [p for p in spine[code] if p in depth]
+        if not parents:
+            continue
+        best = sorted(parents, key=lambda p: (-depth[p], p))[0]
+        under[code] = best
+        kids[best].append(code)
+        rest = sorted(p for p in parents if p != best)
+        if rest:
+            also[code] = rest
+    order: list[str] = []
+    def emit(code: str) -> None:
+        order.append(code)
+        for kid in sorted(kids[code], key=lambda c: (depth[c], c)):
+            emit(kid)
+    for code in sorted(group, key=lambda c: (depth[c], c)):
+        if code not in under:
+            emit(code)
+    # A cycle leaves its members unreachable from any root; they are the
+    # `rows()` finding, and dropping them here would hide it.
+    order += [c for c in sorted(group, key=lambda c: (depth[c], c))
+              if c not in order]
+    return order, under, also
+
+
 def lines_of(chain) -> list[Line]:
     """Every sequence in one chain, spines ordered oldest first.
 
@@ -156,8 +208,9 @@ def lines_of(chain) -> list[Line]:
     out: list[Line] = []
     for group in _components(sorted(docs), neighbours):
         depth = _depths(group, spine)
-        line = Line(depth=depth)
-        for code in sorted(group, key=lambda c: (depth[c], c)):
+        order, under, also = _order(group, spine, depth)
+        line = Line(depth=depth, under=under, also=also)
+        for code in order:
             on_spine = bool(spine[code]) or any(code in spine[o] for o in group)
             (line.spine if on_spine else line.alongside).append(docs[code])
         out.append(line)
@@ -264,8 +317,13 @@ def _render(chain, lines: list[Line]) -> str:
         out.append(f"## From {head.title}")
         out.append("")
         for doc in line.spine:
+            # A step with several parents nests under one of them; the rest
+            # are named here so the page holds every declared edge, not the
+            # subset a tree layout can draw.
+            extra = line.also.get(doc.code, [])
+            tail = (f" — also extends {', '.join(extra)}" if extra else "")
             out.append("  " * line.depth[doc.code] + "- "
-                       + _step(doc, chain))
+                       + _step(doc, chain) + tail)
         for doc in line.alongside:
             out.append(_step(doc, chain, lead="- alongside: "))
         out.append("")

--- a/record/changelog.d/20260907-165427.md
+++ b/record/changelog.d/20260907-165427.md
@@ -1,0 +1,25 @@
+### Fixed
+
+- A chain page nested each step under whichever step at the parent depth
+  happened to precede it, rather than under the parent it actually extends.
+  The page carries nesting as indentation and `lines_of` ordered the spine by
+  `(depth, code)`, so the two agreed only by luck — for a single-root line
+  with one parent per step, which is every chain that existed when the
+  feature shipped.
+
+  With two roots in one group, or one step with two parents, the page
+  asserted a descent nobody declared, silently and in a generated file.
+  Found in `anthology-of-the-sota`: Kimi Linear rendered as a descendant of
+  Mamba-3, because Gated DeltaNet has two parents and the sort put the
+  siblings in an order the indentation then misread.
+
+  Steps are now emitted depth-first from each root, each directly after the
+  parent it nests under — the deepest of its parents, so a step nests under
+  the most specific thing it extends.
+
+### Added
+
+- A step with more than one parent names the others: `— also extends
+  LIT-195`. A tree layout can draw one parent per node, and the edges it
+  cannot draw are still declared, so the page says them rather than dropping
+  them.

--- a/record/devlog.d/2026/09/07/165522.md
+++ b/record/devlog.d/2026/09/07/165522.md
@@ -1,0 +1,56 @@
+---
+title: 'The chain page encoded depth but not parentage'
+created: '2026-09-07T16:55:22'
+tags: []
+---
+
+`lines_of` returned the spine sorted by `(depth, code)` and `_render`
+indented by depth. Nothing anywhere recorded which parent a step nests
+*under*, because for the chains that existed when the feature shipped it did
+not need to: one root, one parent per step, and a depth sort is a valid
+pre-order.
+
+Both assumptions broke the first time a consumer declared a real DAG.
+`anthology-of-the-sota` filed Gated DeltaNet as extending both Mamba-2 and
+DeltaNet — two parents, and therefore two roots in one weakly-connected
+group. Sorted by `(depth, code)` that group came out
+
+    LIT-161 (0)  LIT-195 (0)  LIT-162 (1)  LIT-137 (2)  LIT-165 (2)  LIT-133 (3)
+
+and indented by depth it reads as: Mamba-2 descends from DeltaNet, and Kimi
+Linear descends from Mamba-3. Neither is declared anywhere. Both are stated,
+confidently, in a generated file.
+
+## What makes this worth an entry
+
+The failure is silent and it is in a *view*. The sources were correct the
+whole time — `extends:` said exactly the right thing on every document — and
+`luria lint` was clean, because nothing checks that a rendering preserves the
+relation it renders. A reader would have had to open two notes and compare
+them against the page to notice, which is precisely the work the page exists
+to save.
+
+It is also a failure that gets *more* likely as a record gets better. Every
+chain is a tree until someone declares the second parent, and declaring the
+second parent is the thing you do when you understand the lineage properly.
+So the feature worked for as long as the records using it were thin.
+
+## The fix, and the part that is a judgement
+
+Emit each subtree depth-first from its root, so a step always follows the
+parent it nests under. Where a step has several parents, nest it under the
+**deepest** — it should sit beneath the most specific thing it extends, not
+the most ancestral — and name the rest inline: `— also extends LIT-195`.
+
+That last part is the judgement. A tree layout can draw one parent per node,
+so a DAG loses edges to the layout no matter how the order is chosen. The
+alternatives were to render the node once per parent (which duplicates
+subtrees and inflates the page) or to say nothing (which drops a declared
+fact from the only view that claims to show the line). Naming them is the
+cheap honest option: the page holds every edge, and only the *drawing* is a
+tree.
+
+Cycle members are appended after the depth-first walk rather than dropped.
+They are unreachable from any root by construction, and `rows()` already
+reports them; silently omitting them here would hide a finding behind a
+layout change.

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -474,3 +474,50 @@ output   = "docs/lineage.md"
 facet_by = ["status", "nowhere"]
 """)
         config.current()
+
+
+# --- the rendered order says who descends from whom (#207) -------------------
+
+def test_two_roots_in_one_group_each_keep_their_own_child(
+        tmp_path, monkeypatch):
+    """Two roots join one group through a shared descendant. The page
+    indents by depth, so if the order is not anchored to each node's parent
+    a child lands under whichever root happened to sort last — asserting a
+    descent nobody declared."""
+    root = project(tmp_path, monkeypatch)
+    note(root, 1, "Root A")
+    note(root, 2, "Child of A", extends=["LIT-001"])
+    note(root, 9, "Root B")
+    note(root, 3, "Child of both", extends=["LIT-002", "LIT-009"])
+    line, = chains.walk()
+    order = [d.code for d in line.spine]
+    # LIT-002's parent is LIT-001, so it must follow it rather than trailing
+    # the other root.
+    assert order.index("LIT-002") == order.index("LIT-001") + 1, order
+
+
+def test_a_child_follows_its_parent_not_its_parent_s_sibling(
+        tmp_path, monkeypatch):
+    """The shape that broke the anthology's Mamba line: two siblings at one
+    depth, and the child of the *first* rendered under the second."""
+    root = project(tmp_path, monkeypatch)
+    note(root, 1, "The root")
+    note(root, 2, "First sibling", extends=["LIT-001"])
+    note(root, 3, "Second sibling", extends=["LIT-001"])
+    note(root, 4, "Child of the first", extends=["LIT-002"])
+    line, = chains.walk()
+    order = [d.code for d in line.spine]
+    assert order.index("LIT-004") == order.index("LIT-002") + 1, order
+
+
+def test_a_second_parent_is_named_rather_than_dropped(tmp_path, monkeypatch):
+    """A node renders under one parent. The other edge is true and must not
+    vanish from the page just because the layout is a tree."""
+    root = project(tmp_path, monkeypatch)
+    note(root, 1, "Root A")
+    note(root, 9, "Root B")
+    note(root, 3, "Child of both", extends=["LIT-001", "LIT-009"])
+    page = chains.outputs()[root / "docs/lineage.md"]
+    assert "LIT-009" in page
+    under = [ln for ln in page.splitlines() if "LIT-003" in ln]
+    assert under and "also extends" in under[0].lower(), under


### PR DESCRIPTION
A chain page nested each step under whichever step at the parent depth happened to precede it, rather than under the parent it actually extends.

`lines_of` ordered the spine by `(depth, code)` and `_render` indents by depth. Nothing recorded which parent a step nests *under* — for the chains that existed when the feature shipped it didn't need to: one root, one parent per step, and a depth sort is a valid pre-order.

## How it surfaced

`anthology-of-the-sota` declared Gated DeltaNet as extending **both** Mamba-2 and DeltaNet. Two parents ⇒ two roots in one weakly-connected group:

```
LIT-161 (0)  LIT-195 (0)  LIT-162 (1)  LIT-137 (2)  LIT-165 (2)  LIT-133 (3)
```

Indented by depth, that renders as:

```
- LIT-161 — Mamba
- LIT-195 — DeltaNet
  - LIT-162 — Mamba-2          ← reads as descending from DeltaNet
    - LIT-137 — Gated DeltaNet
    - LIT-165 — Mamba-3
      - LIT-133 — Kimi Linear  ← reads as descending from Mamba-3
```

Neither descent is declared anywhere. Both were asserted, confidently, in a generated file.

After:

```
- LIT-161 — Mamba
  - LIT-162 — Mamba-2
    - LIT-137 — Gated DeltaNet — also extends LIT-195
      - LIT-133 — Kimi Linear
    - LIT-165 — Mamba-3
- LIT-195 — DeltaNet
```

## Why it's worth the devlog entry

The sources were **correct the whole time** — `extends:` said the right thing on every document — and `luria lint` was clean, because nothing checks that a rendering preserves the relation it renders. A reader would have had to open two notes and compare them against the page to catch it, which is the work the page exists to save.

And it gets *more* likely as a record improves. Every chain is a tree until someone declares the second parent, and declaring the second parent is what you do once you actually understand the lineage. The feature worked for exactly as long as the records using it were thin.

## The fix, and the judgement in it

Emit each subtree depth-first from its root, so a step always follows the parent it nests under. Where a step has several parents, nest it under the **deepest** — beneath the most specific thing it extends, not the most ancestral.

A tree layout can draw one parent per node, so a DAG loses edges to the layout however the order is chosen. Rendering the node once per parent duplicates subtrees; saying nothing drops a declared fact from the only view that claims to show the line. So the others are named inline — `— also extends LIT-195` — and the page holds every edge while only the *drawing* is a tree.

Cycle members are appended after the walk rather than dropped: they're unreachable from any root by construction and `rows()` already reports them, so omitting them here would hide a finding behind a layout change.

## Checks

Three tests written first, each failing for its own reason before the fix. `python3 -m pytest tests -q` → **940 passed**. `luria lint` → clean. Fired on the real anthology corpus, which is where the bug came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_