### PR TITLE
A chain's spine can be more than one relation

### DIFF
--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-36 entries. [All books](README.md).
+37 entries. [All books](README.md).
 
 ## Contents
 
@@ -42,6 +42,7 @@
 - [7 Sep 04:40 — The link that resolved to the wrong project](#20260907044002)
 - [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](#20260907053505)
 - [7 Sep 16:55 — The chain page encoded depth but not parentage](#20260907165522)
+- [7 Sep 20:08 — Firing a two-relation spine on a real record, and what hid a config error](#20260907200808)
 
 ---
 
@@ -2370,3 +2371,60 @@ Cycle members are appended after the depth-first walk rather than dropped.
 They are unreachable from any root by construction, and `rows()` already
 reports them; silently omitting them here would hide a finding behind a
 layout change.
+
+---
+
+<a name="20260907200808"></a>
+
+## Firing a two-relation spine on a real record, and what hid a config error
+
+*2026-09-07 20:08:08 · chains · process*
+
+[#211](https://github.com/dmarx/luria/issues/211) was small on purpose: `Chain.relation` becomes a tuple, `_load` unions
+the edge sets before walking, and everything downstream — `_components`,
+`_depths`, `_order` — reads a spine that does not know how many fields filled
+it. That last part is why the change is cheap, and it is worth stating
+because it is the property a future spine option should preserve.
+
+## What the guard caught, on its first real firing
+
+The consumer record has seven `extends:` edges that mean "this exists because
+the parent is broken". I declared `corrects`/`corrected_by` there, moved
+PowLU → GLU-Variants onto it, and set `relation = ["extends", "corrects"]`.
+
+The first attempt failed, correctly, and the failure is the better result:
+
+    luria.toml: chains.practice: `relation` names 'corrects', which is not a
+    reference SOTA declares — a chain over a field nothing types walks no
+    edges and renders an empty page
+
+My edit had matched `relation = "extends"` in *both* chains, and the SOTA
+scheme declares no `corrects`. The check named the chain, the field and the
+scheme, which is exactly what it exists to do. Restricting the edit to the
+LIT chain, the line renders as one three-step sequence with its last step on
+the second relation, and the header reads "walked from `extends:` and
+`corrects:`".
+
+## The trap, and it was mine
+
+I did not see that error the first time, because I ran `luria index
+>/dev/null 2>&1` and then read the page it had not rewritten. The stale page
+looked plausible — the line was intact, the header named one relation — so I
+spent a minute concluding the header formatting was broken when the config had
+simply refused to load.
+
+This is the same silent-failure shape that has bitten this work before with
+`git push >/dev/null`. The rule worth keeping: **never suppress stderr on a
+command whose failure would change the conclusion you are about to draw from
+its output.** A command run for its side effect can be quiet; a command run to
+produce something you are about to read cannot.
+
+## What was checked before trusting it
+
+- 946 tests, six of them new: a two-relation spine as one line, a second
+  relation nesting like the first, a scalar `relation` still reading, the
+  header naming every relation, an undeclared entry in a list refused by name,
+  and a cycle spanning both relations still reported.
+- Both records regenerated with no diff at all on the scalar path — this
+  project's own views and the consumer's 59 files are byte-identical, which is
+  the claim that matters for a change to a shared walker.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [7 Sep 20:08 — Firing a two-relation spine on a real record, and what hid a config error](2026-09.md#20260907200808)
 - [7 Sep 16:55 — The chain page encoded depth but not parentage](2026-09.md#20260907165522)
 - [7 Sep 05:35 — A temporary code is a code to link, and was not one to check](2026-09.md#20260907053505)
 - [7 Sep 04:40 — The link that resolved to the wrong project](2026-09.md#20260907044002)
@@ -45,9 +46,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-82 entries across 2 books, newest first.
+83 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 36 | 2026-09-03 | 2026-09-07 |
+| [2026-09](2026-09.md) | 37 | 2026-09-03 | 2026-09-07 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/luria/chains.py
+++ b/luria/chains.py
@@ -96,7 +96,14 @@ def _load(chain) -> tuple[dict[str, Adr], dict[str, list[str]],
     the scheme is the contract's finding, not a node here."""
     scheme = current().schemes[chain.scheme]
     docs = {d.code: d for d in load_scheme(scheme)}
-    held = relations.edges(chain.scheme, chain.relation)
+    # One spine, spelled by one relation or several (#211). Unioned before
+    # the walk, so every step below reads a spine that does not know how
+    # many fields filled it — which is what keeps ordering, depth and cycle
+    # reporting identical whether a record signs its succession or not.
+    held: dict[str, set[str]] = {}
+    for field in chain.relation:
+        for code, targets in relations.edges(chain.scheme, field).items():
+            held.setdefault(code, set()).update(targets)
     apart = (relations.edges(chain.scheme, chain.sibling)
              if chain.sibling else {})
     spine = {code: sorted(held.get(code, ())) for code in docs}
@@ -239,10 +246,21 @@ def rows() -> list[str]:
             for reached in sorted(_reaches(code, spine)):
                 if code in spine[reached] and code < reached:
                     found.append(
-                        f"{cfg.rel(docs[code].path)}: `{chain.relation}:` "
+                        f"{cfg.rel(docs[code].path)}: {_spine(chain)} "
                         f"makes a cycle — {code} and {reached} each come "
                         f"before the other, so neither is the earlier step")
     return sorted(set(found))
+
+
+def _spine(chain) -> str:
+    """The chain's spine relations, as prose — `` `extends:` `` for the
+    common case and `` `extends:` and `corrects:` `` for a signed one. One
+    implementation, because the cycle finding and the page header name the
+    same thing and drifting apart would be a small lie in two voices."""
+    fields = [f"`{f}:`" for f in chain.relation]
+    if len(fields) < 3:
+        return " and ".join(fields)
+    return ", ".join(fields[:-1]) + f" and {fields[-1]}"
 
 
 def _reaches(start: str, spine: dict[str, list[str]]) -> set[str]:
@@ -309,7 +327,7 @@ def _step(doc: Adr, chain, lead: str = "") -> str:
 def _render(chain, lines: list[Line]) -> str:
     count = f"{len(lines)} line" + ("" if len(lines) == 1 else "s")
     out = [MARKER, "", f"# {chain.title}", "",
-           f"{count}, walked from `{chain.relation}:` on {chain.scheme} "
+           f"{count}, walked from {_spine(chain)} on {chain.scheme} "
            f"documents. Each step explains itself; this page is the order "
            f"they came in.", ""]
     for line in lines:

--- a/luria/config.py
+++ b/luria/config.py
@@ -1198,6 +1198,15 @@ class Chain:
         output   = "docs/lineage.md"         # one page, a section per line
         title    = "Lines of work"
 
+    `relation` takes one field or several — `["extends", "corrects"]` — and
+    several are walked as one spine (#211). That is not a convenience: a
+    record can carry succession with a sign, where "builds on the parent" and
+    "exists because the parent is broken" are both steps in one line and one
+    relation renders them identically. Two relations state the difference
+    where a per-entry attribute would have to qualify a reference, which is
+    the shape the consumer record's own ADR-011 refuses. The sign is which
+    field the code sits in.
+
     `edges.py` already reads a reference field as a typed relation, and the
     site already renders each page's neighbours. What no view answered is
     *what sequence is this document a step in* — and that is the question the
@@ -1210,7 +1219,10 @@ class Chain:
     like current (DP-15)."""
     name: str
     scheme: str
-    relation: str
+    # The spine, always a tuple — one relation is the common case and reads
+    # as `relation = "extends"`, which is why the key stays singular: it
+    # names the concept, not the count. `facet_by` takes either shape too.
+    relation: tuple[str, ...]
     output: Path
     sibling: str = ""
     title: str = ""
@@ -1681,21 +1693,26 @@ def _chains(raw: dict, schemes: dict, root: Path) -> dict[str, Chain]:
                     f"{where}: `facet_by` names {field!r}, which {prefix} "
                     f"does not declare, so every step would render it blank "
                     f"(nameable: {', '.join(sorted(known))})")
-        for key in ("relation", "sibling"):
-            field = str(spec.get(key, ""))
-            if key == "sibling" and not field:
-                continue
-            if field not in declared:
-                raise ValueError(
-                    f"{where}: `{key} = \"{field}\"` is not a reference "
-                    f"{prefix} declares — a chain over a field nothing types "
-                    f"walks no edges and renders an empty page "
-                    f"(declared: {', '.join(sorted(declared)) or 'none'})")
+        raw_spine = spec.get("relation", "")
+        spine = tuple(str(f) for f in (
+            [raw_spine] if isinstance(raw_spine, str) else raw_spine))
+        for key, fields in (("relation", spine),
+                            ("sibling", (str(spec.get("sibling", "")),))):
+            for field in fields:
+                if key == "sibling" and not field:
+                    continue
+                if field not in declared:
+                    raise ValueError(
+                        f"{where}: `{key}` names {field!r}, which is not a "
+                        f"reference {prefix} declares — a chain over a field "
+                        f"nothing types walks no edges and renders an empty "
+                        f"page (declared: "
+                        f"{', '.join(sorted(declared)) or 'none'})")
         if not spec.get("output"):
             raise ValueError(f"{where}: needs an `output` — the page the "
                              f"sequences render to")
         out[name] = Chain(name=name, scheme=prefix,
-                          relation=str(spec["relation"]),
+                          relation=spine,
                           sibling=str(spec.get("sibling", "")),
                           output=root / str(spec["output"]),
                           facet_by=facet_by,

--- a/luria/relations.py
+++ b/luria/relations.py
@@ -430,7 +430,7 @@ def relation_spans(path, text: str) -> list[tuple[int, int]]:
     completes."""
     cfg = current()
     fields = {f for chain in cfg.chains.values()
-              for f in (chain.relation, chain.sibling)
+              for f in (*chain.relation, chain.sibling)
               if f and path.parent == cfg.schemes[chain.scheme].dir}
     fields |= {f for prefix, field, back in pairs()
                for f in (field, back)

--- a/record/changelog.d/20260907-200808.md
+++ b/record/changelog.d/20260907-200808.md
@@ -1,0 +1,19 @@
+### Added
+
+- A chain's `relation` takes one field or several: `relation = ["extends",
+  "corrects"]` walks both as one spine, the way `facet_by` already takes
+  either shape. A record can then carry succession with a sign — "builds on
+  the parent" and "exists because the parent is broken" are both steps in one
+  line, and one relation renders them identically. The sign is which field the
+  code sits in, so no reference entry gains an attribute and nothing has to
+  qualify a relation. Closes [#211](https://github.com/dmarx/luria/issues/211).
+
+### Changed
+
+- The page header and the cycle finding name every spine relation rather than
+  one — "walked from `extends:` and `corrects:`" — through a single spelling,
+  since they name the same thing and drifting apart would be a small lie in
+  two voices.
+- A chain naming an undeclared spine relation now says which one. The message
+  used to interpolate the whole value, so a bad entry in a list read as
+  `` `relation = "['extends', 'corrects']"` is not a reference ``.

--- a/record/devlog.d/2026/09/07/200808.md
+++ b/record/devlog.d/2026/09/07/200808.md
@@ -1,0 +1,56 @@
+---
+title: 'Firing a two-relation spine on a real record, and what hid a config error'
+created: '2026-09-07T20:08:08'
+tags:
+- chains
+- process
+---
+
+[#211](https://github.com/dmarx/luria/issues/211) was small on purpose: `Chain.relation` becomes a tuple, `_load` unions
+the edge sets before walking, and everything downstream — `_components`,
+`_depths`, `_order` — reads a spine that does not know how many fields filled
+it. That last part is why the change is cheap, and it is worth stating
+because it is the property a future spine option should preserve.
+
+## What the guard caught, on its first real firing
+
+The consumer record has seven `extends:` edges that mean "this exists because
+the parent is broken". I declared `corrects`/`corrected_by` there, moved
+PowLU → GLU-Variants onto it, and set `relation = ["extends", "corrects"]`.
+
+The first attempt failed, correctly, and the failure is the better result:
+
+    luria.toml: chains.practice: `relation` names 'corrects', which is not a
+    reference SOTA declares — a chain over a field nothing types walks no
+    edges and renders an empty page
+
+My edit had matched `relation = "extends"` in *both* chains, and the SOTA
+scheme declares no `corrects`. The check named the chain, the field and the
+scheme, which is exactly what it exists to do. Restricting the edit to the
+LIT chain, the line renders as one three-step sequence with its last step on
+the second relation, and the header reads "walked from `extends:` and
+`corrects:`".
+
+## The trap, and it was mine
+
+I did not see that error the first time, because I ran `luria index
+>/dev/null 2>&1` and then read the page it had not rewritten. The stale page
+looked plausible — the line was intact, the header named one relation — so I
+spent a minute concluding the header formatting was broken when the config had
+simply refused to load.
+
+This is the same silent-failure shape that has bitten this work before with
+`git push >/dev/null`. The rule worth keeping: **never suppress stderr on a
+command whose failure would change the conclusion you are about to draw from
+its output.** A command run for its side effect can be quiet; a command run to
+produce something you are about to read cannot.
+
+## What was checked before trusting it
+
+- 946 tests, six of them new: a two-relation spine as one line, a second
+  relation nesting like the first, a scalar `relation` still reading, the
+  header naming every relation, an undeclared entry in a list refused by name,
+  and a cycle spanning both relations still reported.
+- Both records regenerated with no diff at all on the scalar path — this
+  project's own views and the consumer's 59 files are byte-identical, which is
+  the claim that matters for a change to a shared walker.

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -57,11 +57,12 @@ output = "docs/literature"
 
 
 def note(root: Path, number: int, title: str, *, status: str = "Active",
-         extends=(), compared_against=()) -> Path:
+         extends=(), compared_against=(), corrects=()) -> Path:
     front = ["---", f"status: {status}", f"title: {title!r}", "tags:",
              "- record", "date: '2026-01-01'"]
     for name, codes in (("extends", extends),
-                        ("compared_against", compared_against)):
+                        ("compared_against", compared_against),
+                        ("corrects", corrects)):
         if codes:
             front.append(f"{name}:")
             front += [f"- {c}" for c in codes]
@@ -521,3 +522,84 @@ def test_a_second_parent_is_named_rather_than_dropped(tmp_path, monkeypatch):
     assert "LIT-009" in page
     under = [ln for ln in page.splitlines() if "LIT-003" in ln]
     assert under and "also extends" in under[0].lower(), under
+
+
+# --- a spine of more than one relation (#211) --------------------------------
+#
+# A record can carry succession with a sign: "builds on the parent" and
+# "exists because the parent is broken" are both succession, and one relation
+# renders them identically. Two relations say it, and they are one line.
+
+SIGNED = """
+[luria.schemes.LIT.references]
+extends = { scheme = "LIT", required = false, many = true, converse = "extended_by" }
+extended_by = { scheme = "LIT", required = false, many = true, converse = "extends" }
+corrects = { scheme = "LIT", required = false, many = true, converse = "corrected_by" }
+corrected_by = { scheme = "LIT", required = false, many = true, converse = "corrects" }
+compared_against = { scheme = "LIT", required = false, many = true, converse = "compared_against" }
+"""
+
+SIGNED_CHAIN = """
+[luria.chains.lineage]
+scheme   = "LIT"
+relation = ["extends", "corrects"]
+output   = "docs/lineage.md"
+title    = "Lines of work"
+"""
+
+
+def test_a_spine_of_two_relations_is_one_line(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, SIGNED + SIGNED_CHAIN)
+    note(root, 1, "Origin")
+    note(root, 2, "Builds on it", extends=["LIT-001"])
+    note(root, 3, "Fixes that", corrects=["LIT-002"])
+    lines = chains.lines_of(config.current().chains["lineage"])
+    assert len(lines) == 1
+    assert [d.code for d in lines[0].spine] == ["LIT-001", "LIT-002",
+                                                "LIT-003"]
+
+
+def test_a_second_spine_relation_nests_like_the_first(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, SIGNED + SIGNED_CHAIN)
+    note(root, 1, "Origin")
+    note(root, 2, "Fixes it", corrects=["LIT-001"])
+    page = chains.outputs()[root / "docs/lineage.md"]
+    assert page.index("LIT-001") < page.index("LIT-002")
+    assert "  - [LIT-002]" in page
+
+
+def test_a_scalar_relation_still_reads(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)          # relation = "extends"
+    note(root, 1, "Origin")
+    note(root, 2, "Builds on it", extends=["LIT-001"])
+    lines = chains.lines_of(config.current().chains["lineage"])
+    assert [d.code for d in lines[0].spine] == ["LIT-001", "LIT-002"]
+
+
+def test_the_header_names_every_spine_relation(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, SIGNED + SIGNED_CHAIN)
+    note(root, 1, "Origin")
+    note(root, 2, "Fixes it", corrects=["LIT-001"])
+    page = chains.outputs()[root / "docs/lineage.md"]
+    assert "`extends:`" in page and "`corrects:`" in page
+
+
+def test_a_spine_relation_the_scheme_does_not_declare_is_refused(
+        tmp_path, monkeypatch):
+    project(tmp_path, monkeypatch, SIGNED + """
+[luria.chains.lineage]
+scheme   = "LIT"
+relation = ["extends", "supersedes"]
+output   = "docs/lineage.md"
+""")
+    with pytest.raises(ValueError, match="supersedes"):
+        config.current()
+
+
+def test_a_cycle_across_two_spine_relations_is_a_finding(
+        tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, SIGNED + SIGNED_CHAIN)
+    note(root, 1, "One", extends=["LIT-002"])
+    note(root, 2, "Two", corrects=["LIT-001"])
+    found = chains.rows()
+    assert found and "makes a cycle" in found[0]


### PR DESCRIPTION
Closes #211. `relation` takes one field or several — `relation = ["extends", "corrects"]` — walked as one spine, the way `facet_by` already takes either shape.

## The need

Succession with a sign. In the consumer record, **7 of 19 `extends:` edges mean "this exists because the parent is broken"** and twelve mean "this builds on the parent" — and one relation renders them identically. Hyper-connections breaking the identity mapping reads on the page exactly like Mamba-2 following Mamba.

Two relations state the difference, and **the sign is which field the code sits in** — so no reference entry gains an attribute and nothing has to qualify a relation, which is the shape that record's own ADR-011 refuses.

## Why it's small

Everything downstream of `_load` reads a spine that doesn't know how many fields filled it. `_components`, `_depths` and `_order` are untouched; the union happens once, before the walk. Worth preserving if another spine option ever arrives.

Two things drifted out with it:

- **The page header and the cycle finding now share one spelling** of the spine (`_spine()`), rather than each interpolating a field that is no longer a single string. They name the same thing, and drifting apart would be a small lie in two voices.
- **The refusal for an undeclared spine relation names the offending field.** It used to interpolate the whole value, so a bad entry in a list read as `` `relation = "['extends', 'corrects']"` is not a reference `` — which names nothing a reader can fix.

## Fired once on a real record, per DP-6

And the first attempt **failed correctly**, which is the better result:

```
luria.toml: chains.practice: `relation` names 'corrects', which is not a
reference SOTA declares — a chain over a field nothing types walks no
edges and renders an empty page
```

My edit had matched `relation = "extends"` in *both* chains and SOTA declares no `corrects`. The check named the chain, the field and the scheme.

Restricted to the LIT chain, PowLU moves onto `corrects:` and the line still renders as one three-step sequence:

```
## From Language Modeling with Gated Convolutional Networks
- LIT-199 — Language Modeling with Gated Convolutional Networks (Active)
  - LIT-030 — GLU Variants Improve Transformer (Active)
    - LIT-200 — PowLU: An Activation Function… (Active)

6 lines, walked from `extends:` and `corrects:` on LIT documents.
```

## Checks

- **946 tests**, six new: two-relation spine as one line; a second relation nesting like the first; a scalar `relation` still reading; the header naming every relation; an undeclared list entry refused by name; a cycle spanning both relations still reported.
- **Byte-identical on the scalar path** — this project's own generated views and the consumer's 59 files are unchanged before and after. That's the claim that matters for a change to a shared walker.
- `luria lint` clean apart from a pre-existing `DP-017` finding that predates this branch (fallout from #207 concretizing), confirmed by stashing.

## One trap, and it was mine

The devlog records it. I ran `luria index >/dev/null 2>&1`, read a page it had **not** rewritten, and spent a minute debugging header formatting that was really a config error I had hidden. Same shape as the `git push >/dev/null` bug earlier in this work:

> Never suppress stderr on a command whose failure would change the conclusion you are about to draw from its output. A command run for its side effect can be quiet; a command run to produce something you are about to read cannot.

## Not in scope

`sibling` keeps taking a single field. Symmetry argues for the same treatment, there's no demand yet, and #210 may change what `sibling` does first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_