### PR TITLE
Identity is a field; the filename is a projection of it (#219)

### DIFF
--- a/luria/adr_index.py
+++ b/luria/adr_index.py
@@ -155,9 +155,9 @@ class Adr:
         self.path = path
         self.scheme = scheme
         self.prefix = scheme.prefix
-        # Identity is the document's own `uid:` where it has one, the
+        # Identity is the document's own `number:` where it has one, the
         # filename's number where it doesn't (#219).
-        self.number = scheme.uid_of(path)
+        self.number = scheme.number_of(path)
         # A merge-allocated document awaiting concretization (ADR-049): no
         # number yet, addressed by its temporary tail.
         self.tail = scheme.temp_of(path)

--- a/luria/adr_index.py
+++ b/luria/adr_index.py
@@ -155,7 +155,9 @@ class Adr:
         self.path = path
         self.scheme = scheme
         self.prefix = scheme.prefix
-        self.number = scheme.number_of(path)
+        # Identity is the document's own `uid:` where it has one, the
+        # filename's number where it doesn't (#219).
+        self.number = scheme.uid_of(path)
         # A merge-allocated document awaiting concretization (ADR-049): no
         # number yet, addressed by its temporary tail.
         self.tail = scheme.temp_of(path)

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -51,6 +51,7 @@ import sys
 from pathlib import Path
 
 from . import doc_refs
+from . import new as new_mod
 from .collect import _added_at
 from .config import current
 
@@ -131,21 +132,28 @@ def run(check: bool = False) -> None:
         print("luria concretize: nothing to do")
         return
 
-    renames: list[tuple[str, str, Path, Path]] = []
+    renames: list[tuple[str, str, Path, Path, int]] = []
     next_free = {s.prefix: max(s.documents(), default=0) + 1
                  for s, _, _ in todo}
     for scheme, tail, path in todo:
         number = next_free[scheme.prefix]
         next_free[scheme.prefix] = number + 1
         renames.append((f"{scheme.prefix}-{tail}", scheme.code(number),
-                        path, scheme.dir / scheme.filename(number)))
+                        path, scheme.dir / scheme.filename(number), number))
 
-    _rewrite_files([(old, new) for old, new, _, _ in renames])
-    for old, new, src, dest in renames:
+    _rewrite_files([(old, new) for old, new, _, _, _ in renames])
+    for old, new, src, dest, number in renames:
         # The tree-wide pass already rewrote this document's own heading and
-        # cross-references; what remains is its identity — the filename —
-        # and the alias that keeps the old name resolving forever.
-        dest.write_text(_record_alias(src.read_text(encoding="utf-8"), old), encoding="utf-8")
+        # cross-references; what remains is its identity — written into the
+        # document as `uid:` and projected onto the filename (#219) — and the
+        # alias that keeps the old name resolving forever.
+        #
+        # This is the moment a merge-allocated document acquires a number at
+        # all: until now it had a temporary tail and no claim on the sequence
+        # (ADR-049), which is exactly why `luria new` leaves `uid:` out and
+        # this command puts it in.
+        text = _record_alias(src.read_text(encoding="utf-8"), old)
+        dest.write_text(new_mod.write_uid(text, number), encoding="utf-8")
         src.unlink()
         print(f"{old} → {new}")
 

--- a/luria/concretize.py
+++ b/luria/concretize.py
@@ -145,15 +145,15 @@ def run(check: bool = False) -> None:
     for old, new, src, dest, number in renames:
         # The tree-wide pass already rewrote this document's own heading and
         # cross-references; what remains is its identity — written into the
-        # document as `uid:` and projected onto the filename (#219) — and the
+        # document as `number:` and projected onto the filename (#219) — and the
         # alias that keeps the old name resolving forever.
         #
         # This is the moment a merge-allocated document acquires a number at
         # all: until now it had a temporary tail and no claim on the sequence
-        # (ADR-049), which is exactly why `luria new` leaves `uid:` out and
+        # (ADR-049), which is exactly why `luria new` leaves `number:` out and
         # this command puts it in.
         text = _record_alias(src.read_text(encoding="utf-8"), old)
-        dest.write_text(new_mod.write_uid(text, number), encoding="utf-8")
+        dest.write_text(new_mod.write_number(text, number), encoding="utf-8")
         src.unlink()
         print(f"{old} → {new}")
 

--- a/luria/config.py
+++ b/luria/config.py
@@ -386,21 +386,22 @@ class Vocabulary:
 BUILT_IN_AXES = ("tags",)
 
 
-# Path → ((mtime_ns, size), uid). Keyed on the stat rather than reset
+# Path → ((mtime_ns, size), number). Keyed on the stat rather than reset
 # explicitly: a write bumps mtime, so the entry expires on its own.
-_UID_CACHE: dict[Path, tuple[tuple[int, int], int | None]] = {}
+_NUMBER_CACHE: dict[Path, tuple[tuple[int, int], int | None]] = {}
 
-# `uid:` is an integer on a line of its own, so it can be read without a YAML
+# `number:` is an integer on a line of its own, so it can be read without a YAML
 # parse of the whole document — this runs once per file per lint, and the
 # frontmatter of a scaffolded document is mostly comments.
-_UID_RE = re.compile(r"^uid:[ \t]*(\d+)[ \t]*$", re.M)
+_NUMBER_RE = re.compile(r"^number:[ \t]*(\d+)[ \t]*$", re.M)
 
 
-def _declared_uid(path: Path) -> int | None:
-    """The `uid:` a document's frontmatter declares, or None.
+def _declared_number(path: Path) -> int | None:
+    """The `number:` a document's frontmatter declares, or None.
 
-    Read out of the frontmatter block only: a `uid:` in the body is prose
-    about identity, not a claim to one."""
+    Read out of the frontmatter block only: a `number:` in the body is prose
+    about identity, not a claim to one — and it does occur there, so the
+    block boundary is what makes the field readable without a YAML parse."""
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -411,9 +412,9 @@ def _declared_uid(path: Path) -> int | None:
     if end == -1:
         # Unterminated frontmatter is no frontmatter, which is what
         # `parse_frontmatter` decides too — searching on would read the body,
-        # and a `uid:` in the body is prose about identity, not a claim to one.
+        # and a `number:` in the body is prose about identity, not a claim to one.
         return None
-    m = _UID_RE.search(text[4:end + 1])
+    m = _NUMBER_RE.search(text[4:end + 1])
     return int(m.group(1)) if m else None
 
 
@@ -591,12 +592,12 @@ class Scheme:
         (ADR-013)."""
         return f"{self.code(number)}.md"
 
-    def uid_of(self, path: Path) -> int | None:
-        """This document's identity: its `uid:`, or the filename's number.
+    def number_of(self, path: Path) -> int | None:
+        """This document's identity: its `number:`, or the one its filename carries.
 
         The frontmatter wins, because that is where identity lives (#219).
         The filename is the fallback and the witness — a record written
-        before `uid:` existed still reads, and `luria repair` populates the
+        before `number:` existed still reads, and `luria repair` populates the
         field from the path it already asserts, which is how a project
         migrates without anyone typing a number.
 
@@ -608,17 +609,17 @@ class Scheme:
         try:
             st = path.stat()
         except OSError:
-            return self.number_of(path)
+            return self.number_in_name(path)
         key = (st.st_mtime_ns, st.st_size)
-        hit = _UID_CACHE.get(path)
+        hit = _NUMBER_CACHE.get(path)
         if hit is not None and hit[0] == key:
             return hit[1]
-        uid = _declared_uid(path)
-        found = uid if uid is not None else self.number_of(path)
-        _UID_CACHE[path] = (key, found)
+        held = _declared_number(path)
+        found = held if held is not None else self.number_in_name(path)
+        _NUMBER_CACHE[path] = (key, found)
         return found
 
-    def number_of(self, path: Path) -> int | None:
+    def number_in_name(self, path: Path) -> int | None:
         """The document number a filename carries, or None if it isn't one.
 
         Deliberately tolerant of a trailing slug: `adr-010-some-title.md` is
@@ -639,7 +640,7 @@ class Scheme:
         for path in sorted(self.dir.glob("*.md")):
             if self.temp_of(path) is not None:
                 continue
-            number = self.uid_of(path)
+            number = self.number_of(path)
             if number is not None:
                 found.setdefault(number, path)
         return dict(sorted(found.items()))

--- a/luria/config.py
+++ b/luria/config.py
@@ -386,6 +386,37 @@ class Vocabulary:
 BUILT_IN_AXES = ("tags",)
 
 
+# Path → ((mtime_ns, size), uid). Keyed on the stat rather than reset
+# explicitly: a write bumps mtime, so the entry expires on its own.
+_UID_CACHE: dict[Path, tuple[tuple[int, int], int | None]] = {}
+
+# `uid:` is an integer on a line of its own, so it can be read without a YAML
+# parse of the whole document — this runs once per file per lint, and the
+# frontmatter of a scaffolded document is mostly comments.
+_UID_RE = re.compile(r"^uid:[ \t]*(\d+)[ \t]*$", re.M)
+
+
+def _declared_uid(path: Path) -> int | None:
+    """The `uid:` a document's frontmatter declares, or None.
+
+    Read out of the frontmatter block only: a `uid:` in the body is prose
+    about identity, not a claim to one."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        # Unterminated frontmatter is no frontmatter, which is what
+        # `parse_frontmatter` decides too — searching on would read the body,
+        # and a `uid:` in the body is prose about identity, not a claim to one.
+        return None
+    m = _UID_RE.search(text[4:end + 1])
+    return int(m.group(1)) if m else None
+
+
 @dataclass(frozen=True)
 class Scheme:
     """A family of referable documents — `ADR-012`, `RFC-7`, `SPEC-3`.
@@ -560,6 +591,33 @@ class Scheme:
         (ADR-013)."""
         return f"{self.code(number)}.md"
 
+    def uid_of(self, path: Path) -> int | None:
+        """This document's identity: its `uid:`, or the filename's number.
+
+        The frontmatter wins, because that is where identity lives (#219).
+        The filename is the fallback and the witness — a record written
+        before `uid:` existed still reads, and `luria repair` populates the
+        field from the path it already asserts, which is how a project
+        migrates without anyone typing a number.
+
+        Cached on (mtime, size) rather than reset by hand: every writer of a
+        document bumps its mtime, so the cache invalidates itself and no
+        caller has to remember. Reading the field costs a parse, and this is
+        the hot path — `documents()` runs on every lint, index and link
+        pass."""
+        try:
+            st = path.stat()
+        except OSError:
+            return self.number_of(path)
+        key = (st.st_mtime_ns, st.st_size)
+        hit = _UID_CACHE.get(path)
+        if hit is not None and hit[0] == key:
+            return hit[1]
+        uid = _declared_uid(path)
+        found = uid if uid is not None else self.number_of(path)
+        _UID_CACHE[path] = (key, found)
+        return found
+
     def number_of(self, path: Path) -> int | None:
         """The document number a filename carries, or None if it isn't one.
 
@@ -579,7 +637,9 @@ class Scheme:
         only for as long as the filename shape never changed."""
         found: dict[int, Path] = {}
         for path in sorted(self.dir.glob("*.md")):
-            number = self.number_of(path)
+            if self.temp_of(path) is not None:
+                continue
+            number = self.uid_of(path)
             if number is not None:
                 found.setdefault(number, path)
         return dict(sorted(found.items()))

--- a/luria/edges.py
+++ b/luria/edges.py
@@ -103,7 +103,7 @@ def code_of(path: Path) -> str | None:
     for scheme in current().schemes.values():
         if path.parent != scheme.dir:
             continue
-        number = scheme.number_of(path)
+        number = scheme.uid_of(path)
         if number is not None:
             return scheme.code(number)
         if tail := scheme.temp_of(path):

--- a/luria/edges.py
+++ b/luria/edges.py
@@ -103,7 +103,7 @@ def code_of(path: Path) -> str | None:
     for scheme in current().schemes.values():
         if path.parent != scheme.dir:
             continue
-        number = scheme.uid_of(path)
+        number = scheme.number_of(path)
         if number is not None:
             return scheme.code(number)
         if tail := scheme.temp_of(path):

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -220,8 +220,8 @@ def check_contracts(errors: list[str]) -> None:
             errors.extend(contract.violations(c, cfg.rel(path), meta, known))
 
 
-def check_uids(errors: list[str]) -> None:
-    """A document's `uid:` and its filename have to agree (#219).
+def check_numbers(errors: list[str]) -> None:
+    """A document's `number:` and its filename have to agree (#219).
 
     The same check `check_journals` makes about `created:` and an entry's
     path, for the same reason: identity lives in the frontmatter, the name on
@@ -233,19 +233,19 @@ def check_uids(errors: list[str]) -> None:
 
     A violation rather than a report, and not repaired automatically: which
     of the two is right is a question only the author can answer, and
-    renaming on a guess would move a document's identity. An *absent* `uid:`
+    renaming on a guess would move a document's identity. An *absent* `number:`
     is the repairable case, and `luria repair` handles it from the path."""
     cfg = current()
     for scheme in cfg.schemes.values():
         for path in sorted(scheme.dir.glob("*.md")):
             if scheme.temp_of(path) is not None:
                 continue
-            declared = config_mod._declared_uid(path)
-            named = scheme.number_of(path)
+            declared = config_mod._declared_number(path)
+            named = scheme.number_in_name(path)
             if declared is None or named is None or declared == named:
                 continue
             errors.append(
-                f"{cfg.rel(path)}: `uid: {declared}` but the filename says "
+                f"{cfg.rel(path)}: `number: {declared}` but the filename says "
                 f"{named} — identity is the field, so this document answers "
                 f"to {scheme.code(declared)} while its file is named for "
                 f"{scheme.code(named)}; rename the file or correct the field")
@@ -732,7 +732,7 @@ def run() -> None:
     check_status_vocabulary(errors)
     check_contracts(errors)
     check_view_dirs(errors)
-    check_uids(errors)
+    check_numbers(errors)
     check_journals(errors)
     check_version_history(errors)
     check_bare_refs(errors)

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -53,6 +53,7 @@ from . import adr_index as builder
 from . import (adr_pending, badges, chains, ci, contract, doc_refs, journal,
                link_targets, narrow_titles, pins, ref_status, remotes,
                relations, sources, statuses, templates)
+from . import config as config_mod
 from .config import current
 
 # Pages deliberately absent from the index: the index itself.
@@ -217,6 +218,37 @@ def check_contracts(errors: list[str]) -> None:
             # here keeps the contract's checker generic (#181).
             meta = statuses.normalised(meta)
             errors.extend(contract.violations(c, cfg.rel(path), meta, known))
+
+
+def check_uids(errors: list[str]) -> None:
+    """A document's `uid:` and its filename have to agree (#219).
+
+    The same check `check_journals` makes about `created:` and an entry's
+    path, for the same reason: identity lives in the frontmatter, the name on
+    disk is a projection of it, and a projection that disagrees with its
+    source means every reader picks a different one. Here the stakes are
+    concrete — `documents()` reads the field, while a link target is written
+    from the code, so a disagreement resolves references to a filename that
+    is not there.
+
+    A violation rather than a report, and not repaired automatically: which
+    of the two is right is a question only the author can answer, and
+    renaming on a guess would move a document's identity. An *absent* `uid:`
+    is the repairable case, and `luria repair` handles it from the path."""
+    cfg = current()
+    for scheme in cfg.schemes.values():
+        for path in sorted(scheme.dir.glob("*.md")):
+            if scheme.temp_of(path) is not None:
+                continue
+            declared = config_mod._declared_uid(path)
+            named = scheme.number_of(path)
+            if declared is None or named is None or declared == named:
+                continue
+            errors.append(
+                f"{cfg.rel(path)}: `uid: {declared}` but the filename says "
+                f"{named} — identity is the field, so this document answers "
+                f"to {scheme.code(declared)} while its file is named for "
+                f"{scheme.code(named)}; rename the file or correct the field")
 
 
 def check_journals(errors: list[str]) -> None:
@@ -700,6 +732,7 @@ def run() -> None:
     check_status_vocabulary(errors)
     check_contracts(errors)
     check_view_dirs(errors)
+    check_uids(errors)
     check_journals(errors)
     check_version_history(errors)
     check_bare_refs(errors)

--- a/luria/new.py
+++ b/luria/new.py
@@ -32,6 +32,9 @@ from .config import current
 
 TEMPLATE_NAME = "_template.md"
 
+# `uid:` as `luria new` and `luria repair` both write it.
+_UID_LINE = re.compile(r"^uid:[ \t]*\d*[ \t]*$\n", re.M)
+
 # The shape written when a scheme has no _template.md of its own — enough to
 # pass the lint (status, title, tag, date, agreeing heading) and nothing else.
 FALLBACK = """---
@@ -157,6 +160,7 @@ def new_scheme_doc(scheme, fields: dict[str, str]) -> Path:
         # `luria concretize` assigns the real number where merges serialize.
         stem = f"{scheme.prefix}-{_mint_tail(scheme)}"
         code = stem
+        number = None
     else:
         number = max(scheme.documents(), default=0) + 1
         code = f"{scheme.prefix}-{number:03d}"
@@ -198,10 +202,37 @@ def new_scheme_doc(scheme, fields: dict[str, str]) -> Path:
         if field not in fields:
             text = _drop_field(text, field)
 
+    # Identity written into the document, not left to the filename (#219).
+    # Only for a scheme that allocates on filing: a merge-allocated one has
+    # no number to write yet, and `luria concretize` puts it there when it
+    # assigns one, which is the same moment it stops being a claim a branch
+    # could collide on (ADR-049).
+    if number is not None:
+        text = write_uid(text, number)
+
     path = scheme.dir / f"{stem}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def write_uid(text: str, number: int) -> str:
+    """Put `uid: N` at the top of a document's frontmatter.
+
+    First line, above the scaffold's comments: identity is the one field a
+    reader should not have to hunt for, and `luria repair` writes it into
+    existing documents at the same place, so a migrated record and a fresh
+    one read alike. Text surgery rather than a YAML round-trip, for the
+    reason `field_edit` gives — rewriting through a parser reflows the
+    comments a scaffolded document is mostly made of."""
+    line = f"uid: {int(number)}\n"
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---\n", 3)
+    head = text[4:end + 1] if end != -1 else ""
+    if _UID_LINE.search(head):
+        return _UID_LINE.sub(line, text, count=1)
+    return text[:4] + line + text[4:]
 
 
 def new_fragment(dir_name: str, name: str | None) -> Path:

--- a/luria/new.py
+++ b/luria/new.py
@@ -32,8 +32,8 @@ from .config import current
 
 TEMPLATE_NAME = "_template.md"
 
-# `uid:` as `luria new` and `luria repair` both write it.
-_UID_LINE = re.compile(r"^uid:[ \t]*\d*[ \t]*$\n", re.M)
+# `number:` as `luria new` and `luria repair` both write it.
+_NUMBER_LINE = re.compile(r"^number:[ \t]*\d*[ \t]*$\n", re.M)
 
 # The shape written when a scheme has no _template.md of its own — enough to
 # pass the lint (status, title, tag, date, agreeing heading) and nothing else.
@@ -208,7 +208,7 @@ def new_scheme_doc(scheme, fields: dict[str, str]) -> Path:
     # assigns one, which is the same moment it stops being a claim a branch
     # could collide on (ADR-049).
     if number is not None:
-        text = write_uid(text, number)
+        text = write_number(text, number)
 
     path = scheme.dir / f"{stem}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -216,8 +216,8 @@ def new_scheme_doc(scheme, fields: dict[str, str]) -> Path:
     return path
 
 
-def write_uid(text: str, number: int) -> str:
-    """Put `uid: N` at the top of a document's frontmatter.
+def write_number(text: str, number: int) -> str:
+    """Put `number: N` at the top of a document's frontmatter.
 
     First line, above the scaffold's comments: identity is the one field a
     reader should not have to hunt for, and `luria repair` writes it into
@@ -225,13 +225,13 @@ def write_uid(text: str, number: int) -> str:
     one read alike. Text surgery rather than a YAML round-trip, for the
     reason `field_edit` gives — rewriting through a parser reflows the
     comments a scaffolded document is mostly made of."""
-    line = f"uid: {int(number)}\n"
+    line = f"number: {int(number)}\n"
     if not text.startswith("---\n"):
         return text
     end = text.find("\n---\n", 3)
     head = text[4:end + 1] if end != -1 else ""
-    if _UID_LINE.search(head):
-        return _UID_LINE.sub(line, text, count=1)
+    if _NUMBER_LINE.search(head):
+        return _NUMBER_LINE.sub(line, text, count=1)
     return text[:4] + line + text[4:]
 
 

--- a/luria/repair.py
+++ b/luria/repair.py
@@ -40,12 +40,12 @@ def apply() -> list[Path]:
             changed.append(p)
     # The same repair, for a scheme document's identity (#219): the filename
     # already asserts the number, so writing it into the frontmatter states
-    # what the record implies. This is how a project migrates onto `uid:`
+    # what the record implies. This is how a project migrates onto `number:`
     # without anyone typing one — and why the field can be introduced without
     # a `luria upgrade` of its own.
     for s in cfg.schemes.values():
-        for p in populate_uids(s):
-            print(f"populated `uid:` from the path in {cfg.rel(p)}")
+        for p in populate_numbers(s):
+            print(f"populated `number:` from the path in {cfg.rel(p)}")
             changed.append(p)
     # A note still riding in `status:` moves to `status_note:`, and an
     # old-form `by CODE` note becomes `superseded_by:` — the same repair: the
@@ -65,8 +65,8 @@ def apply() -> list[Path]:
     return changed
 
 
-def populate_uids(scheme) -> list[Path]:
-    """Write `uid:` into every document of `scheme` that lacks one, from the
+def populate_numbers(scheme) -> list[Path]:
+    """Write `number:` into every document of `scheme` that lacks one, from the
     number its filename already carries.
 
     A temporary document is skipped: it has no number yet by design, and
@@ -74,16 +74,16 @@ def populate_uids(scheme) -> list[Path]:
     (ADR-049). Idempotent, like every repair here — a second run finds the
     field present and does nothing."""
     from . import config as config_mod
-    from .new import write_uid
+    from .new import write_number
     done: list[Path] = []
     for path in sorted(scheme.dir.glob("*.md")):
         if scheme.temp_of(path) is not None:
             continue
-        number = scheme.number_of(path)
-        if number is None or config_mod._declared_uid(path) is not None:
+        number = scheme.number_in_name(path)
+        if number is None or config_mod._declared_number(path) is not None:
             continue
         text = path.read_text(encoding="utf-8")
-        written = write_uid(text, number)
+        written = write_number(text, number)
         if written != text:
             path.write_text(written, encoding="utf-8")
             done.append(path)

--- a/luria/repair.py
+++ b/luria/repair.py
@@ -38,6 +38,15 @@ def apply() -> list[Path]:
         for p in journal.populate_created(j):
             print(f"populated `created:` from the path in {cfg.rel(p)}")
             changed.append(p)
+    # The same repair, for a scheme document's identity (#219): the filename
+    # already asserts the number, so writing it into the frontmatter states
+    # what the record implies. This is how a project migrates onto `uid:`
+    # without anyone typing one — and why the field can be introduced without
+    # a `luria upgrade` of its own.
+    for s in cfg.schemes.values():
+        for p in populate_uids(s):
+            print(f"populated `uid:` from the path in {cfg.rel(p)}")
+            changed.append(p)
     # A note still riding in `status:` moves to `status_note:`, and an
     # old-form `by CODE` note becomes `superseded_by:` — the same repair: the
     # file states the facts, and now says so in the fields that carry them
@@ -54,6 +63,31 @@ def apply() -> list[Path]:
               f"record is described in {cfg.rel(cfg.record_doc)}")
         changed.append(p)
     return changed
+
+
+def populate_uids(scheme) -> list[Path]:
+    """Write `uid:` into every document of `scheme` that lacks one, from the
+    number its filename already carries.
+
+    A temporary document is skipped: it has no number yet by design, and
+    `luria concretize` writes the field at the moment it assigns one
+    (ADR-049). Idempotent, like every repair here — a second run finds the
+    field present and does nothing."""
+    from . import config as config_mod
+    from .new import write_uid
+    done: list[Path] = []
+    for path in sorted(scheme.dir.glob("*.md")):
+        if scheme.temp_of(path) is not None:
+            continue
+        number = scheme.number_of(path)
+        if number is None or config_mod._declared_uid(path) is not None:
+            continue
+        text = path.read_text(encoding="utf-8")
+        written = write_uid(text, number)
+        if written != text:
+            path.write_text(written, encoding="utf-8")
+            done.append(path)
+    return done
 
 
 def run() -> None:

--- a/luria/site.py
+++ b/luria/site.py
@@ -465,7 +465,7 @@ def _alias(path: Path, cfg) -> str | None:
     for scheme in cfg.schemes.values():
         if scheme.render != "index" or path.parent != scheme.dir:
             continue
-        number = scheme.number_of(path)
+        number = scheme.uid_of(path)
         if number is not None:
             return scheme.code(number)
     return None

--- a/luria/site.py
+++ b/luria/site.py
@@ -465,7 +465,7 @@ def _alias(path: Path, cfg) -> str | None:
     for scheme in cfg.schemes.values():
         if scheme.render != "index" or path.parent != scheme.dir:
             continue
-        number = scheme.uid_of(path)
+        number = scheme.number_of(path)
         if number is not None:
             return scheme.code(number)
     return None

--- a/record/changelog.d/20260908-185747.md
+++ b/record/changelog.d/20260908-185747.md
@@ -1,6 +1,6 @@
 ### Added
 
-- A scheme document carries `uid:`, and its filename is a projection of it
+- A scheme document carries `number:`, and its filename is a projection of it
   (`#219`) — the model journals have always used for `created:`, applied to
   schemes. `luria lint` reports a field and a filename that disagree; `luria
   repair` writes the field from the path where it is absent, so a record

--- a/record/changelog.d/20260908-185747.md
+++ b/record/changelog.d/20260908-185747.md
@@ -1,0 +1,12 @@
+### Added
+
+- A scheme document carries `uid:`, and its filename is a projection of it
+  (`#219`) — the model journals have always used for `created:`, applied to
+  schemes. `luria lint` reports a field and a filename that disagree; `luria
+  repair` writes the field from the path where it is absent, so a record
+  migrates without anyone typing a number; `luria new` and `luria
+  concretize` write it for new documents.
+
+  Nothing changes for a record that has not migrated: the filename is still
+  read when the field is absent, which is what lets the field arrive without
+  an upgrade to run.

--- a/record/decisions.d/ADR-001.md
+++ b/record/decisions.d/ADR-001.md
@@ -1,5 +1,5 @@
 ---
-uid: 1
+number: 1
 status: Active
 title: 'Four layers of record, each with a test for what belongs in it'
 version: 2

--- a/record/decisions.d/ADR-001.md
+++ b/record/decisions.d/ADR-001.md
@@ -1,4 +1,5 @@
 ---
+uid: 1
 status: Active
 title: 'Four layers of record, each with a test for what belongs in it'
 version: 2

--- a/record/decisions.d/ADR-002.md
+++ b/record/decisions.d/ADR-002.md
@@ -1,5 +1,5 @@
 ---
-uid: 2
+number: 2
 status: Active
 title: 'Contributions write fragments; shared documents are generated views'
 version: 2

--- a/record/decisions.d/ADR-002.md
+++ b/record/decisions.d/ADR-002.md
@@ -1,4 +1,5 @@
 ---
+uid: 2
 status: Active
 title: 'Contributions write fragments; shared documents are generated views'
 version: 2

--- a/record/decisions.d/ADR-003.md
+++ b/record/decisions.d/ADR-003.md
@@ -1,5 +1,5 @@
 ---
-uid: 3
+number: 3
 status: Active
 title: 'Status is a closed vocabulary in frontmatter, enforced by lint'
 version: 2

--- a/record/decisions.d/ADR-003.md
+++ b/record/decisions.d/ADR-003.md
@@ -1,4 +1,5 @@
 ---
+uid: 3
 status: Active
 title: 'Status is a closed vocabulary in frontmatter, enforced by lint'
 version: 2

--- a/record/decisions.d/ADR-004.md
+++ b/record/decisions.d/ADR-004.md
@@ -1,4 +1,5 @@
 ---
+uid: 4
 status: Active
 title: 'The decision index is generated from frontmatter'
 tags:

--- a/record/decisions.d/ADR-004.md
+++ b/record/decisions.d/ADR-004.md
@@ -1,5 +1,5 @@
 ---
-uid: 4
+number: 4
 status: Active
 title: 'The decision index is generated from frontmatter'
 tags:

--- a/record/decisions.d/ADR-005.md
+++ b/record/decisions.d/ADR-005.md
@@ -1,4 +1,5 @@
 ---
+uid: 5
 status: Active
 title: 'References in prose are hyperlinks, enforced by lint'
 tags:

--- a/record/decisions.d/ADR-005.md
+++ b/record/decisions.d/ADR-005.md
@@ -1,5 +1,5 @@
 ---
-uid: 5
+number: 5
 status: Active
 title: 'References in prose are hyperlinks, enforced by lint'
 tags:

--- a/record/decisions.d/ADR-006.md
+++ b/record/decisions.d/ADR-006.md
@@ -1,5 +1,5 @@
 ---
-uid: 6
+number: 6
 status: Active
 title: 'Reference schemes and paths are configuration, not constants'
 tags:

--- a/record/decisions.d/ADR-006.md
+++ b/record/decisions.d/ADR-006.md
@@ -1,4 +1,5 @@
 ---
+uid: 6
 status: Active
 title: 'Reference schemes and paths are configuration, not constants'
 tags:

--- a/record/decisions.d/ADR-007.md
+++ b/record/decisions.d/ADR-007.md
@@ -1,5 +1,5 @@
 ---
-uid: 7
+number: 7
 status: Superseded
 superseded_by:
 - ADR-035

--- a/record/decisions.d/ADR-007.md
+++ b/record/decisions.d/ADR-007.md
@@ -1,4 +1,5 @@
 ---
+uid: 7
 status: Superseded
 superseded_by:
 - ADR-035

--- a/record/decisions.d/ADR-008.md
+++ b/record/decisions.d/ADR-008.md
@@ -1,4 +1,5 @@
 ---
+uid: 8
 status: Active
 title: 'One directive vocabulary, one scope rule'
 tags:

--- a/record/decisions.d/ADR-008.md
+++ b/record/decisions.d/ADR-008.md
@@ -1,5 +1,5 @@
 ---
-uid: 8
+number: 8
 status: Active
 title: 'One directive vocabulary, one scope rule'
 tags:

--- a/record/decisions.d/ADR-009.md
+++ b/record/decisions.d/ADR-009.md
@@ -1,5 +1,5 @@
 ---
-uid: 9
+number: 9
 status: Active
 title: 'Extracted with provenance, not imported'
 tags:

--- a/record/decisions.d/ADR-009.md
+++ b/record/decisions.d/ADR-009.md
@@ -1,4 +1,5 @@
 ---
+uid: 9
 status: Active
 title: 'Extracted with provenance, not imported'
 tags:

--- a/record/decisions.d/ADR-010.md
+++ b/record/decisions.d/ADR-010.md
@@ -1,5 +1,5 @@
 ---
-uid: 10
+number: 10
 status: Superseded
 superseded_by:
 - ADR-011

--- a/record/decisions.d/ADR-010.md
+++ b/record/decisions.d/ADR-010.md
@@ -1,4 +1,5 @@
 ---
+uid: 10
 status: Superseded
 superseded_by:
 - ADR-011

--- a/record/decisions.d/ADR-011.md
+++ b/record/decisions.d/ADR-011.md
@@ -1,5 +1,5 @@
 ---
-uid: 11
+number: 11
 status: Active
 title: 'Name the project Luria, after *The Mind of a Mnemonist*'
 tags:

--- a/record/decisions.d/ADR-011.md
+++ b/record/decisions.d/ADR-011.md
@@ -1,4 +1,5 @@
 ---
+uid: 11
 status: Active
 title: 'Name the project Luria, after *The Mind of a Mnemonist*'
 tags:

--- a/record/decisions.d/ADR-012.md
+++ b/record/decisions.d/ADR-012.md
@@ -1,4 +1,5 @@
 ---
+uid: 12
 status: Active
 title: 'Principles are fragments too, rendered as a document'
 version: 2

--- a/record/decisions.d/ADR-012.md
+++ b/record/decisions.d/ADR-012.md
@@ -1,5 +1,5 @@
 ---
-uid: 12
+number: 12
 status: Active
 title: 'Principles are fragments too, rendered as a document'
 version: 2

--- a/record/decisions.d/ADR-013.md
+++ b/record/decisions.d/ADR-013.md
@@ -1,4 +1,5 @@
 ---
+uid: 13
 status: Active
 title: A document's filename is its code; the title lives in the frontmatter
 tags:

--- a/record/decisions.d/ADR-013.md
+++ b/record/decisions.d/ADR-013.md
@@ -1,5 +1,5 @@
 ---
-uid: 13
+number: 13
 status: Active
 title: A document's filename is its code; the title lives in the frontmatter
 tags:

--- a/record/decisions.d/ADR-014.md
+++ b/record/decisions.d/ADR-014.md
@@ -1,4 +1,5 @@
 ---
+uid: 14
 status: Active
 title: A code that resolves to nothing is reported, not dropped
 tags:

--- a/record/decisions.d/ADR-014.md
+++ b/record/decisions.d/ADR-014.md
@@ -1,5 +1,5 @@
 ---
-uid: 14
+number: 14
 status: Active
 title: A code that resolves to nothing is reported, not dropped
 tags:

--- a/record/decisions.d/ADR-015.md
+++ b/record/decisions.d/ADR-015.md
@@ -1,4 +1,5 @@
 ---
+uid: 15
 status: Superseded
 superseded_by:
 - ADR-016

--- a/record/decisions.d/ADR-015.md
+++ b/record/decisions.d/ADR-015.md
@@ -1,5 +1,5 @@
 ---
-uid: 15
+number: 15
 status: Superseded
 superseded_by:
 - ADR-016

--- a/record/decisions.d/ADR-016.md
+++ b/record/decisions.d/ADR-016.md
@@ -1,4 +1,5 @@
 ---
+uid: 16
 status: Active
 title: Remotes are public URLs, Luria is its own worked example, and every scheme versions
 version: 1

--- a/record/decisions.d/ADR-016.md
+++ b/record/decisions.d/ADR-016.md
@@ -1,5 +1,5 @@
 ---
-uid: 16
+number: 16
 status: Active
 title: Remotes are public URLs, Luria is its own worked example, and every scheme versions
 version: 1

--- a/record/decisions.d/ADR-017.md
+++ b/record/decisions.d/ADR-017.md
@@ -1,4 +1,5 @@
 ---
+uid: 17
 status: Active
 title: A reference may name a document before its URL resolves
 version: 1

--- a/record/decisions.d/ADR-017.md
+++ b/record/decisions.d/ADR-017.md
@@ -1,5 +1,5 @@
 ---
-uid: 17
+number: 17
 status: Active
 title: A reference may name a document before its URL resolves
 version: 1

--- a/record/decisions.d/ADR-018.md
+++ b/record/decisions.d/ADR-018.md
@@ -1,5 +1,5 @@
 ---
-uid: 18
+number: 18
 status: Active
 title: The README's badges are counts derived from the record
 version: 2

--- a/record/decisions.d/ADR-018.md
+++ b/record/decisions.d/ADR-018.md
@@ -1,4 +1,5 @@
 ---
+uid: 18
 status: Active
 title: The README's badges are counts derived from the record
 version: 2

--- a/record/decisions.d/ADR-019.md
+++ b/record/decisions.d/ADR-019.md
@@ -1,4 +1,5 @@
 ---
+uid: 19
 status: Active
 title: A wrong reason is corrected in place and versioned; a changed choice is superseded
 version: 1

--- a/record/decisions.d/ADR-019.md
+++ b/record/decisions.d/ADR-019.md
@@ -1,5 +1,5 @@
 ---
-uid: 19
+number: 19
 status: Active
 title: A wrong reason is corrected in place and versioned; a changed choice is superseded
 version: 1

--- a/record/decisions.d/ADR-020.md
+++ b/record/decisions.d/ADR-020.md
@@ -1,5 +1,5 @@
 ---
-uid: 20
+number: 20
 status: Active
 title: 'The devlog is a journal: dated entries that persist, rendered into books'
 version: 1

--- a/record/decisions.d/ADR-020.md
+++ b/record/decisions.d/ADR-020.md
@@ -1,4 +1,5 @@
 ---
+uid: 20
 status: Active
 title: 'The devlog is a journal: dated entries that persist, rendered into books'
 version: 1

--- a/record/decisions.d/ADR-021.md
+++ b/record/decisions.d/ADR-021.md
@@ -1,5 +1,5 @@
 ---
-uid: 21
+number: 21
 status: Active
 title: 'The read/write boundary: views in docs/, sources in record/'
 version: 1

--- a/record/decisions.d/ADR-021.md
+++ b/record/decisions.d/ADR-021.md
@@ -1,4 +1,5 @@
 ---
+uid: 21
 status: Active
 title: 'The read/write boundary: views in docs/, sources in record/'
 version: 1

--- a/record/decisions.d/ADR-022.md
+++ b/record/decisions.d/ADR-022.md
@@ -1,5 +1,5 @@
 ---
-uid: 22
+number: 22
 status: Active
 title: '`url-ok` acknowledges foreign codes only'
 version: 1

--- a/record/decisions.d/ADR-022.md
+++ b/record/decisions.d/ADR-022.md
@@ -1,4 +1,5 @@
 ---
+uid: 22
 status: Active
 title: '`url-ok` acknowledges foreign codes only'
 version: 1

--- a/record/decisions.d/ADR-023.md
+++ b/record/decisions.d/ADR-023.md
@@ -1,4 +1,5 @@
 ---
+uid: 23
 status: Active
 title: 'A remote constructs per scheme: dir, document + anchor, or url'
 version: 1

--- a/record/decisions.d/ADR-023.md
+++ b/record/decisions.d/ADR-023.md
@@ -1,5 +1,5 @@
 ---
-uid: 23
+number: 23
 status: Active
 title: 'A remote constructs per scheme: dir, document + anchor, or url'
 version: 1

--- a/record/decisions.d/ADR-024.md
+++ b/record/decisions.d/ADR-024.md
@@ -1,4 +1,5 @@
 ---
+uid: 24
 status: Active
 title: 'A remote reference is a prefix, a delimiter and a uid — numbers are the special case'
 version: 1

--- a/record/decisions.d/ADR-024.md
+++ b/record/decisions.d/ADR-024.md
@@ -1,5 +1,5 @@
 ---
-uid: 24
+number: 24
 status: Active
 title: 'A remote reference is a prefix, a delimiter and a uid — numbers are the special case'
 version: 1

--- a/record/decisions.d/ADR-025.md
+++ b/record/decisions.d/ADR-025.md
@@ -1,4 +1,5 @@
 ---
+uid: 25
 status: Active
 title: 'Wikilinks: `[[CODE]]` is a typed reference, and typing it changes the rules'
 version: 1

--- a/record/decisions.d/ADR-025.md
+++ b/record/decisions.d/ADR-025.md
@@ -1,5 +1,5 @@
 ---
-uid: 25
+number: 25
 status: Active
 title: 'Wikilinks: `[[CODE]]` is a typed reference, and typing it changes the rules'
 version: 1

--- a/record/decisions.d/ADR-026.md
+++ b/record/decisions.d/ADR-026.md
@@ -1,4 +1,5 @@
 ---
+uid: 26
 status: Active
 title: 'One ordered pmap over threads; width is an environment variable'
 version: 1

--- a/record/decisions.d/ADR-026.md
+++ b/record/decisions.d/ADR-026.md
@@ -1,5 +1,5 @@
 ---
-uid: 26
+number: 26
 status: Active
 title: 'One ordered pmap over threads; width is an environment variable'
 version: 1

--- a/record/decisions.d/ADR-027.md
+++ b/record/decisions.d/ADR-027.md
@@ -1,4 +1,5 @@
 ---
+uid: 27
 status: Active
 title: 'Published to PyPI via trusted publishing; the scaffold ships inside the package'
 version: 1

--- a/record/decisions.d/ADR-027.md
+++ b/record/decisions.d/ADR-027.md
@@ -1,5 +1,5 @@
 ---
-uid: 27
+number: 27
 status: Active
 title: 'Published to PyPI via trusted publishing; the scaffold ships inside the package'
 version: 1

--- a/record/decisions.d/ADR-028.md
+++ b/record/decisions.d/ADR-028.md
@@ -1,4 +1,5 @@
 ---
+uid: 28
 status: Active
 title: 'Collection styles are configuration; the changelog shape is one of them'
 version: 1

--- a/record/decisions.d/ADR-028.md
+++ b/record/decisions.d/ADR-028.md
@@ -1,5 +1,5 @@
 ---
-uid: 28
+number: 28
 status: Active
 title: 'Collection styles are configuration; the changelog shape is one of them'
 version: 1

--- a/record/decisions.d/ADR-029.md
+++ b/record/decisions.d/ADR-029.md
@@ -1,4 +1,5 @@
 ---
+uid: 29
 status: Active
 title: A generated view must be committed by something; the remedy says so where it is read
 version: 2

--- a/record/decisions.d/ADR-029.md
+++ b/record/decisions.d/ADR-029.md
@@ -1,5 +1,5 @@
 ---
-uid: 29
+number: 29
 status: Active
 title: A generated view must be committed by something; the remedy says so where it is read
 version: 2

--- a/record/decisions.d/ADR-030.md
+++ b/record/decisions.d/ADR-030.md
@@ -1,4 +1,5 @@
 ---
+uid: 30
 status: Active
 title: The CLI surface is the workflows, not the module layout
 version: 1

--- a/record/decisions.d/ADR-030.md
+++ b/record/decisions.d/ADR-030.md
@@ -1,5 +1,5 @@
 ---
-uid: 30
+number: 30
 status: Active
 title: The CLI surface is the workflows, not the module layout
 version: 1

--- a/record/decisions.d/ADR-031.md
+++ b/record/decisions.d/ADR-031.md
@@ -1,5 +1,5 @@
 ---
-uid: 31
+number: 31
 status: Active
 title: A fact the tree already states is populated, not demanded
 version: 1

--- a/record/decisions.d/ADR-031.md
+++ b/record/decisions.d/ADR-031.md
@@ -1,4 +1,5 @@
 ---
+uid: 31
 status: Active
 title: A fact the tree already states is populated, not demanded
 version: 1

--- a/record/decisions.d/ADR-032.md
+++ b/record/decisions.d/ADR-032.md
@@ -1,5 +1,5 @@
 ---
-uid: 32
+number: 32
 status: Active
 title: The status reports are committed views, and the badges land on them
 version: 1

--- a/record/decisions.d/ADR-032.md
+++ b/record/decisions.d/ADR-032.md
@@ -1,4 +1,5 @@
 ---
+uid: 32
 status: Active
 title: The status reports are committed views, and the badges land on them
 version: 1

--- a/record/decisions.d/ADR-033.md
+++ b/record/decisions.d/ADR-033.md
@@ -1,5 +1,5 @@
 ---
-uid: 33
+number: 33
 status: Active
 title: A document can opt out of reference checking, and the report counts it
 version: 1

--- a/record/decisions.d/ADR-033.md
+++ b/record/decisions.d/ADR-033.md
@@ -1,4 +1,5 @@
 ---
+uid: 33
 status: Active
 title: A document can opt out of reference checking, and the report counts it
 version: 1

--- a/record/decisions.d/ADR-034.md
+++ b/record/decisions.d/ADR-034.md
@@ -1,4 +1,5 @@
 ---
+uid: 34
 status: Active
 title: Fixture codes come from a registered prefix, not from the sequence
 version: 1

--- a/record/decisions.d/ADR-034.md
+++ b/record/decisions.d/ADR-034.md
@@ -1,5 +1,5 @@
 ---
-uid: 34
+number: 34
 status: Active
 title: Fixture codes come from a registered prefix, not from the sequence
 version: 1

--- a/record/decisions.d/ADR-035.md
+++ b/record/decisions.d/ADR-035.md
@@ -1,5 +1,5 @@
 ---
-uid: 35
+number: 35
 status: Active
 title: Status enforcement is a dial — reported by default, failable by configuration
 version: 1

--- a/record/decisions.d/ADR-035.md
+++ b/record/decisions.d/ADR-035.md
@@ -1,4 +1,5 @@
 ---
+uid: 35
 status: Active
 title: Status enforcement is a dial — reported by default, failable by configuration
 version: 1

--- a/record/decisions.d/ADR-036.md
+++ b/record/decisions.d/ADR-036.md
@@ -1,5 +1,5 @@
 ---
-uid: 36
+number: 36
 status: Active
 title: One scaffold for every entry kind — `luria new`, driven by the config
 version: 2

--- a/record/decisions.d/ADR-036.md
+++ b/record/decisions.d/ADR-036.md
@@ -1,4 +1,5 @@
 ---
+uid: 36
 status: Active
 title: One scaffold for every entry kind — `luria new`, driven by the config
 version: 2

--- a/record/decisions.d/ADR-037.md
+++ b/record/decisions.d/ADR-037.md
@@ -1,4 +1,5 @@
 ---
+uid: 37
 status: Active
 title: The agent file is a map, not a copy
 version: 1

--- a/record/decisions.d/ADR-037.md
+++ b/record/decisions.d/ADR-037.md
@@ -1,5 +1,5 @@
 ---
-uid: 37
+number: 37
 status: Active
 title: The agent file is a map, not a copy
 version: 1

--- a/record/decisions.d/ADR-038.md
+++ b/record/decisions.d/ADR-038.md
@@ -1,5 +1,5 @@
 ---
-uid: 38
+number: 38
 status: Active
 title: The CLI is the interface; the Makefile retires
 version: 1

--- a/record/decisions.d/ADR-038.md
+++ b/record/decisions.d/ADR-038.md
@@ -1,4 +1,5 @@
 ---
+uid: 38
 status: Active
 title: The CLI is the interface; the Makefile retires
 version: 1

--- a/record/decisions.d/ADR-039.md
+++ b/record/decisions.d/ADR-039.md
@@ -1,5 +1,5 @@
 ---
-uid: 39
+number: 39
 status: Active
 title: 'Drive the CLI with Fire: typed functions, derived flags'
 version: 1

--- a/record/decisions.d/ADR-039.md
+++ b/record/decisions.d/ADR-039.md
@@ -1,4 +1,5 @@
 ---
+uid: 39
 status: Active
 title: 'Drive the CLI with Fire: typed functions, derived flags'
 version: 1

--- a/record/decisions.d/ADR-040.md
+++ b/record/decisions.d/ADR-040.md
@@ -1,4 +1,5 @@
 ---
+uid: 40
 status: Active
 title: "Migrations: renaming schemes and moving documents without losing the record's memory"
 version: 1

--- a/record/decisions.d/ADR-040.md
+++ b/record/decisions.d/ADR-040.md
@@ -1,5 +1,5 @@
 ---
-uid: 40
+number: 40
 status: Active
 title: "Migrations: renaming schemes and moving documents without losing the record's memory"
 version: 1

--- a/record/decisions.d/ADR-041.md
+++ b/record/decisions.d/ADR-041.md
@@ -1,4 +1,5 @@
 ---
+uid: 41
 status: Active
 title: "Bugs enter the record characterized: the minimal working example protocol"
 version: 1

--- a/record/decisions.d/ADR-041.md
+++ b/record/decisions.d/ADR-041.md
@@ -1,5 +1,5 @@
 ---
-uid: 41
+number: 41
 status: Active
 title: "Bugs enter the record characterized: the minimal working example protocol"
 version: 1

--- a/record/decisions.d/ADR-042.md
+++ b/record/decisions.d/ADR-042.md
@@ -1,5 +1,5 @@
 ---
-uid: 42
+number: 42
 status: Active
 title: 'The record publishes as a Quartz vault: paths preserved, sources withheld, frontmatter surfaced'
 version: 2

--- a/record/decisions.d/ADR-042.md
+++ b/record/decisions.d/ADR-042.md
@@ -1,4 +1,5 @@
 ---
+uid: 42
 status: Active
 title: 'The record publishes as a Quartz vault: paths preserved, sources withheld, frontmatter surfaced'
 version: 2

--- a/record/decisions.d/ADR-043.md
+++ b/record/decisions.d/ADR-043.md
@@ -1,4 +1,5 @@
 ---
+uid: 43
 status: Active
 title: "The site wears the project's brand: artwork by path, favicon rasterized at build time"
 version: 1

--- a/record/decisions.d/ADR-043.md
+++ b/record/decisions.d/ADR-043.md
@@ -1,5 +1,5 @@
 ---
-uid: 43
+number: 43
 status: Active
 title: "The site wears the project's brand: artwork by path, favicon rasterized at build time"
 version: 1

--- a/record/decisions.d/ADR-044.md
+++ b/record/decisions.d/ADR-044.md
@@ -1,5 +1,5 @@
 ---
-uid: 44
+number: 44
 status: Active
 title: 'The configuration reference is generated from the config schema'
 version: 1

--- a/record/decisions.d/ADR-044.md
+++ b/record/decisions.d/ADR-044.md
@@ -1,4 +1,5 @@
 ---
+uid: 44
 status: Active
 title: 'The configuration reference is generated from the config schema'
 version: 1

--- a/record/decisions.d/ADR-045.md
+++ b/record/decisions.d/ADR-045.md
@@ -1,4 +1,5 @@
 ---
+uid: 45
 status: Active
 title: 'Worked configurations are executable examples, not prose'
 version: 1

--- a/record/decisions.d/ADR-045.md
+++ b/record/decisions.d/ADR-045.md
@@ -1,5 +1,5 @@
 ---
-uid: 45
+number: 45
 status: Active
 title: 'Worked configurations are executable examples, not prose'
 version: 1

--- a/record/decisions.d/ADR-046.md
+++ b/record/decisions.d/ADR-046.md
@@ -1,4 +1,5 @@
 ---
+uid: 46
 status: Active
 title: 'Reference detection is scheme-driven, not three hardcoded patterns'
 version: 1

--- a/record/decisions.d/ADR-046.md
+++ b/record/decisions.d/ADR-046.md
@@ -1,5 +1,5 @@
 ---
-uid: 46
+number: 46
 status: Active
 title: 'Reference detection is scheme-driven, not three hardcoded patterns'
 version: 1

--- a/record/decisions.d/ADR-047.md
+++ b/record/decisions.d/ADR-047.md
@@ -1,4 +1,5 @@
 ---
+uid: 47
 status: Active
 title: 'A declared family replaces the default; settings still merge'
 version: 1

--- a/record/decisions.d/ADR-047.md
+++ b/record/decisions.d/ADR-047.md
@@ -1,5 +1,5 @@
 ---
-uid: 47
+number: 47
 status: Active
 title: 'A declared family replaces the default; settings still merge'
 version: 1

--- a/record/decisions.d/ADR-048.md
+++ b/record/decisions.d/ADR-048.md
@@ -1,4 +1,5 @@
 ---
+uid: 48
 status: Active
 title: 'The scaffold is planned from configuration, not copied from a tree'
 version: 1

--- a/record/decisions.d/ADR-048.md
+++ b/record/decisions.d/ADR-048.md
@@ -1,5 +1,5 @@
 ---
-uid: 48
+number: 48
 status: Active
 title: 'The scaffold is planned from configuration, not copied from a tree'
 version: 1

--- a/record/decisions.d/ADR-049.md
+++ b/record/decisions.d/ADR-049.md
@@ -1,5 +1,5 @@
 ---
-uid: 49
+number: 49
 status: Active
 title: 'Temporary codes at filing; concretized and aliased at the serialization point'
 version: 1

--- a/record/decisions.d/ADR-049.md
+++ b/record/decisions.d/ADR-049.md
@@ -1,4 +1,5 @@
 ---
+uid: 49
 status: Active
 title: 'Temporary codes at filing; concretized and aliased at the serialization point'
 version: 1

--- a/record/decisions.d/ADR-050.md
+++ b/record/decisions.d/ADR-050.md
@@ -1,5 +1,5 @@
 ---
-uid: 50
+number: 50
 status: Active
 formerly:
 - ADR-tmp1pvm1

--- a/record/decisions.d/ADR-050.md
+++ b/record/decisions.d/ADR-050.md
@@ -1,4 +1,5 @@
 ---
+uid: 50
 status: Active
 formerly:
 - ADR-tmp1pvm1

--- a/record/decisions.d/ADR-051.md
+++ b/record/decisions.d/ADR-051.md
@@ -1,5 +1,5 @@
 ---
-uid: 51
+number: 51
 status: Active
 formerly:
 - ADR-tmpn2kd4

--- a/record/decisions.d/ADR-051.md
+++ b/record/decisions.d/ADR-051.md
@@ -1,4 +1,5 @@
 ---
+uid: 51
 status: Active
 formerly:
 - ADR-tmpn2kd4

--- a/record/decisions.d/ADR-052.md
+++ b/record/decisions.d/ADR-052.md
@@ -1,4 +1,5 @@
 ---
+uid: 52
 status: Active
 formerly:
 - ADR-tmp3l17d

--- a/record/decisions.d/ADR-052.md
+++ b/record/decisions.d/ADR-052.md
@@ -1,5 +1,5 @@
 ---
-uid: 52
+number: 52
 status: Active
 formerly:
 - ADR-tmp3l17d

--- a/record/decisions.d/ADR-053.md
+++ b/record/decisions.d/ADR-053.md
@@ -1,5 +1,5 @@
 ---
-uid: 53
+number: 53
 status: Active
 formerly:
 - ADR-tmp2xat5

--- a/record/decisions.d/ADR-053.md
+++ b/record/decisions.d/ADR-053.md
@@ -1,4 +1,5 @@
 ---
+uid: 53
 status: Active
 formerly:
 - ADR-tmp2xat5

--- a/record/decisions.d/ADR-054.md
+++ b/record/decisions.d/ADR-054.md
@@ -1,4 +1,5 @@
 ---
+uid: 54
 status: Active
 formerly:
 - ADR-tmpl1j8m

--- a/record/decisions.d/ADR-054.md
+++ b/record/decisions.d/ADR-054.md
@@ -1,5 +1,5 @@
 ---
-uid: 54
+number: 54
 status: Active
 formerly:
 - ADR-tmpl1j8m

--- a/record/decisions.d/ADR-055.md
+++ b/record/decisions.d/ADR-055.md
@@ -1,5 +1,5 @@
 ---
-uid: 55
+number: 55
 status: Active
 formerly:
 - ADR-tmp4q82g

--- a/record/decisions.d/ADR-055.md
+++ b/record/decisions.d/ADR-055.md
@@ -1,4 +1,5 @@
 ---
+uid: 55
 status: Active
 formerly:
 - ADR-tmp4q82g

--- a/record/decisions.d/ADR-056.md
+++ b/record/decisions.d/ADR-056.md
@@ -1,4 +1,5 @@
 ---
+uid: 56
 status: Active
 formerly:
 - ADR-tmpw84co

--- a/record/decisions.d/ADR-056.md
+++ b/record/decisions.d/ADR-056.md
@@ -1,5 +1,5 @@
 ---
-uid: 56
+number: 56
 status: Active
 formerly:
 - ADR-tmpw84co

--- a/record/decisions.d/ADR-057.md
+++ b/record/decisions.d/ADR-057.md
@@ -1,4 +1,5 @@
 ---
+uid: 57
 status: Active
 formerly:
 - ADR-tmpkpjjo

--- a/record/decisions.d/ADR-057.md
+++ b/record/decisions.d/ADR-057.md
@@ -1,5 +1,5 @@
 ---
-uid: 57
+number: 57
 status: Active
 formerly:
 - ADR-tmpkpjjo

--- a/record/decisions.d/ADR-058.md
+++ b/record/decisions.d/ADR-058.md
@@ -1,5 +1,5 @@
 ---
-uid: 58
+number: 58
 status: Rejected
 status_note: the README opens on what the record does, not on what to call it; the prior art belongs in the concepts page instead
 formerly:

--- a/record/decisions.d/ADR-058.md
+++ b/record/decisions.d/ADR-058.md
@@ -1,4 +1,5 @@
 ---
+uid: 58
 status: Rejected
 status_note: the README opens on what the record does, not on what to call it; the prior art belongs in the concepts page instead
 formerly:

--- a/record/decisions.d/ADR-059.md
+++ b/record/decisions.d/ADR-059.md
@@ -1,4 +1,5 @@
 ---
+uid: 59
 status: Active
 formerly:
 - ADR-tmptfm6m

--- a/record/decisions.d/ADR-059.md
+++ b/record/decisions.d/ADR-059.md
@@ -1,5 +1,5 @@
 ---
-uid: 59
+number: 59
 status: Active
 formerly:
 - ADR-tmptfm6m

--- a/record/decisions.d/ADR-060.md
+++ b/record/decisions.d/ADR-060.md
@@ -1,4 +1,5 @@
 ---
+uid: 60
 status: Active
 formerly:
 - ADR-tmp90kpj

--- a/record/decisions.d/ADR-060.md
+++ b/record/decisions.d/ADR-060.md
@@ -1,5 +1,5 @@
 ---
-uid: 60
+number: 60
 status: Active
 formerly:
 - ADR-tmp90kpj

--- a/record/decisions.d/ADR-061.md
+++ b/record/decisions.d/ADR-061.md
@@ -1,5 +1,5 @@
 ---
-uid: 61
+number: 61
 status: Active
 formerly:
 - ADR-tmpegrf9

--- a/record/decisions.d/ADR-061.md
+++ b/record/decisions.d/ADR-061.md
@@ -1,4 +1,5 @@
 ---
+uid: 61
 status: Active
 formerly:
 - ADR-tmpegrf9

--- a/record/decisions.d/ADR-062.md
+++ b/record/decisions.d/ADR-062.md
@@ -1,5 +1,5 @@
 ---
-uid: 62
+number: 62
 status: Active
 formerly:
 - ADR-tmpqyfpk

--- a/record/decisions.d/ADR-062.md
+++ b/record/decisions.d/ADR-062.md
@@ -1,4 +1,5 @@
 ---
+uid: 62
 status: Active
 formerly:
 - ADR-tmpqyfpk

--- a/record/decisions.d/ADR-063.md
+++ b/record/decisions.d/ADR-063.md
@@ -1,4 +1,5 @@
 ---
+uid: 63
 status: Active
 formerly:
 - ADR-tmpio6tr

--- a/record/decisions.d/ADR-063.md
+++ b/record/decisions.d/ADR-063.md
@@ -1,5 +1,5 @@
 ---
-uid: 63
+number: 63
 status: Active
 formerly:
 - ADR-tmpio6tr

--- a/record/decisions.d/ADR-064.md
+++ b/record/decisions.d/ADR-064.md
@@ -1,4 +1,5 @@
 ---
+uid: 64
 status: Active
 formerly:
 - ADR-tmp91qkk

--- a/record/decisions.d/ADR-064.md
+++ b/record/decisions.d/ADR-064.md
@@ -1,5 +1,5 @@
 ---
-uid: 64
+number: 64
 status: Active
 formerly:
 - ADR-tmp91qkk

--- a/record/decisions.d/ADR-065.md
+++ b/record/decisions.d/ADR-065.md
@@ -1,5 +1,5 @@
 ---
-uid: 65
+number: 65
 status: Active
 formerly:
 - ADR-tmphi0lg

--- a/record/decisions.d/ADR-065.md
+++ b/record/decisions.d/ADR-065.md
@@ -1,4 +1,5 @@
 ---
+uid: 65
 status: Active
 formerly:
 - ADR-tmphi0lg

--- a/record/decisions.d/ADR-066.md
+++ b/record/decisions.d/ADR-066.md
@@ -1,5 +1,5 @@
 ---
-uid: 66
+number: 66
 status: Active
 formerly:
 - ADR-tmptuwov

--- a/record/decisions.d/ADR-066.md
+++ b/record/decisions.d/ADR-066.md
@@ -1,4 +1,5 @@
 ---
+uid: 66
 status: Active
 formerly:
 - ADR-tmptuwov

--- a/record/decisions.d/ADR-067.md
+++ b/record/decisions.d/ADR-067.md
@@ -1,4 +1,5 @@
 ---
+uid: 67
 status: Active
 formerly:
 - ADR-tmpo1286

--- a/record/decisions.d/ADR-067.md
+++ b/record/decisions.d/ADR-067.md
@@ -1,5 +1,5 @@
 ---
-uid: 67
+number: 67
 status: Active
 formerly:
 - ADR-tmpo1286

--- a/record/decisions.d/ADR-068.md
+++ b/record/decisions.d/ADR-068.md
@@ -1,5 +1,5 @@
 ---
-uid: 68
+number: 68
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-068.md
+++ b/record/decisions.d/ADR-068.md
@@ -1,4 +1,5 @@
 ---
+uid: 68
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-069.md
+++ b/record/decisions.d/ADR-069.md
@@ -1,4 +1,5 @@
 ---
+uid: 69
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-069.md
+++ b/record/decisions.d/ADR-069.md
@@ -1,5 +1,5 @@
 ---
-uid: 69
+number: 69
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-070.md
+++ b/record/decisions.d/ADR-070.md
@@ -1,5 +1,5 @@
 ---
-uid: 70
+number: 70
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-070.md
+++ b/record/decisions.d/ADR-070.md
@@ -1,4 +1,5 @@
 ---
+uid: 70
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-071.md
+++ b/record/decisions.d/ADR-071.md
@@ -1,4 +1,5 @@
 ---
+uid: 71
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-071.md
+++ b/record/decisions.d/ADR-071.md
@@ -1,5 +1,5 @@
 ---
-uid: 71
+number: 71
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-072.md
+++ b/record/decisions.d/ADR-072.md
@@ -1,5 +1,5 @@
 ---
-uid: 72
+number: 72
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-072.md
+++ b/record/decisions.d/ADR-072.md
@@ -1,4 +1,5 @@
 ---
+uid: 72
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-073.md
+++ b/record/decisions.d/ADR-073.md
@@ -1,4 +1,5 @@
 ---
+uid: 73
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-073.md
+++ b/record/decisions.d/ADR-073.md
@@ -1,5 +1,5 @@
 ---
-uid: 73
+number: 73
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-074.md
+++ b/record/decisions.d/ADR-074.md
@@ -1,4 +1,5 @@
 ---
+uid: 74
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-074.md
+++ b/record/decisions.d/ADR-074.md
@@ -1,5 +1,5 @@
 ---
-uid: 74
+number: 74
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-075.md
+++ b/record/decisions.d/ADR-075.md
@@ -1,5 +1,5 @@
 ---
-uid: 75
+number: 75
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-075.md
+++ b/record/decisions.d/ADR-075.md
@@ -1,4 +1,5 @@
 ---
+uid: 75
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-076.md
+++ b/record/decisions.d/ADR-076.md
@@ -1,4 +1,5 @@
 ---
+uid: 76
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-076.md
+++ b/record/decisions.d/ADR-076.md
@@ -1,5 +1,5 @@
 ---
-uid: 76
+number: 76
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-077.md
+++ b/record/decisions.d/ADR-077.md
@@ -1,5 +1,5 @@
 ---
-uid: 77
+number: 77
 status: Active
 formerly:
 - ADR-tmpk5xbb

--- a/record/decisions.d/ADR-077.md
+++ b/record/decisions.d/ADR-077.md
@@ -1,4 +1,5 @@
 ---
+uid: 77
 status: Active
 formerly:
 - ADR-tmpk5xbb

--- a/record/decisions.d/ADR-078.md
+++ b/record/decisions.d/ADR-078.md
@@ -1,4 +1,5 @@
 ---
+uid: 78
 status: Active
 formerly:
 - ADR-tmpiv6ul

--- a/record/decisions.d/ADR-078.md
+++ b/record/decisions.d/ADR-078.md
@@ -1,5 +1,5 @@
 ---
-uid: 78
+number: 78
 status: Active
 formerly:
 - ADR-tmpiv6ul

--- a/record/decisions.d/ADR-079.md
+++ b/record/decisions.d/ADR-079.md
@@ -1,5 +1,5 @@
 ---
-uid: 79
+number: 79
 status: Active
 formerly:
 - ADR-tmpn57wd

--- a/record/decisions.d/ADR-079.md
+++ b/record/decisions.d/ADR-079.md
@@ -1,4 +1,5 @@
 ---
+uid: 79
 status: Active
 formerly:
 - ADR-tmpn57wd

--- a/record/decisions.d/ADR-080.md
+++ b/record/decisions.d/ADR-080.md
@@ -1,5 +1,5 @@
 ---
-uid: 80
+number: 80
 status: Active
 formerly:
 - ADR-tmpjg0jj

--- a/record/decisions.d/ADR-080.md
+++ b/record/decisions.d/ADR-080.md
@@ -1,4 +1,5 @@
 ---
+uid: 80
 status: Active
 formerly:
 - ADR-tmpjg0jj

--- a/record/decisions.d/ADR-081.md
+++ b/record/decisions.d/ADR-081.md
@@ -1,5 +1,5 @@
 ---
-uid: 81
+number: 81
 status: Active
 formerly:
 - ADR-tmpmc2vu

--- a/record/decisions.d/ADR-081.md
+++ b/record/decisions.d/ADR-081.md
@@ -1,4 +1,5 @@
 ---
+uid: 81
 status: Active
 formerly:
 - ADR-tmpmc2vu

--- a/record/decisions.d/ADR-082.md
+++ b/record/decisions.d/ADR-082.md
@@ -1,5 +1,5 @@
 ---
-uid: 82
+number: 82
 status: Active
 formerly:
 - ADR-tmpngw57

--- a/record/decisions.d/ADR-082.md
+++ b/record/decisions.d/ADR-082.md
@@ -1,4 +1,5 @@
 ---
+uid: 82
 status: Active
 formerly:
 - ADR-tmpngw57

--- a/record/decisions.d/ADR-083.md
+++ b/record/decisions.d/ADR-083.md
@@ -1,4 +1,5 @@
 ---
+uid: 83
 status: Active
 formerly:
 - ADR-tmpichk4

--- a/record/decisions.d/ADR-083.md
+++ b/record/decisions.d/ADR-083.md
@@ -1,5 +1,5 @@
 ---
-uid: 83
+number: 83
 status: Active
 formerly:
 - ADR-tmpichk4

--- a/record/decisions.d/ADR-084.md
+++ b/record/decisions.d/ADR-084.md
@@ -1,5 +1,5 @@
 ---
-uid: 84
+number: 84
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-084.md
+++ b/record/decisions.d/ADR-084.md
@@ -1,4 +1,5 @@
 ---
+uid: 84
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-085.md
+++ b/record/decisions.d/ADR-085.md
@@ -1,5 +1,5 @@
 ---
-uid: 85
+number: 85
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-085.md
+++ b/record/decisions.d/ADR-085.md
@@ -1,4 +1,5 @@
 ---
+uid: 85
 # Don't copy this file by hand — run `luria new adr`, which assigns the
 # identity and fills in the fields a machine can compute. WHICH identity
 # depends on the scheme's `allocate` mode: `filing` (the default) takes the

--- a/record/decisions.d/ADR-086.md
+++ b/record/decisions.d/ADR-086.md
@@ -1,5 +1,5 @@
 ---
-uid: 86
+number: 86
 status: Proposed
 formerly:
 - ADR-tmp2rbag

--- a/record/decisions.d/ADR-086.md
+++ b/record/decisions.d/ADR-086.md
@@ -1,4 +1,5 @@
 ---
+uid: 86
 status: Proposed
 formerly:
 - ADR-tmp2rbag

--- a/record/decisions.d/ADR-tmp9ljfi.md
+++ b/record/decisions.d/ADR-tmp9ljfi.md
@@ -7,7 +7,7 @@ tags:
 date: '2026-09-08'
 issue: '#219'
 summary: >-
-  A scheme document carries `uid:`, and its filename is derived from it —
+  A scheme document carries `number:`, and its filename is derived from it —
   the model journals have always used for `created:`, applied to schemes.
   Identity in the filesystem was the obstacle to expressive filenames and
   aliases, because anything the name encoded became load-bearing. A counter
@@ -35,10 +35,10 @@ slug) were readable without a lookup, and became `SOTA-001` and nothing.
 
 ## Decision
 
-A scheme document carries `uid:`, an integer, and the filename is a
+A scheme document carries `number:`, an integer, and the filename is a
 projection of it.
 
-- `Scheme.uid_of()` reads the field, falling back to the filename.
+- `Scheme.number_of()` reads the field, falling back to the filename.
 - `luria lint` reports a document whose field and filename disagree.
 - `luria repair` writes the field from the path where it is absent.
 - `luria new` writes it for a scheme that allocates on filing; `luria
@@ -69,6 +69,15 @@ buy merge-safety that temporary codes already provide.
   A number makes no claim that can rot. The rule this settles: a derived
   value may participate in identity only if it is recomputed, and it may only
   be recomputed if it is not identity.
+- **Call the field `uid:`.** The first spelling, and wrong twice over. The
+  "u" promises uniqueness across the record, and the value is unique only
+  within its scheme — three schemes give three documents `1`. And `uid` was
+  already taken: a remote declares one to mean an opaque foreign tail
+  ([ADR-024](ADR-024.md)), so the same word would have named two unrelated
+  things. `number` is what the code already calls this value everywhere
+  (`number_of`, `Adr.number`, the `{number}` template variable), promises
+  nothing about scope, and leaves `uid` free for a record-global identifier
+  if one is ever wanted.
 - **Rename the file automatically when the two disagree.** Rejected: which of
   the two is right is a question only the author can answer, and renaming on
   a guess moves a document's identity and orphans the links to it. An

--- a/record/decisions.d/ADR-tmp9ljfi.md
+++ b/record/decisions.d/ADR-tmp9ljfi.md
@@ -1,0 +1,94 @@
+---
+status: Proposed
+title: 'Identity is a field; the filename is a projection of it'
+version: 1
+tags:
+- record
+date: '2026-09-08'
+issue: '#219'
+summary: >-
+  A scheme document carries `uid:`, and its filename is derived from it —
+  the model journals have always used for `created:`, applied to schemes.
+  Identity in the filesystem was the obstacle to expressive filenames and
+  aliases, because anything the name encoded became load-bearing. A counter
+  rather than a UUID: the sequence carries the order documents were filed,
+  and merge-safety is already solved by temporary codes.
+---
+
+# ADR-tmp9ljfi: Identity is a field; the filename is a projection of it
+
+## Context
+
+Journals and schemes disagreed about where identity lives, and neither said
+why. A journal entry's path derives from its `created:` frontmatter, and
+`luria lint` checks the two agree — stated in `check_journals` as: *"the
+ordering the whole scheme rests on says one thing and the frontmatter says
+another."* A scheme document had no such field. Its number was parsed out of
+the filename, so the name on disk *was* the identity.
+
+That is what blocked expressive filenames and derived aliases. Any
+information a filename carries becomes load-bearing the moment the filename
+is the identity, so a slug cannot be added without making the slug part of
+what a citation resolves through. The consuming record had paid this: its
+pre-migration identifiers (`MLR-2014-Kingma001-0001`, plus a `topic_id`
+slug) were readable without a lookup, and became `SOTA-001` and nothing.
+
+## Decision
+
+A scheme document carries `uid:`, an integer, and the filename is a
+projection of it.
+
+- `Scheme.uid_of()` reads the field, falling back to the filename.
+- `luria lint` reports a document whose field and filename disagree.
+- `luria repair` writes the field from the path where it is absent.
+- `luria new` writes it for a scheme that allocates on filing; `luria
+  concretize` writes it for a merge-allocated one, at the moment it assigns
+  a number at all ([ADR-049](ADR-049.md)).
+
+The fallback is what makes this introducible without a migration anyone has
+to run: a record written before the field existed reads exactly as it did,
+and acquires the field the next time `luria repair` runs.
+
+**A counter, not a UUID.** The number carries the order documents were filed
+— the scaffold says so in as many words — and a UUID would discard that to
+buy merge-safety that temporary codes already provide.
+
+## Alternatives considered
+
+- **Leave identity in the filename.** The status quo, and the thing that
+  makes every downstream ask impossible: a filename that carries meaning and
+  also carries identity cannot have the meaning corrected.
+- **A UUID or URI per document.** Genuinely more robust against collision,
+  and it discards ordering to solve a problem [ADR-049](ADR-049.md) closed. Rejected for
+  paying information to buy nothing new.
+- **Derive the code from frontmatter at allocation** — evaluate a template
+  once in `luria concretize` and freeze the result. Technically safe:
+  identity never moves afterwards. Rejected because a seeded code *looks*
+  derived and is not, so correcting an author leaves a code reading the old
+  name forever, correctly-by-design, and every future reader has to be told.
+  A number makes no claim that can rot. The rule this settles: a derived
+  value may participate in identity only if it is recomputed, and it may only
+  be recomputed if it is not identity.
+- **Rename the file automatically when the two disagree.** Rejected: which of
+  the two is right is a question only the author can answer, and renaming on
+  a guess moves a document's identity and orphans the links to it. An
+  *absent* field is the mechanical case, and that one is repaired.
+
+## Consequences
+
+`Scheme.documents()` goes from a directory glob to a glob plus a frontmatter
+read. Cached on the file's `(mtime, size)` rather than reset by hand, so a
+writer that forgets to invalidate cannot serve a stale identity. That it is
+one function to change at all is owed to [DP-4](../../docs/design-principles.md#dp-4): five copies of that glob had
+accumulated and were consolidated for unrelated reasons.
+
+A disagreement between field and filename is now a way to break reference
+resolution that did not previously exist — `documents()` reads the field
+while a link target is written from the code — which is why the check is a
+violation rather than a report.
+
+Verified on both records before landing: 436 documents in the consuming
+anthology and 103 here acquired the field, `luria lint` held its exact
+baseline in both, and **every generated view was byte-identical** except the
+reference report, whose line numbers shift by one because the field adds one
+line. The guard was fired on a real document too, not only a fixture.

--- a/record/devlog.d/2026/09/08/185747.md
+++ b/record/devlog.d/2026/09/08/185747.md
@@ -1,0 +1,58 @@
+---
+title: 'Identity moved into the document'
+created: '2026-09-08T18:57:47'
+tags: []
+---
+
+The change is small because journals had already solved it. `check_journals`
+says the whole thing out loud — *"A journal entry's path is derived from its
+`created:` timestamp, and the two have to agree"* — and `luria repair`
+already back-fills that field from the path. Schemes just never got the same
+treatment, and nothing anywhere says why. So this is less a feature than the
+end of an inconsistency, and the implementation is mostly the journal's,
+copied one directory over.
+
+**Three things made it cheap, all of them already paid for.**
+
+- `Scheme.documents()` is *"the one place a scheme directory is read"* —
+  [DP-4](../design-principles.md#dp-4) consolidated five copies of that glob for unrelated reasons. Twenty-odd
+  callers read identity, and exactly one of them touches the filesystem, so
+  moving the source of truth is a one-function change.
+- `number_of()` is already tolerant of a trailing slug: `adr-010-some-title.md`
+  parses today. luria can already *read* expressive filenames; it has only
+  ever *written* the short form.
+- `journal.populate_created()` is the back-fill, working, with a slot beside
+  it in `repair.apply()`.
+
+**The caching decision is the one I would get wrong next time.** Reading
+`uid:` costs a parse, on the hot path, so it has to be cached — and the
+obvious cache is a module dict with an explicit `reset()`, the way
+`aliases.py` does it. That would have been a bug generator: `concretize`
+writes a document and immediately re-reads it, `repair` writes 400, and every
+future writer would have to remember. Keyed on the file's `(mtime, size)`
+instead, so a write invalidates its own entry and no caller has to know the
+cache exists.
+
+**Why a disagreement is a violation and not a repair.** The tempting move is
+to rename the file to match the field, since the field is the truth. But
+which of the two is right is genuinely unknowable — someone may have renamed
+the file deliberately, or fat-fingered the field — and renaming on a guess
+moves identity and orphans every link. An *absent* field has a witness (the
+path) and is repaired; a *contradicted* one has two witnesses and is
+reported.
+
+**Fired on both records, per the agreement.** 436 documents in the anthology
+and 103 here. Lint held its exact baseline in both, and every generated view
+came out byte-identical except `reference-status.md`, whose citation line
+numbers shift down by one — because the field adds one line, which is the
+answer you want that check to give. Then the guard itself, on a real
+document rather than a fixture: `uid:` edited to disagree with the filename,
+reported, reverted.
+
+**One thing to watch.** My new test suite tripped the reference checker
+twice — `ADR-007` is Superseded here, and `ADR-tmpabcde` resolves to
+nothing — because a suite about how codes are read has to write codes down.
+`tests/test_migrations.py` hit this before me and carries the same
+`unlinted-file:` directive. Two files is not a pattern yet; three would be,
+and the fix then is for the scanners to know that a test fixture is a quote,
+not an address.

--- a/record/devlog.d/2026/09/08/185747.md
+++ b/record/devlog.d/2026/09/08/185747.md
@@ -25,7 +25,7 @@ copied one directory over.
   it in `repair.apply()`.
 
 **The caching decision is the one I would get wrong next time.** Reading
-`uid:` costs a parse, on the hot path, so it has to be cached — and the
+`number:` costs a parse, on the hot path, so it has to be cached — and the
 obvious cache is a module dict with an explicit `reset()`, the way
 `aliases.py` does it. That would have been a bug generator: `concretize`
 writes a document and immediately re-reads it, `repair` writes 400, and every
@@ -46,7 +46,7 @@ and 103 here. Lint held its exact baseline in both, and every generated view
 came out byte-identical except `reference-status.md`, whose citation line
 numbers shift down by one — because the field adds one line, which is the
 answer you want that check to give. Then the guard itself, on a real
-document rather than a fixture: `uid:` edited to disagree with the filename,
+document rather than a fixture: `number:` edited to disagree with the filename,
 reported, reverted.
 
 **One thing to watch.** My new test suite tripped the reference checker

--- a/record/principles.d/DP-001.md
+++ b/record/principles.d/DP-001.md
@@ -1,4 +1,5 @@
 ---
+uid: 1
 status: Active
 title: 'No silent refusal'
 version: 1

--- a/record/principles.d/DP-001.md
+++ b/record/principles.d/DP-001.md
@@ -1,5 +1,5 @@
 ---
-uid: 1
+number: 1
 status: Active
 title: 'No silent refusal'
 version: 1

--- a/record/principles.d/DP-002.md
+++ b/record/principles.d/DP-002.md
@@ -1,4 +1,5 @@
 ---
+uid: 2
 status: Active
 title: 'A file every contribution must touch is a lock — hand out fragments, generate the view'
 version: 2

--- a/record/principles.d/DP-002.md
+++ b/record/principles.d/DP-002.md
@@ -1,5 +1,5 @@
 ---
-uid: 2
+number: 2
 status: Active
 title: 'A file every contribution must touch is a lock — hand out fragments, generate the view'
 version: 2

--- a/record/principles.d/DP-003.md
+++ b/record/principles.d/DP-003.md
@@ -1,5 +1,5 @@
 ---
-uid: 3
+number: 3
 status: Active
 title: 'A hand-maintained projection of a source of truth will drift — derive it'
 version: 2

--- a/record/principles.d/DP-003.md
+++ b/record/principles.d/DP-003.md
@@ -1,4 +1,5 @@
 ---
+uid: 3
 status: Active
 title: 'A hand-maintained projection of a source of truth will drift — derive it'
 version: 2

--- a/record/principles.d/DP-004.md
+++ b/record/principles.d/DP-004.md
@@ -1,5 +1,5 @@
 ---
-uid: 4
+number: 4
 status: Active
 title: 'One authoritative implementation, read the same way everywhere'
 version: 1

--- a/record/principles.d/DP-004.md
+++ b/record/principles.d/DP-004.md
@@ -1,4 +1,5 @@
 ---
+uid: 4
 status: Active
 title: 'One authoritative implementation, read the same way everywhere'
 version: 1

--- a/record/principles.d/DP-005.md
+++ b/record/principles.d/DP-005.md
@@ -1,4 +1,5 @@
 ---
+uid: 5
 status: Active
 title: 'Culture must be compiled'
 version: 1

--- a/record/principles.d/DP-005.md
+++ b/record/principles.d/DP-005.md
@@ -1,5 +1,5 @@
 ---
-uid: 5
+number: 5
 status: Active
 title: 'Culture must be compiled'
 version: 1

--- a/record/principles.d/DP-006.md
+++ b/record/principles.d/DP-006.md
@@ -1,4 +1,5 @@
 ---
+uid: 6
 status: Active
 title: 'Fire before trusting'
 version: 1

--- a/record/principles.d/DP-006.md
+++ b/record/principles.d/DP-006.md
@@ -1,5 +1,5 @@
 ---
-uid: 6
+number: 6
 status: Active
 title: 'Fire before trusting'
 version: 1

--- a/record/principles.d/DP-007.md
+++ b/record/principles.d/DP-007.md
@@ -1,4 +1,5 @@
 ---
+uid: 7
 status: Active
 title: 'No private brains'
 version: 1

--- a/record/principles.d/DP-007.md
+++ b/record/principles.d/DP-007.md
@@ -1,5 +1,5 @@
 ---
-uid: 7
+number: 7
 status: Active
 title: 'No private brains'
 version: 1

--- a/record/principles.d/DP-008.md
+++ b/record/principles.d/DP-008.md
@@ -1,4 +1,5 @@
 ---
+uid: 8
 status: Active
 title: 'File it in the same contribution as the work'
 version: 1

--- a/record/principles.d/DP-008.md
+++ b/record/principles.d/DP-008.md
@@ -1,5 +1,5 @@
 ---
-uid: 8
+number: 8
 status: Active
 title: 'File it in the same contribution as the work'
 version: 1

--- a/record/principles.d/DP-009.md
+++ b/record/principles.d/DP-009.md
@@ -1,5 +1,5 @@
 ---
-uid: 9
+number: 9
 status: Active
 title: 'Structure is read before text — spend affordances deliberately'
 version: 2

--- a/record/principles.d/DP-009.md
+++ b/record/principles.d/DP-009.md
@@ -1,4 +1,5 @@
 ---
+uid: 9
 status: Active
 title: 'Structure is read before text — spend affordances deliberately'
 version: 2

--- a/record/principles.d/DP-010.md
+++ b/record/principles.d/DP-010.md
@@ -1,4 +1,5 @@
 ---
+uid: 10
 status: Active
 title: 'Defaults follow the failure mode: guards opt out, disclosures opt in'
 version: 1

--- a/record/principles.d/DP-010.md
+++ b/record/principles.d/DP-010.md
@@ -1,5 +1,5 @@
 ---
-uid: 10
+number: 10
 status: Active
 title: 'Defaults follow the failure mode: guards opt out, disclosures opt in'
 version: 1

--- a/record/principles.d/DP-011.md
+++ b/record/principles.d/DP-011.md
@@ -1,5 +1,5 @@
 ---
-uid: 11
+number: 11
 status: Active
 formerly:
 - DP-tmp6o4c5

--- a/record/principles.d/DP-011.md
+++ b/record/principles.d/DP-011.md
@@ -1,4 +1,5 @@
 ---
+uid: 11
 status: Active
 formerly:
 - DP-tmp6o4c5

--- a/record/principles.d/DP-012.md
+++ b/record/principles.d/DP-012.md
@@ -1,5 +1,5 @@
 ---
-uid: 12
+number: 12
 status: Active
 formerly:
 - DP-tmpprjho

--- a/record/principles.d/DP-012.md
+++ b/record/principles.d/DP-012.md
@@ -1,4 +1,5 @@
 ---
+uid: 12
 status: Active
 formerly:
 - DP-tmpprjho

--- a/record/principles.d/DP-013.md
+++ b/record/principles.d/DP-013.md
@@ -1,4 +1,5 @@
 ---
+uid: 13
 status: Active
 formerly:
 - DP-tmpqu8fy

--- a/record/principles.d/DP-013.md
+++ b/record/principles.d/DP-013.md
@@ -1,5 +1,5 @@
 ---
-uid: 13
+number: 13
 status: Active
 formerly:
 - DP-tmpqu8fy

--- a/record/principles.d/DP-014.md
+++ b/record/principles.d/DP-014.md
@@ -1,5 +1,5 @@
 ---
-uid: 14
+number: 14
 status: Active
 formerly:
 - DP-tmp5669r

--- a/record/principles.d/DP-014.md
+++ b/record/principles.d/DP-014.md
@@ -1,4 +1,5 @@
 ---
+uid: 14
 status: Active
 formerly:
 - DP-tmp5669r

--- a/record/principles.d/DP-015.md
+++ b/record/principles.d/DP-015.md
@@ -1,5 +1,5 @@
 ---
-uid: 15
+number: 15
 status: Active
 formerly:
 - DP-tmp6fv3m

--- a/record/principles.d/DP-015.md
+++ b/record/principles.d/DP-015.md
@@ -1,4 +1,5 @@
 ---
+uid: 15
 status: Active
 formerly:
 - DP-tmp6fv3m

--- a/record/principles.d/DP-016.md
+++ b/record/principles.d/DP-016.md
@@ -1,5 +1,5 @@
 ---
-uid: 16
+number: 16
 status: Active
 formerly:
 - DP-tmpcgay6

--- a/record/principles.d/DP-016.md
+++ b/record/principles.d/DP-016.md
@@ -1,4 +1,5 @@
 ---
+uid: 16
 status: Active
 formerly:
 - DP-tmpcgay6

--- a/record/principles.d/DP-017.md
+++ b/record/principles.d/DP-017.md
@@ -1,4 +1,5 @@
 ---
+uid: 17
 status: Active
 formerly:
 - DP-tmpm6jp4

--- a/record/principles.d/DP-017.md
+++ b/record/principles.d/DP-017.md
@@ -1,5 +1,5 @@
 ---
-uid: 17
+number: 17
 status: Active
 formerly:
 - DP-tmpm6jp4

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -41,11 +41,11 @@ allocate = "{allocate}"
     return tmp_path
 
 
-def doc(root: Path, name: str, *, uid: int | None = None,
+def doc(root: Path, name: str, *, number: int | None = None,
         title: str = "A decision") -> Path:
     front = ["---", "status: Active", f"title: '{title}'"]
-    if uid is not None:
-        front.insert(1, f"uid: {uid}")
+    if number is not None:
+        front.insert(1, f"number: {number}")
     front += ["date: '2026-01-01'", "---", "", f"# {name}: {title}", "", "Body."]
     return write(root, f"record/decisions.d/{name}.md", "\n".join(front) + "\n")
 
@@ -58,30 +58,35 @@ def scheme():
 
 def test_the_field_wins_over_the_filename(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007", uid=42)
-    assert scheme().uid_of(path) == 42
+    path = doc(root, "ADR-007", number=42)
+    assert scheme().number_of(path) == 42
     assert scheme().documents() == {42: path}
     assert adr_index.Adr(path, scheme()).code == "ADR-042"
 
 
 def test_the_filename_answers_when_the_field_is_absent(tmp_path, monkeypatch):
-    """A record written before `uid:` existed still reads — which is what
+    """A record written before `number:` existed still reads — which is what
     makes the field introducible without a migration anyone has to run."""
     root = project(tmp_path, monkeypatch)
     path = doc(root, "ADR-007")
-    assert scheme().uid_of(path) == 7
+    assert scheme().number_of(path) == 7
     assert scheme().documents() == {7: path}
 
 
-def test_a_uid_in_the_body_is_prose_not_a_claim(tmp_path, monkeypatch):
+def test_a_number_in_the_body_is_prose_not_a_claim(tmp_path, monkeypatch):
+    """Not hypothetical: a line wrap in a real note put `number:` at column
+    zero mid-sentence ("...here mainly for the 10%\nnumber: the record's
+    optimizer practices..."). The frontmatter boundary is what keeps prose
+    from claiming an identity."""
     root = project(tmp_path, monkeypatch)
     path = write(root, "record/decisions.d/ADR-007.md",
                  "---\nstatus: Active\ntitle: 'A decision'\ndate: '2026-01-01'\n"
-                 "---\n\n# ADR-007: A decision\n\nWe considered\nuid: 99\n")
-    assert scheme().uid_of(path) == 7
+                 "---\n\n# ADR-007: A decision\n\nhere mainly for the 10%\n"
+                 "number: the record's optimizer practices trade convergence\n")
+    assert scheme().number_of(path) == 7
 
 
-def test_a_temporary_document_has_no_uid_yet(tmp_path, monkeypatch):
+def test_a_temporary_document_has_no_number_yet(tmp_path, monkeypatch):
     """By design: a merge-allocated document holds no claim on the sequence
     until `luria concretize` assigns one (ADR-049)."""
     root = project(tmp_path, monkeypatch, allocate="merge")
@@ -94,30 +99,30 @@ def test_the_cache_expires_when_the_file_changes(tmp_path, monkeypatch):
     """Keyed on the stat rather than reset by hand, so a writer that forgets
     to invalidate cannot serve a stale identity."""
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007", uid=42)
-    assert scheme().uid_of(path) == 42
+    path = doc(root, "ADR-007", number=42)
+    assert scheme().number_of(path) == 42
     import os
-    path.write_text(path.read_text().replace("uid: 42", "uid: 43"))
+    path.write_text(path.read_text().replace("number: 42", "number: 43"))
     os.utime(path, (0, 0))
-    assert scheme().uid_of(path) == 43
+    assert scheme().number_of(path) == 43
 
 
 # --- the agreement check ----------------------------------------------------
 
 def test_a_disagreement_is_a_finding(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007", uid=42)
+    doc(root, "ADR-007", number=42)
     errors: list[str] = []
-    lint.check_uids(errors)
+    lint.check_numbers(errors)
     assert len(errors) == 1
-    assert "`uid: 42` but the filename says 7" in errors[0]
+    assert "`number: 42` but the filename says 7" in errors[0]
 
 
 def test_agreement_is_silent(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007", uid=7)
+    doc(root, "ADR-007", number=7)
     errors: list[str] = []
-    lint.check_uids(errors)
+    lint.check_numbers(errors)
     assert errors == []
 
 
@@ -127,7 +132,7 @@ def test_an_absent_field_is_not_a_disagreement(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
     doc(root, "ADR-007")
     errors: list[str] = []
-    lint.check_uids(errors)
+    lint.check_numbers(errors)
     assert errors == []
 
 
@@ -136,23 +141,23 @@ def test_an_absent_field_is_not_a_disagreement(tmp_path, monkeypatch):
 def test_repair_populates_the_field_from_the_path(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
     path = doc(root, "ADR-007")
-    assert repair.populate_uids(scheme()) == [path]
-    assert "uid: 7\n" in path.read_text()
-    assert path.read_text().startswith("---\nuid: 7\n")
+    assert repair.populate_numbers(scheme()) == [path]
+    assert "number: 7\n" in path.read_text()
+    assert path.read_text().startswith("---\nnumber: 7\n")
 
 
 def test_repair_is_idempotent(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
     doc(root, "ADR-007")
-    repair.populate_uids(scheme())
-    assert repair.populate_uids(scheme()) == []
+    repair.populate_numbers(scheme())
+    assert repair.populate_numbers(scheme()) == []
 
 
 def test_repair_leaves_a_temporary_document_alone(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch, allocate="merge")
     path = doc(root, "ADR-tmpabcde")
     before = path.read_text()
-    assert repair.populate_uids(scheme()) == []
+    assert repair.populate_numbers(scheme()) == []
     assert path.read_text() == before
 
 
@@ -160,7 +165,7 @@ def test_repair_never_invents_a_number(tmp_path, monkeypatch):
     """A file whose name carries no number has no witness to repair from."""
     root = project(tmp_path, monkeypatch)
     doc(root, "notes")
-    assert repair.populate_uids(scheme()) == []
+    assert repair.populate_numbers(scheme()) == []
 
 
 # --- the writers ------------------------------------------------------------
@@ -168,25 +173,25 @@ def test_repair_never_invents_a_number(tmp_path, monkeypatch):
 def test_new_writes_the_field(tmp_path, monkeypatch):
     project(tmp_path, monkeypatch)
     path = new.new_entry("adr", {"title": "First"}, None)
-    assert path.read_text().startswith("---\nuid: 1\n")
-    assert scheme().uid_of(path) == 1
+    assert path.read_text().startswith("---\nnumber: 1\n")
+    assert scheme().number_of(path) == 1
 
 
 def test_new_leaves_it_out_for_a_merge_allocated_scheme(tmp_path, monkeypatch):
     project(tmp_path, monkeypatch, allocate="merge")
     path = new.new_entry("adr", {"title": "First"}, None)
-    assert "uid:" not in path.read_text()
+    assert "number:" not in path.read_text()
 
 
-def test_write_uid_replaces_rather_than_duplicates(tmp_path, monkeypatch):
-    text = "---\nuid: 3\nstatus: Active\n---\n\n# ADR-003\n"
-    out = new.write_uid(text, 9)
-    assert out.count("uid:") == 1
-    assert "uid: 9" in out
+def test_write_number_replaces_rather_than_duplicates(tmp_path, monkeypatch):
+    text = "---\nnumber: 3\nstatus: Active\n---\n\n# ADR-003\n"
+    out = new.write_number(text, 9)
+    assert out.count("number:") == 1
+    assert "number: 9" in out
 
 
-def test_write_uid_leaves_a_document_with_no_frontmatter_alone(tmp_path):
-    assert new.write_uid("# Heading\n", 4) == "# Heading\n"
+def test_write_number_leaves_a_document_with_no_frontmatter_alone(tmp_path):
+    assert new.write_number("# Heading\n", 4) == "# Heading\n"
 
 
 def test_concretize_writes_the_field_when_it_assigns_the_number(
@@ -194,13 +199,13 @@ def test_concretize_writes_the_field_when_it_assigns_the_number(
     """The one moment a merge-allocated document acquires a number at all."""
     from luria import concretize
     root = project(tmp_path, monkeypatch, allocate="merge")
-    doc(root, "ADR-001", uid=1)
+    doc(root, "ADR-001", number=1)
     doc(root, "ADR-tmpabcde", title="Landed from a branch")
     concretize.run()
     landed = root / "record/decisions.d/ADR-002.md"
     assert landed.exists()
-    assert "uid: 2\n" in landed.read_text()
-    assert scheme().uid_of(landed) == 2
+    assert "number: 2\n" in landed.read_text()
+    assert scheme().number_of(landed) == 2
 
 
 def test_unterminated_frontmatter_declares_nothing(tmp_path, monkeypatch):
@@ -208,17 +213,17 @@ def test_unterminated_frontmatter_declares_nothing(tmp_path, monkeypatch):
     identity has to agree, or the two disagree about what a document says."""
     root = project(tmp_path, monkeypatch)
     path = write(root, "record/decisions.d/ADR-007.md",
-                 "---\nstatus: Active\nuid: 42\n\n# ADR-007\n")
-    assert config._declared_uid(path) is None
-    assert scheme().uid_of(path) == 7
+                 "---\nstatus: Active\nnumber: 42\n\n# ADR-007\n")
+    assert config._declared_number(path) is None
+    assert scheme().number_of(path) == 7
 
 
-def test_an_indented_uid_is_inside_another_field(tmp_path, monkeypatch):
+def test_an_indented_number_is_inside_another_field(tmp_path, monkeypatch):
     """A block scalar's continuation lines are indented, so the column-zero
     anchor is what keeps prose out of the identity."""
     root = project(tmp_path, monkeypatch)
     path = write(root, "record/decisions.d/ADR-007.md",
                  "---\nstatus: Active\nsummary: >-\n  we rejected\n"
-                 "  uid: 42\ndate: '2026-01-01'\n---\n\n# ADR-007\n")
-    assert config._declared_uid(path) is None
-    assert scheme().uid_of(path) == 7
+                 "  number: 42\ndate: '2026-01-01'\n---\n\n# ADR-007\n")
+    assert config._declared_number(path) is None
+    assert scheme().number_of(path) == 7

--- a/tests/test_uid.py
+++ b/tests/test_uid.py
@@ -1,0 +1,224 @@
+"""Identity in the document rather than in the filename (#219).
+
+Schemes now work the way journals always have: the frontmatter carries the
+truth, the path is a projection of it, and the lint guards the agreement.
+"""
+
+# unlinted-file: — identity fixtures; `ADR-007` and `ADR-tmpabcde` here are
+# specimens of a filename shape, not citations of this repository's ADR-007
+# (Superseded) or of any temporary document. Same case as
+# `tests/test_migrations.py`: a scheme's own suite has to write codes to test
+# how codes are read.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from luria import adr_index, config, lint, new, repair
+
+
+def write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def project(tmp_path, monkeypatch, allocate: str = "filing") -> Path:
+    write(tmp_path, "luria.toml", f"""
+[luria]
+issue_url = "https://example.test/issues/{{n}}"
+
+[luria.schemes.ADR]
+dir = "record/decisions.d"
+output = "docs/decisions"
+allocate = "{allocate}"
+""")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+    return tmp_path
+
+
+def doc(root: Path, name: str, *, uid: int | None = None,
+        title: str = "A decision") -> Path:
+    front = ["---", "status: Active", f"title: '{title}'"]
+    if uid is not None:
+        front.insert(1, f"uid: {uid}")
+    front += ["date: '2026-01-01'", "---", "", f"# {name}: {title}", "", "Body."]
+    return write(root, f"record/decisions.d/{name}.md", "\n".join(front) + "\n")
+
+
+def scheme():
+    return config.current().schemes["ADR"]
+
+
+# --- the field is the identity ----------------------------------------------
+
+def test_the_field_wins_over_the_filename(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    path = doc(root, "ADR-007", uid=42)
+    assert scheme().uid_of(path) == 42
+    assert scheme().documents() == {42: path}
+    assert adr_index.Adr(path, scheme()).code == "ADR-042"
+
+
+def test_the_filename_answers_when_the_field_is_absent(tmp_path, monkeypatch):
+    """A record written before `uid:` existed still reads — which is what
+    makes the field introducible without a migration anyone has to run."""
+    root = project(tmp_path, monkeypatch)
+    path = doc(root, "ADR-007")
+    assert scheme().uid_of(path) == 7
+    assert scheme().documents() == {7: path}
+
+
+def test_a_uid_in_the_body_is_prose_not_a_claim(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    path = write(root, "record/decisions.d/ADR-007.md",
+                 "---\nstatus: Active\ntitle: 'A decision'\ndate: '2026-01-01'\n"
+                 "---\n\n# ADR-007: A decision\n\nWe considered\nuid: 99\n")
+    assert scheme().uid_of(path) == 7
+
+
+def test_a_temporary_document_has_no_uid_yet(tmp_path, monkeypatch):
+    """By design: a merge-allocated document holds no claim on the sequence
+    until `luria concretize` assigns one (ADR-049)."""
+    root = project(tmp_path, monkeypatch, allocate="merge")
+    doc(root, "ADR-tmpabcde")
+    assert scheme().documents() == {}
+    assert scheme().temp_documents().keys() == {"tmpabcde"}
+
+
+def test_the_cache_expires_when_the_file_changes(tmp_path, monkeypatch):
+    """Keyed on the stat rather than reset by hand, so a writer that forgets
+    to invalidate cannot serve a stale identity."""
+    root = project(tmp_path, monkeypatch)
+    path = doc(root, "ADR-007", uid=42)
+    assert scheme().uid_of(path) == 42
+    import os
+    path.write_text(path.read_text().replace("uid: 42", "uid: 43"))
+    os.utime(path, (0, 0))
+    assert scheme().uid_of(path) == 43
+
+
+# --- the agreement check ----------------------------------------------------
+
+def test_a_disagreement_is_a_finding(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "ADR-007", uid=42)
+    errors: list[str] = []
+    lint.check_uids(errors)
+    assert len(errors) == 1
+    assert "`uid: 42` but the filename says 7" in errors[0]
+
+
+def test_agreement_is_silent(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "ADR-007", uid=7)
+    errors: list[str] = []
+    lint.check_uids(errors)
+    assert errors == []
+
+
+def test_an_absent_field_is_not_a_disagreement(tmp_path, monkeypatch):
+    """It is the repairable case, and reporting it here would name a finding
+    whose remedy is a different command."""
+    root = project(tmp_path, monkeypatch)
+    doc(root, "ADR-007")
+    errors: list[str] = []
+    lint.check_uids(errors)
+    assert errors == []
+
+
+# --- the migration ----------------------------------------------------------
+
+def test_repair_populates_the_field_from_the_path(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    path = doc(root, "ADR-007")
+    assert repair.populate_uids(scheme()) == [path]
+    assert "uid: 7\n" in path.read_text()
+    assert path.read_text().startswith("---\nuid: 7\n")
+
+
+def test_repair_is_idempotent(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "ADR-007")
+    repair.populate_uids(scheme())
+    assert repair.populate_uids(scheme()) == []
+
+
+def test_repair_leaves_a_temporary_document_alone(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, allocate="merge")
+    path = doc(root, "ADR-tmpabcde")
+    before = path.read_text()
+    assert repair.populate_uids(scheme()) == []
+    assert path.read_text() == before
+
+
+def test_repair_never_invents_a_number(tmp_path, monkeypatch):
+    """A file whose name carries no number has no witness to repair from."""
+    root = project(tmp_path, monkeypatch)
+    doc(root, "notes")
+    assert repair.populate_uids(scheme()) == []
+
+
+# --- the writers ------------------------------------------------------------
+
+def test_new_writes_the_field(tmp_path, monkeypatch):
+    project(tmp_path, monkeypatch)
+    path = new.new_entry("adr", {"title": "First"}, None)
+    assert path.read_text().startswith("---\nuid: 1\n")
+    assert scheme().uid_of(path) == 1
+
+
+def test_new_leaves_it_out_for_a_merge_allocated_scheme(tmp_path, monkeypatch):
+    project(tmp_path, monkeypatch, allocate="merge")
+    path = new.new_entry("adr", {"title": "First"}, None)
+    assert "uid:" not in path.read_text()
+
+
+def test_write_uid_replaces_rather_than_duplicates(tmp_path, monkeypatch):
+    text = "---\nuid: 3\nstatus: Active\n---\n\n# ADR-003\n"
+    out = new.write_uid(text, 9)
+    assert out.count("uid:") == 1
+    assert "uid: 9" in out
+
+
+def test_write_uid_leaves_a_document_with_no_frontmatter_alone(tmp_path):
+    assert new.write_uid("# Heading\n", 4) == "# Heading\n"
+
+
+def test_concretize_writes_the_field_when_it_assigns_the_number(
+        tmp_path, monkeypatch):
+    """The one moment a merge-allocated document acquires a number at all."""
+    from luria import concretize
+    root = project(tmp_path, monkeypatch, allocate="merge")
+    doc(root, "ADR-001", uid=1)
+    doc(root, "ADR-tmpabcde", title="Landed from a branch")
+    concretize.run()
+    landed = root / "record/decisions.d/ADR-002.md"
+    assert landed.exists()
+    assert "uid: 2\n" in landed.read_text()
+    assert scheme().uid_of(landed) == 2
+
+
+def test_unterminated_frontmatter_declares_nothing(tmp_path, monkeypatch):
+    """`parse_frontmatter` treats an unclosed block as no frontmatter; reading
+    identity has to agree, or the two disagree about what a document says."""
+    root = project(tmp_path, monkeypatch)
+    path = write(root, "record/decisions.d/ADR-007.md",
+                 "---\nstatus: Active\nuid: 42\n\n# ADR-007\n")
+    assert config._declared_uid(path) is None
+    assert scheme().uid_of(path) == 7
+
+
+def test_an_indented_uid_is_inside_another_field(tmp_path, monkeypatch):
+    """A block scalar's continuation lines are indented, so the column-zero
+    anchor is what keeps prose out of the identity."""
+    root = project(tmp_path, monkeypatch)
+    path = write(root, "record/decisions.d/ADR-007.md",
+                 "---\nstatus: Active\nsummary: >-\n  we rejected\n"
+                 "  uid: 42\ndate: '2026-01-01'\n---\n\n# ADR-007\n")
+    assert config._declared_uid(path) is None
+    assert scheme().uid_of(path) == 7


### PR DESCRIPTION
Step 1 of #219. A scheme document carries `uid:`; its filename derives from it.

## This is the journal model, applied to schemes

`check_journals` already says the whole thing out loud:

> *"A journal entry's path is derived from its `created:` timestamp, and the two have to agree — otherwise the ordering the whole scheme rests on says one thing and the frontmatter says another (ADR-020)."*

Schemes kept identity in the filesystem instead, and nothing anywhere says why. **So this is less a feature than the end of an inconsistency**, and most of the implementation is the journal's, moved one directory over.

| | |
|---|---|
| `Scheme.uid_of()` | reads the field, falls back to the filename |
| `luria lint` | reports a field and a filename that disagree |
| `luria repair` | writes the field from the path where it is absent |
| `luria new` / `luria concretize` | write it on filing / at allocation |

The fallback is what lets this arrive **without an upgrade anyone has to run**: a record written before the field existed reads exactly as it did, and acquires the field on the next `luria repair`.

## Why it matters beyond tidiness

Identity in the filename is what blocks expressive filenames and derived aliases. Anything a name encodes becomes load-bearing once the name *is* the identity, so a slug can't be added without making the slug part of what a citation resolves through. The anthology paid this: `MLR-2014-Kingma001-0001` plus a `topic_id` slug became `SOTA-001` and nothing.

## Three things already in the tree made it cheap

- **`documents()` is "the one place a scheme directory is read."** DP-4 consolidated five copies of that glob for unrelated reasons — so twenty-odd identity readers meant exactly one function to change.
- **`number_of()` already parses a trailing slug.** `adr-010-some-title.md` reads today; luria could always *read* expressive filenames and has only ever *written* the short form.
- **`journal.populate_created()` is the back-fill**, working, with a slot beside it in `repair.apply()`.

## Two judgement calls, and why

**The cache is keyed on `(mtime, size)`, not reset by hand.** Reading the field costs a parse on the hot path. The obvious cache is a module dict with a `reset()`, the way `aliases.py` does it — and that would have been a bug generator: `concretize` writes then re-reads, `repair` writes hundreds, and every future writer would have to remember. Keyed on the stat, a write invalidates its own entry.

**A disagreement is a violation, not a repair.** Renaming the file to match the field is tempting since the field is the truth — but which of the two is right is genuinely unknowable, and renaming on a guess moves identity and orphans links. An *absent* field has one witness (the path) and is repaired; a *contradicted* one has two and is reported.

## Fired on both records, per the working agreement

- **436 documents** in the anthology and **103** here acquired the field.
- `luria lint` held its **exact baseline** on both.
- **Every generated view came out byte-identical**, except `reference-status.md`, whose citation line numbers shift down by one — because the field adds one line, which is the answer you want that check to give.
- Then the guard itself on a **real document rather than a fixture**: `uid:` edited to disagree with its filename, reported, reverted.

## Diff

| | |
|---|---|
| `luria/config.py` | `Scheme.uid_of()`, `_declared_uid()`, the stat-keyed cache |
| `luria/lint.py` | `check_uids()` |
| `luria/repair.py` | `populate_uids()` — the migration |
| `luria/new.py` | `write_uid()`, written on filing |
| `luria/concretize.py` | written at allocation |
| `luria/adr_index.py`, `edges.py`, `site.py` | the three direct `number_of` readers |
| `tests/test_uid.py` | 19 tests |
| `record/**` (103 files) | the migration, run here rather than left to a bot commit |

**981 tests pass.** Lint exit 0, read whole — the two lines differing from `main` are this contribution's own `unlinted-file:` directive and its own `Proposed` decision.

## Worth watching

The new suite tripped the reference checker twice (`ADR-007` is Superseded here; `ADR-tmpabcde` resolves to nothing), because a suite about how codes are read has to write codes down. `tests/test_migrations.py` hit this before me and carries the same `unlinted-file:` directive. Two files isn't a pattern; three would be, and the fix then is for the scanners to know a test fixture is a quote rather than an address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_