### PR TITLE
`derive` is a template, not a grammar of its own (#219)

### DIFF
--- a/luria/aliases.py
+++ b/luria/aliases.py
@@ -87,14 +87,12 @@ def render(template: str, meta: dict, scheme, number: int) -> str | None:
     through, fed from a different source. A template naming a field this
     document lacks renders nothing rather than a half-spelling: a partial
     alias would resolve for some documents and not others, silently."""
+    from . import derive
     values = dict(meta)
     values.update(number=number, prefix=scheme.prefix,
                   code=scheme.code(number))
-    try:
-        out = template.format(**values).strip()
-    except (KeyError, IndexError, AttributeError, TypeError):
-        return None
-    return out or None
+    out = derive.render(template, values)
+    return str(out) if out is not None else None
 
 
 def alias_map(cfg: Config | None = None) -> dict[str, Alias]:

--- a/luria/config.py
+++ b/luria/config.py
@@ -1221,8 +1221,9 @@ def _fields(prefix: str, raw: dict, scheme_dir: Path, root: Path,
             if spec.get("required"):
                 raise ValueError(
                     f"{where}: a derived field is present exactly when "
-                    f"`{rule.source}:` is, so `required` here would name the "
-                    f"wrong line as the fix — require `{rule.source}` instead")
+                    f"the fields it reads are, so `required` here would "
+                    f"name the wrong line as the fix — require "
+                    f"{', '.join(f'`{n}`' for n in rule.sources)} instead")
             if spec.get("default") is not None:
                 raise ValueError(
                     f"{where}: `default` and `derive` are two answers to "
@@ -1901,25 +1902,32 @@ def _check_derivations(prefix: str, scheme) -> None:
     List-valued is the harder rule and the one worth stating: `first:` of a
     single value is that value, so a derivation off a scalar is a rename
     wearing a derivation's clothes, and renames belong in the frontmatter."""
+    from .derive import lone_field
     plural = {"tags", *(v.field for v in scheme.vocabularies if v.many),
               *(r.field for r in scheme.references if r.many),
               *(f.field for f in scheme.plain_fields if f.many)}
-    nameable = {*BUILT_IN_CONDITION_FIELDS, *scheme.requires,
+    nameable = {*BUILT_IN_CONDITION_FIELDS, "number", *scheme.requires,
                 *(r.field for r in scheme.references),
                 *(v.field for v in scheme.vocabularies),
                 *(f.field for f in scheme.plain_fields)}
     for rule in scheme.derived:
         where = f"luria.toml: schemes.{prefix}.fields.{rule.field}.derive"
-        if rule.source not in nameable:
+        for name in rule.sources:
+            if name not in nameable:
+                raise ValueError(
+                    f"{where}: `{name}` is not a field {prefix} declares, so "
+                    f"`{rule.field}` resolves to nothing on every document "
+                    f"(nameable: {', '.join(sorted(nameable))})")
+        # The scalar-rename rule, narrowed to where it still bites. A template
+        # that builds something — `"LIT-{first_author}-{number}"` — reads
+        # single-valued fields legitimately. A template that is *only* a
+        # single-valued field copies it under a second name, which is the
+        # rename this refused before templates existed.
+        if lone_field(rule.template) and rule.sources[0] not in plural:
             raise ValueError(
-                f"{where}: `{rule.source}` is not a field {prefix} declares, "
-                f"so `{rule.field}` resolves to nothing on every document "
-                f"(nameable: {', '.join(sorted(nameable))})")
-        if rule.source not in plural:
-            raise ValueError(
-                f"{where}: `{rule.source}` holds one value, and "
-                f"`{rule.take}:` of one value is that value — a derivation "
-                f"off a scalar renames a field rather than deriving one")
+                f"{where}: `{rule.template}` is just `{rule.sources[0]}` under "
+                f"another name — a template that reads one single-valued field "
+                f"and nothing else renames a field rather than deriving one")
 
 
 def _alias_template(prefix: str, raw) -> str:

--- a/luria/contract.py
+++ b/luria/contract.py
@@ -319,7 +319,7 @@ def describe(contract: Contract) -> list[str]:
         if field.builtin:
             continue
         if (rule := contract.derivation(field.name)) is not None:
-            what = f"derived — the {rule.take} of `{rule.source}:`, never written"
+            what = f"derived — `{rule.template}`, never written"
             if field.vocabulary is not None:
                 what += (", and one of "
                          + ", ".join(f"`{v}`" for v in field.values))
@@ -482,7 +482,7 @@ def violations(contract: Contract, rel: str, meta: dict,
             f"{rel}: `{name}:` is written in frontmatter, but "
             f"{contract.scheme} derives it (`{rule.spec}`) — the value has "
             f"one source and this is not it; drop the line and order "
-            f"`{rule.source}:` to say it")
+            f"the fields it reads to say it")
     meta = derive.applied(meta, contract.derived)
     for field in contract.fields:
         raw = meta.get(field.name)

--- a/luria/derive.py
+++ b/luria/derive.py
@@ -24,71 +24,141 @@ source for something luria cannot otherwise know. A written `primary_topic:`
 is not that: it is the same fact as `tags[0]`, stored twice and free to
 disagree. So writing a derived field is a finding, not an override.
 
-**A closed set of takes, not an expression language.** `first` and `last` over
-a list. The source must be list-valued — `first:` of a scalar is the scalar,
-which is a rename wearing a derivation's clothes. Everything past this waits
-for a case that needs it.
+**One template vocabulary, two variable sources (#219).** The spelling is
+`str.format` — the engine `Remote.uri` already renders URLs through, fed here
+from a document's frontmatter instead of from a remote and a code. So there
+is one template language in luria, not a second grammar per feature, and
+`{tags[0]}`, `{first_author}`, `{published:.4}` all mean what they mean
+everywhere else.
+
+**A lone field returns the value, not a string.** `"{tags[0]}"` yields the
+tag itself, so it stays identical to the vocabulary member a check compares
+it against and to the value another document's tag list intersects with.
+Anything with literal text around it — `"LIT-{first_author}-{number}"` — is
+a string, because that is what it was written to build. The rule is the
+template's shape rather than a flag, so nothing has to be declared twice.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-# The takes, and what each one reads off a list. Closed: a spelling outside
-# this map is refused where the config is read, not discovered as a field that
-# silently never resolves.
-TAKES = {
-    "first": lambda values: values[0],
-    "last": lambda values: values[-1],
-}
-
-
 @dataclass(frozen=True)
 class Derived:
-    """One derivation: `field` is what it defines, off `source`, by `take`."""
+    """One derivation: `field` is what it defines, `template` how."""
     field: str
-    take: str
-    source: str
+    template: str
 
     @property
     def spec(self) -> str:
         """The declaration as written, for messages that name it."""
-        return f"{self.take}:{self.source}"
+        return self.template
+
+    @property
+    def sources(self) -> tuple[str, ...]:
+        """The frontmatter fields this template reads, for the eager check."""
+        return names_in(self.template)
+
+
+def names_in(template: str) -> tuple[str, ...]:
+    """The field names a template reads, without the indexing or the format
+    spec — `"LIT-{authors[0]}-{published:.4}"` names `authors` and
+    `published`. What the eager check needs in order to say whether a scheme
+    can hold them."""
+    import string
+    out = []
+    for _, field, _, _ in string.Formatter().parse(template):
+        if field:
+            root = field.split(".")[0].split("[")[0].strip()
+            if root and not root.isdigit() and root not in out:
+                out.append(root)
+    return tuple(out)
+
+
+def lone_field(template: str) -> bool:
+    """Whether the template is exactly one replacement field and nothing else.
+
+    That is the case where the value survives as itself rather than as its
+    rendering, which is what keeps a derived field comparable to the
+    vocabulary it is checked against."""
+    import string
+    parts = list(string.Formatter().parse(template))
+    return (len(parts) == 1 and parts[0][0] == "" and parts[0][1] is not None
+            and not parts[0][2])
+
+
+def render(template: str, values: dict):
+    """A template against one document's values, or None when it cannot fill.
+
+    None rather than a partial rendering: a half-filled spelling would
+    resolve for some documents and not others, with nothing saying which."""
+    try:
+        if lone_field(template):
+            import string
+            name = list(string.Formatter().parse(template))[0][1]
+            got = string.Formatter().get_field(name, (), values)[0]
+            return got if got not in (None, "") else None
+        out = template.format(**values).strip()
+    except (KeyError, IndexError, AttributeError, TypeError, ValueError):
+        return None
+    return out or None
 
 
 def parse(where: str, field: str, raw) -> Derived:
-    """One `derive = "take:source"` declaration, or a ValueError naming the
-    spelling that was wrong. Shape only — whether `source` is a field the
-    scheme can hold needs the whole scheme, so it is checked there."""
+    """One `derive = "{template}"` declaration, or a ValueError naming what
+    was wrong with it. Shape only — whether the names are fields the scheme
+    can hold needs the whole scheme, so that is checked there."""
     text = str(raw).strip()
-    take, sep, source = text.partition(":")
-    take, source = take.strip(), source.strip()
-    if not sep or not take or not source:
+    if not text:
+        raise ValueError(f"{where}: `derive` is empty")
+    try:
+        text.format_map(_Probe())
+    except (ValueError, IndexError) as exc:
+        raise ValueError(f"{where}: `derive = {text!r}` is not a template "
+                         f"`str.format` can render ({exc})") from exc
+    read = names_in(text)
+    if not read:
         raise ValueError(
-            f"{where}: `derive = {text!r}` is not a derivation — the shape is "
-            f'"take:field", as in "first:tags"')
-    if take not in TAKES:
-        raise ValueError(
-            f"{where}: `derive` takes {take!r}, which is not one of "
-            f"{', '.join(sorted(TAKES))}")
-    if source == field:
+            f"{where}: `derive = {text!r}` reads no field, so every document "
+            f"would get the same value — which is a default, not a derivation")
+    if field in read:
         raise ValueError(
             f"{where}: `{field}` derives from itself, which resolves to "
             f"nothing")
-    return Derived(field=str(field), take=take, source=source)
+    return Derived(field=str(field), template=text)
+
+
+class _Probe(dict):
+    """Answers to any name, so a template's shape can be checked without a
+    document — indexing and attributes included, since `{authors[0]}` and
+    `{date.year}` are ordinary spellings."""
+
+    def __missing__(self, key):
+        return self
+
+    def __getitem__(self, key):
+        return self
+
+    def __getattr__(self, name):
+        return self
+
+    def __format__(self, spec):
+        return ""
 
 
 def value(meta: dict, rule: Derived):
-    """The derived value for one document, or None when the source holds
-    nothing.
+    """The derived value for one document, or None when the template cannot
+    be filled.
 
     Absence is not an error here. A document with no `tags:` has no primary
     topic to compute, and saying so is the tags field's job — reporting it
-    twice would name the wrong line as the fix."""
-    raw = meta.get(rule.source)
-    values = raw if isinstance(raw, list) else ([] if raw in (None, "") else [raw])
-    values = [v for v in values if v not in (None, "")]
-    return TAKES[rule.take](values) if values else None
+    twice would name the wrong line as the fix.
+
+    Only the document's own frontmatter is in scope, and that is enough for
+    `{number}` too, now that identity is a field a document carries rather
+    than a filename it is parsed out of — a capability this step inherits
+    rather than adds."""
+    return render(rule.template, meta)
 
 
 def written(meta: dict, rules) -> list[str]:

--- a/record/changelog.d/20260908-230434.md
+++ b/record/changelog.d/20260908-230434.md
@@ -1,0 +1,22 @@
+### Changed
+
+- `derive` is a `str.format` template rather than a `take:field` grammar
+  (`#219`): `derive = "{tags[0]}"` where it used to be `"first:tags"`. One
+  template vocabulary now covers a remote's URIs, a scheme's `alias`, and a
+  derived field — the same spelling means the same thing in all three, and
+  `derive` and `alias` render through one function.
+
+  **A template that is exactly one replacement field returns the value, not
+  its rendering.** `{versions[0]}` yields the number rather than `"3"`, which
+  keeps a derived field identical to the vocabulary member a check compares
+  it against. Literal text around the field — `"LIT-{first_author}"` — means
+  a string was intended, so a string comes back.
+
+  `last:` has no template spelling: `str.format` reads `{tags[-1]}` as a
+  string key, not a negative index. A record using it must name the position
+  (`{tags[1]}`); nothing shipped with one, and adding an extension to keep it
+  would have re-opened the second grammar this change closes.
+
+  The scalar-rename refusal narrows to where it still applies: a template
+  that *builds* from single-valued fields is fine, and only a bare
+  `"{year}"` under a second name is refused.

--- a/record/devlog.d/2026/09/08/230434.md
+++ b/record/devlog.d/2026/09/08/230434.md
@@ -1,0 +1,43 @@
+---
+title: 'One template vocabulary, and the take grammar that went away'
+created: '2026-09-08T23:04:34'
+tags: []
+---
+
+The last step of the identity work, and mostly a deletion: `derive`'s
+`take:field` grammar becomes a `str.format` template, so luria has one
+template language rather than one per feature.
+
+**What made it cheap was doing it in the wrong order first.** `derive`
+shipped with its own tiny grammar, `alias` shipped with `str.format`, and
+having both side by side for an afternoon is what made the redundancy
+obvious and the merge trivial: `aliases.render` already did the work, so
+`derive` delegates to it and the two share a vocabulary.
+
+**The lone-field rule is the only real design in it.** A template that is
+exactly one replacement field returns the *value*; anything with literal
+text returns a string. That distinction matters because a derived field gets
+compared against a closed vocabulary and intersected with another document's
+tags — `"2014"` and `2014` are not the same value, and a formatter's job is
+to produce the former. The rule reads off the template's shape rather than a
+flag, so nothing has to be declared twice.
+
+**A capability went away and it is worth naming.** `last:tags` has no
+template spelling: `str.format` parses `{tags[-1]}` as the string key `-1`,
+not a negative index, so the take that existed only because it "fell out for
+free" now costs a real extension to keep. Dropped rather than special-cased —
+an extension on top of `str.format` is the second grammar this change
+exists to end. A record wanting the last element names its position.
+
+**My own guard caught my own test, and was right.** I wrote a
+type-preservation test using `derive = "{year}"`, and the scalar-rename check
+refused it: `{year}` under a second name copies a field rather than deriving
+one. The test premise was wrong, not the check. Rewritten against a
+list-valued field, which is where a lone-field derivation is legitimate —
+and the refusal now has a test of its own, since narrowing a rule is exactly
+when you want to pin what survives.
+
+**Fired on the real record, both halves through one vocabulary.** 188 of 188
+practices resolved `primary_topic` from `{tags[0]}`, still a `str` identical
+to its vocabulary member; 218 notes rendered
+`LIT-{first_author}-{published:.4}-{number}` with no collisions.

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -32,7 +32,7 @@ encoding:
 
 DERIVED = """
 [luria.schemes.LIT.fields.primary_topic]
-derive     = "first:tags"
+derive     = "{tags[0]}"
 vocabulary = "tags"
 """
 
@@ -101,9 +101,9 @@ def test_order_is_the_whole_statement(tmp_path, monkeypatch):
     assert adr_index.Adr(b, scheme()).meta["primary_topic"] == "optimizers"
 
 
-def test_last_reads_the_other_end(tmp_path, monkeypatch):
+def test_an_explicit_index_reads_further_in(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch,
-                   DERIVED.replace('"first:tags"', '"last:tags"'))
+                   DERIVED.replace('"{tags[0]}"', '"{tags[1]}"'))
     path = note(root, 1, ["stability", "optimizers"])
     assert adr_index.Adr(path, scheme()).meta["primary_topic"] == "optimizers"
 
@@ -137,7 +137,7 @@ def test_writing_a_derived_field_is_a_finding(tmp_path, monkeypatch):
     out = findings(root, path)
     assert len(out) == 1
     assert "`primary_topic:` is written in frontmatter" in out[0]
-    assert "first:tags" in out[0]
+    assert "{tags[0]}" in out[0]
 
 
 def test_a_written_value_that_agrees_is_still_a_finding(tmp_path, monkeypatch):
@@ -231,21 +231,21 @@ def test_the_record_page_says_where_the_value_comes_from(tmp_path, monkeypatch):
     project(tmp_path, monkeypatch)
     lines = contract.describe(contract.for_scheme(scheme()))
     line = next(l for l in lines if l.startswith("`primary_topic`"))
-    assert "derived — the first of `tags:`, never written" in line
+    assert "derived — `{tags[0]}`, never written" in line
 
 
 # --- refused at load ---------------------------------------------------------
 
 @pytest.mark.parametrize("spec,message", [
-    ('"tags"', "is not a derivation"),
-    ('"middle:tags"', "not one of first, last"),
-    ('"first:primary_topic"', "derives from itself"),
-    ('"first:nonexistent"', "is not a field LIT declares"),
-    ('"first:status"', "renames a field rather than deriving one"),
+    ('"tags"', "reads no field"),
+    ('"LIT-{tags[0]"', "not a template"),
+    ('"{primary_topic}"', "derives from itself"),
+    ('"{nonexistent}"', "is not a field LIT declares"),
+    ('"{status}"', "renames a field rather than deriving one"),
 ])
 def test_a_derivation_that_could_never_resolve_is_refused(
         tmp_path, monkeypatch, spec, message):
-    project(tmp_path, monkeypatch, DERIVED.replace('"first:tags"', spec))
+    project(tmp_path, monkeypatch, DERIVED.replace('"{tags[0]}"', spec))
     with pytest.raises(ValueError, match=message):
         config.current()
 
@@ -268,7 +268,7 @@ def test_a_derivation_needs_no_vocabulary_to_be_a_field(tmp_path, monkeypatch):
     page cannot tell a reader about."""
     project(tmp_path, monkeypatch, '''
 [luria.schemes.LIT.fields.primary_topic]
-derive = "first:tags"
+derive = "{tags[0]}"
 ''')
     root = tmp_path
     path = note(root, 1, ["homemade"])
@@ -276,4 +276,78 @@ derive = "first:tags"
     assert findings(root, path) == []
     line = next(l for l in contract.describe(contract.for_scheme(scheme()))
                 if l.startswith("`primary_topic`"))
-    assert "derived — the first of `tags:`, never written" in line
+    assert "derived — `{tags[0]}`, never written" in line
+
+
+# --- one template vocabulary -------------------------------------------------
+
+def test_a_lone_field_keeps_the_value_s_type(tmp_path, monkeypatch):
+    """`{versions[0]}` is the number, not "3". What keeps a derived value
+    comparable to the vocabulary member a check matches it against, and to
+    the value another document's list is intersected with."""
+    root = project(tmp_path, monkeypatch, '''
+[luria.schemes.LIT.fields.era]
+derive = "{versions[0]}"
+
+[luria.schemes.LIT.fields.versions]
+required = true
+many = true
+''')
+    path = write(root, "record/literature.d/LIT-001.md",
+                 "---\nstatus: Active\ntitle: 'N'\nversions:\n- 3\n- 4\n"
+                 "date: '2026-01-01'\n---\n\n# LIT-001: N\n")
+    assert adr_index.Adr(path, scheme()).meta["era"] == 3
+
+
+def test_a_template_that_builds_something_is_a_string(tmp_path, monkeypatch):
+    """The other half of the rule: literal text around a field means the
+    author was writing a string, so they get one."""
+    root = project(tmp_path, monkeypatch, '''
+[luria.schemes.LIT.fields.era]
+derive = "v{versions[0]}"
+
+[luria.schemes.LIT.fields.versions]
+required = true
+many = true
+''')
+    path = write(root, "record/literature.d/LIT-001.md",
+                 "---\nstatus: Active\ntitle: 'N'\nversions:\n- 3\n- 4\n"
+                 "date: '2026-01-01'\n---\n\n# LIT-001: N\n")
+    assert adr_index.Adr(path, scheme()).meta["era"] == "v3"
+
+
+def test_a_lone_scalar_field_is_still_refused_as_a_rename(tmp_path, monkeypatch):
+    """The pre-template rule, narrowed to where it still bites: `{year}`
+    under a second name copies a field rather than deriving one. A template
+    that *builds* from scalars is fine — this is only the bare case."""
+    project(tmp_path, monkeypatch, '''
+[luria.schemes.LIT.fields.era]
+derive = "{year}"
+
+[luria.schemes.LIT.fields.year]
+required = true
+''')
+    with pytest.raises(ValueError, match="renames a field"):
+        config.current()
+
+
+def test_derive_and_alias_render_through_one_vocabulary(tmp_path, monkeypatch):
+    """The point of the step: the same spelling means the same thing whether
+    it names a field or an alias."""
+    from luria import aliases, derive as derive_mod
+    meta = {"tags": ["stability", "x"], "first_author": "Dao",
+            "published": "2022-05-01"}
+    assert derive_mod.render("{tags[0]}", meta) == "stability"
+    assert derive_mod.render("LIT-{first_author}-{published:.4}",
+                             meta) == "LIT-Dao-2022"
+    project(tmp_path, monkeypatch)
+    assert aliases.render("LIT-{first_author}-{published:.4}", meta,
+                          scheme(), 74) == "LIT-Dao-2022"
+
+
+def test_a_template_reading_nothing_is_refused(tmp_path, monkeypatch):
+    """A constant is a default, not a derivation — and `default` is the
+    spelling that already means that."""
+    project(tmp_path, monkeypatch, DERIVED.replace('"{tags[0]}"', '"constant"'))
+    with pytest.raises(ValueError, match="reads no field"):
+        config.current()


### PR DESCRIPTION
Step 3 of #219, and **mostly a deletion**.

```toml
derive = "{tags[0]}"        # was "first:tags"
```

luria now has **one template language rather than one per feature**: a remote's URIs, a scheme's `alias`, and a derived field all render through `str.format`, and `derive` and `alias` share a function.

## Doing it in the wrong order first is what made it cheap

`derive` shipped with its own tiny grammar (#217) and `alias` shipped with `str.format` (#221). Having both side by side for an afternoon is what made the redundancy obvious and the merge trivial — `aliases.render` already did the work, so `derive` delegates and the two share a vocabulary.

## The lone-field rule is the only real design in it

A template that is **exactly one replacement field returns the value**; anything with literal text around it returns a string.

```
{versions[0]}   ->  3        (the number)
v{versions[0]}  ->  "v3"     (a string, because one was written)
```

That matters because a derived field gets compared against a closed vocabulary and intersected with another document's tags — `"2014"` is not `2014`, and a formatter's job is to produce the former. The rule reads off the template's *shape* rather than a flag, so nothing is declared twice.

## A capability went away, and it's worth naming

**`last:` has no template spelling.** `str.format` parses `{tags[-1]}` as the string key `-1`, not a negative index. It existed only because it "fell out for free," and keeping it would need an extension on top of `str.format` — the second grammar this change exists to end. A record wanting the last element names its position. Nothing shipped with one.

## The scalar-rename refusal narrows to where it still bites

A template that **builds** from single-valued fields is legitimate — `"LIT-{first_author}-{number}"` reads two scalars and is exactly the point. Only a bare `"{year}"` under a second name is the rename the old rule refused.

**My own check caught my own test here.** I wrote the type-preservation case as `derive = "{year}"` and it was refused — correctly. The premise was wrong, not the guard. Rewritten against a list-valued field, and the refusal now has a test of its own, since narrowing a rule is exactly when you want to pin what survives.

## Fired on the real record, both halves through one vocabulary

- **188 of 188** practices resolved `primary_topic` from `{tags[0]}` — still a `str`, identical to its vocabulary member.
- **218 notes** rendered `LIT-{first_author}-{published:.4}-{number}`, no collisions.

**1027 tests pass.** Lint **identical to main's baseline**.

---

This completes #219. Steps 1 and 2 are already on `main` (`ADR-087`, `ADR-088`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_