### PR TITLE
ADR-089 states its correction in `history:`, not just in prose

### DIFF
--- a/record/decisions.d/ADR-089.md
+++ b/record/decisions.d/ADR-089.md
@@ -5,6 +5,23 @@ formerly:
 - ADR-tmpqufvc
 title: 'A derived field is read-only, unlike a derived URI'
 version: 2
+history:
+- version: 1
+  date: '2026-09-08'
+  note: >-
+    Rejected an expression language on a count of luria's existing expression
+    surfaces. The count was circular: it inventoried a codebase whose
+    constraints forbade the thing, found it absent, and read the absence as
+    evidence nobody wanted it. Demand had already shown up in URL
+    construction, interpretable codes, filename slugs and site layout.
+- version: 2
+  date: '2026-09-08'
+  note: >-
+    The choice stands, the reason did not. Corrected in place to the narrower
+    ground that survives — `first` was the case in hand and the closed set is
+    a starting point rather than a ceiling — with the general form planned
+    rather than forbidden. It shipped shortly after, as one template
+    vocabulary over `str.format`.
 tags:
 - record
 date: '2026-09-08'
@@ -88,13 +105,6 @@ Two parts are load-bearing:
   stays unbound with no legal way to express what it shares, so the [#214](https://github.com/dmarx/luria/issues/214) check
   reports findings whose only remedies are to widen the vocabulary or to invent
   private tags — and both make the topic pages worse.
-
-## History
-
-- **v2** — the "expression language" rejection was argued from a count of
-  luria's expression surfaces, and that count was circular. Corrected in
-  place: the choice stands, the reason did not, and the general form is
-  planned rather than forbidden.
 
 ## Consequences
 


### PR DESCRIPTION
**`main` is red, and this is mine.**

```
record/decisions.d/ADR-089.md: version 2 with no `history:` —
a correction is only honest if it says what changed (see ADR-019)
```

Amending the decision on #217 I bumped `version: 2` and wrote a `## History` **section in the body**. The contract asks for a `history:` **frontmatter field**. The prose said what changed; the field the check reads was empty.

## Why #217's CI was green

The document was still a temporary code (`ADR-tmpqufvc`), and the version/history check skips temp documents. It fired the moment `luria concretize` gave it a number on the trunk.

So **the branch that introduced this could not have caught it** — which is worth knowing about this check generally, and is the same shape as the thing that bit #221 earlier today: a class of finding that only exists once a temp code becomes a real one. Not proposing a change to it here; noting it.

## The fix

The section moves into the field, with **both** versions recorded rather than only the correction. v1 is the claim that was wrong; a history that omits what it is correcting is half a record.

**1027 tests pass.** Lint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_