### PR TITLE
A docstring is one block, the way a fence already was (#222)

### DIFF
--- a/docs/devlog/2026-09.md
+++ b/docs/devlog/2026-09.md
@@ -2,7 +2,7 @@
 
 # Development log — September 2026
 
-42 entries. [All books](README.md).
+43 entries. [All books](README.md).
 
 ## Contents
 
@@ -48,6 +48,7 @@
 - [8 Sep 18:57 — Identity moved into the document](#20260908185747)
 - [8 Sep 21:01 — Alias inference, and the map that was never wired up](#20260908210139)
 - [8 Sep 23:04 — One template vocabulary, and the take grammar that went away](#20260908230434)
+- [8 Sep 23:30 — A docstring is one block, the way a fence already was](#20260908233041)
 
 ---
 
@@ -2739,3 +2740,59 @@ when you want to pin what survives.
 practices resolved `primary_topic` from `{tags[0]}`, still a `str` identical
 to its vocabulary member; 218 notes rendered
 `LIT-{first_author}-{published:.4}-{number}` with no collisions.
+
+---
+
+<a name="20260908233041"></a>
+
+## A docstring is one block, the way a fence already was
+
+*2026-09-08 23:30:41*
+
+The scope rule caught me three times in a day, and the third one had no good
+answer: a citation in the third paragraph of a docstring could only be
+acknowledged with `-file`, so I deleted the citation instead. Deleting a
+reference to avoid annotating it is the workflow telling you something.
+
+**The fix was already written down, for a different case.** The rules say
+fenced code counts as one block even when it contains blank lines — a
+syntactic unit is not split by the whitespace inside it. A docstring is the
+same shape, and once that is said the change is four lines: `blocks()` learns
+the file's language and treats docstring spans as atomic, the way it already
+treats fences. The span starts at the `def` line rather than the quotes, so a
+directive written above the definition governs what the definition says.
+
+**Measured before designing.** I tried the four placements on the real case
+rather than reasoning about them:
+
+| placement | before |
+|---|---|
+| no directive | warns (the control) |
+| `-block` above the `def` | reported STALE |
+| `-file` at module top | acknowledged |
+| `inactive-ok:` inside the docstring | warns |
+
+That table is what made the answer obvious, and getting it took two false
+starts worth recording. My first probe reported every case as quiet,
+including the control — the replacement string didn't match, so nothing was
+ever mutated. My second reported every case as acknowledged, including the
+control — `luria lint` writes to stderr and I was capturing only stdout. Both
+times the *control* was the tell: a probe whose control does not reproduce
+the condition is measuring nothing, and it is worth checking that first.
+
+**The last row stays as it is, deliberately.** A directive written inside a
+docstring still does not fire, because a docstring is not a comment — that
+rule exists because prose about the syntax used to invoke it, and a
+docstring example silently annotated its own module. This change does not
+touch it, and there is a test pinning it.
+
+**And I broke the module while documenting it**, by putting a `"""` example
+inside a `"""` docstring. The example now uses `'''`.
+
+Fired on the real case: the `ADR-087` citation I had deleted from
+`derive.value` is back, acknowledged by a `-block` directive above the
+definition, with the lint identical to main's baseline.
+
+**What this does not fix.** The three suites carrying `unlinted-file:` are a
+different problem — fixture codes in string literals and comments, not
+docstring prose. [#222](https://github.com/dmarx/luria/issues/222)'s other options still stand for those.

--- a/docs/devlog/README.md
+++ b/docs/devlog/README.md
@@ -6,6 +6,7 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## Currently — [September 2026](2026-09.md)
 
+- [8 Sep 23:30 — A docstring is one block, the way a fence already was](2026-09.md#20260908233041)
 - [8 Sep 23:04 — One template vocabulary, and the take grammar that went away](2026-09.md#20260908230434)
 - [8 Sep 21:01 — Alias inference, and the map that was never wired up](2026-09.md#20260908210139)
 - [8 Sep 18:57 — Identity moved into the document](2026-09.md#20260908185747)
@@ -51,9 +52,9 @@ The narrative that doesn't fit a changelog entry: root-cause archaeology, failed
 
 ## All books
 
-88 entries across 2 books, newest first.
+89 entries across 2 books, newest first.
 
 | Book | Entries | First | Last |
 |---|--:|---|---|
-| [2026-09](2026-09.md) | 42 | 2026-09-03 | 2026-09-08 |
+| [2026-09](2026-09.md) | 43 | 2026-09-03 | 2026-09-08 |
 | [2026-08](2026-08.md) | 46 | 2026-08-03 | 2026-08-28 |

--- a/docs/reports/pending-decisions.md
+++ b/docs/reports/pending-decisions.md
@@ -12,7 +12,7 @@
 | 2026-09-06 | Proposed | [ADR-085](../../record/decisions.d/ADR-085.md) | 5 | 5 | Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote |
 | 2026-09-06 | Proposed | [ADR-084](../../record/decisions.d/ADR-084.md) | 0 | 0 | A relation declares its converse; symmetry is the self-converse case |
 | 2026-09-07 | Proposed | [ADR-086](../../record/decisions.d/ADR-086.md) | 0 | 0 | A marked region is how the README carries a derived fact |
-| 2026-09-08 | Proposed | [ADR-087](../../record/decisions.d/ADR-087.md) | 1 | 0 | Identity is a field; the filename is a projection of it |
+| 2026-09-08 | Proposed | [ADR-087](../../record/decisions.d/ADR-087.md) | 2 | 0 | Identity is a field; the filename is a projection of it |
 | 2026-09-08 | Proposed | [ADR-088](../../record/decisions.d/ADR-088.md) | 1 | 0 | A derived alias is kept; a former spelling is rewritten |
 | 2026-09-08 | Proposed | [ADR-089](../../record/decisions.d/ADR-089.md) | 0 | 0 | A derived field is read-only, unlike a derived URI |
 

--- a/docs/reports/reference-status.md
+++ b/docs/reports/reference-status.md
@@ -9,7 +9,7 @@ Every reference in the record is a claim — "this is why things are the way the
 
 Only an `Active` document is in force. `Proposed` and `Deferred` mean *not in force yet* — an open question, being cited as if it were settled — while `Superseded` and `Rejected` mean *no longer in force*, which is often a perfectly good thing to cite: history, or a rejection worth pointing at. Either way the citation should be deliberate, and this section lists the ones nobody has vouched for yet.
 
-**1 document cited without acknowledgement.** Not listed: 54 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
+**1 document cited without acknowledgement.** Not listed: 55 citations someone has already vouched for with an `inactive-ok:` comment at the citing site.
 
 To vouch for one, put the reason where the citation is — `inactive-ok:` covers its own line and the line below it, `inactive-ok-block:` its paragraph, `inactive-ok-file:` the whole page:
 

--- a/luria/derive.py
+++ b/luria/derive.py
@@ -146,6 +146,8 @@ class _Probe(dict):
         return ""
 
 
+# inactive-ok-block: ADR-087 — Proposed, from the same plan; cited for the
+# capability it added, not as settled evidence
 def value(meta: dict, rule: Derived):
     """The derived value for one document, or None when the template cannot
     be filled.
@@ -156,8 +158,8 @@ def value(meta: dict, rule: Derived):
 
     Only the document's own frontmatter is in scope, and that is enough for
     `{number}` too, now that identity is a field a document carries rather
-    than a filename it is parsed out of — a capability this step inherits
-    rather than adds."""
+    than a filename it is parsed out of (ADR-087) — a capability this step
+    inherits rather than adds."""
     return render(rule.template, meta)
 
 

--- a/luria/directives.py
+++ b/luria/directives.py
@@ -32,7 +32,16 @@ defaults to remember:
 - **block** (`-block`) — the run of non-blank lines it sits in. A directive
   standing alone between blank lines has no content block of its own, so the
   block it means is the one it introduces: the next one. Fenced code counts as
-  one block even when it contains blank lines.
+  one block even when it contains blank lines, and so does a Python
+  docstring — one syntactic unit however many paragraphs it holds, counted
+  from its `def` or `class` line, so this reaches a citation in a docstring:
+
+      # inactive-ok-block: ADR-012 — the decision this function replaced
+      def apply(...):
+          '''First paragraph.
+
+          A later paragraph citing ADR-012.'''
+
 - **file** (`-file`) — the whole document.
 
 A blank line between a directive and what it governs therefore needs `-block`:
@@ -113,10 +122,50 @@ def _fence_line_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
-def blocks(text: str) -> list[tuple[int, int]]:
-    """Blank-line-delimited runs of lines, 1-based inclusive. A fenced block is
-    atomic — a blank line inside a code sample doesn't end the paragraph."""
+def _docstring_line_spans(text: str) -> list[tuple[int, int]]:
+    """1-based (first, last) line numbers of each docstring in a Python source.
+
+    Module, class and function docstrings only — a string used as a value is
+    not one, and annotating it is not what anyone means. Unparseable source
+    yields nothing rather than raising: a directive scope is not the place to
+    discover a syntax error."""
+    import ast
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return []
+    spans = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                 ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body or not isinstance(body[0], ast.Expr):
+            continue
+        doc = body[0].value
+        if isinstance(doc, ast.Constant) and isinstance(doc.value, str):
+            # From the `def` line, so a directive written above the definition
+            # governs the docstring it introduces rather than stopping at the
+            # signature.
+            first = getattr(node, "lineno", doc.lineno)
+            spans.append((first, doc.end_lineno or doc.lineno))
+    return spans
+
+
+def blocks(text: str, path: Path | None = None) -> list[tuple[int, int]]:
+    """Blank-line-delimited runs of lines, 1-based inclusive.
+
+    A fenced block is atomic — a blank line inside a code sample doesn't end
+    the paragraph — and so is a **Python docstring**, for the same reason and
+    on the same principle (#222). A docstring is one syntactic unit however
+    many paragraphs it holds, so a `-block` directive written above a
+    definition governs the whole of what that definition says, not just its
+    first paragraph. Without it the only annotation that reaches a citation in
+    a docstring's third paragraph is `-file`, which is far too blunt for the
+    case: an ordinary sentence of prose that happens to name a code."""
     fenced = _fence_line_spans(text)
+    if path is not None and path.suffix.lower() == ".py":
+        fenced = fenced + _docstring_line_spans(text)
 
     def in_fence(line: int) -> bool:
         return any(a <= line <= b for a, b in fenced)
@@ -210,7 +259,7 @@ def _line_offsets(text: str) -> list[int]:
 
 def find(path: Path, text: str, names: set[str] | None = None) -> list[Directive]:
     """Every directive in `path`, with the lines each one governs resolved."""
-    spans = blocks(text)
+    spans = blocks(text, path)
     found: list[Directive] = []
     for line_no, offset, body in comment_fragments(path, text):
         m = DIRECTIVE_RE.match(body.strip())

--- a/record/changelog.d/20260908-233041.md
+++ b/record/changelog.d/20260908-233041.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- A `-block` directive above a Python definition now governs the whole
+  docstring (`#222`). A docstring is one syntactic unit however many
+  paragraphs it holds, and is treated as atomic exactly the way a fenced code
+  block already was:
+
+      # inactive-ok-block: [ADR-012](record/decisions.d/ADR-012.md) — the decision this function replaced
+      def apply():
+          '''First paragraph.
+
+          A later paragraph citing [ADR-012](record/decisions.d/ADR-012.md).'''
+
+  Before, block scope stopped at the docstring's first blank line, so a
+  citation in a later paragraph could only be acknowledged with
+  `-file` — far too blunt for one sentence of prose that happens to name a
+  code. A directive written *inside* a docstring still does not fire: a
+  docstring is not a comment.

--- a/record/devlog.d/2026/09/08/233041.md
+++ b/record/devlog.d/2026/09/08/233041.md
@@ -1,0 +1,53 @@
+---
+title: 'A docstring is one block, the way a fence already was'
+created: '2026-09-08T23:30:41'
+tags: []
+---
+
+The scope rule caught me three times in a day, and the third one had no good
+answer: a citation in the third paragraph of a docstring could only be
+acknowledged with `-file`, so I deleted the citation instead. Deleting a
+reference to avoid annotating it is the workflow telling you something.
+
+**The fix was already written down, for a different case.** The rules say
+fenced code counts as one block even when it contains blank lines — a
+syntactic unit is not split by the whitespace inside it. A docstring is the
+same shape, and once that is said the change is four lines: `blocks()` learns
+the file's language and treats docstring spans as atomic, the way it already
+treats fences. The span starts at the `def` line rather than the quotes, so a
+directive written above the definition governs what the definition says.
+
+**Measured before designing.** I tried the four placements on the real case
+rather than reasoning about them:
+
+| placement | before |
+|---|---|
+| no directive | warns (the control) |
+| `-block` above the `def` | reported STALE |
+| `-file` at module top | acknowledged |
+| `inactive-ok:` inside the docstring | warns |
+
+That table is what made the answer obvious, and getting it took two false
+starts worth recording. My first probe reported every case as quiet,
+including the control — the replacement string didn't match, so nothing was
+ever mutated. My second reported every case as acknowledged, including the
+control — `luria lint` writes to stderr and I was capturing only stdout. Both
+times the *control* was the tell: a probe whose control does not reproduce
+the condition is measuring nothing, and it is worth checking that first.
+
+**The last row stays as it is, deliberately.** A directive written inside a
+docstring still does not fire, because a docstring is not a comment — that
+rule exists because prose about the syntax used to invoke it, and a
+docstring example silently annotated its own module. This change does not
+touch it, and there is a test pinning it.
+
+**And I broke the module while documenting it**, by putting a `"""` example
+inside a `"""` docstring. The example now uses `'''`.
+
+Fired on the real case: the `ADR-087` citation I had deleted from
+`derive.value` is back, acknowledged by a `-block` directive above the
+definition, with the lint identical to main's baseline.
+
+**What this does not fix.** The three suites carrying `unlinted-file:` are a
+different problem — fixture codes in string literals and comments, not
+docstring prose. [#222](https://github.com/dmarx/luria/issues/222)'s other options still stand for those.

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -235,3 +235,62 @@ def test_in_frontmatter_the_line_below_is_the_whole_entry():
 def test_in_prose_the_line_below_is_still_one_line():
     d, = find("<!-- inactive-ok: RFC-012 — x -->\n- RFC-012\n- RFC-020\n")
     assert d.lines == frozenset({1, 2})
+
+
+# --- a docstring is one block (#222) -----------------------------------------
+
+def test_a_block_directive_above_a_def_reaches_its_whole_docstring(tmp_path):
+    """The case that motivated this: a citation in a docstring's *third*
+    paragraph. Before, only `-file` reached it — far too blunt for one
+    sentence of prose that happens to name a code."""
+    src = ('# inactive-ok-block: ADR-012 — the decision this replaced\n'
+           'def apply():\n'
+           '    """First paragraph.\n'
+           '\n'
+           '    Second paragraph.\n'
+           '\n'
+           '    A third one citing ADR-012.\n'
+           '    """\n'
+           '    return 1\n')
+    path = tmp_path / "m.py"
+    path.write_text(src)
+    found = directives.find(path, src)
+    assert len(found) == 1
+    cite = next(n for n, line in enumerate(src.splitlines(), 1)
+                if "citing ADR-012" in line)
+    assert cite in found[0].lines
+
+
+def test_a_docstring_is_atomic_the_way_a_fence_is(tmp_path):
+    """The principle it rests on, already in the rules for fenced code: a
+    blank line inside one syntactic unit does not end the paragraph."""
+    src = ('def apply():\n'
+           '    """One.\n'
+           '\n'
+           '    Two.\n'
+           '    """\n'
+           '    return 1\n')
+    # One run: the docstring's internal blank line no longer splits it, so the
+    # definition and its body are a single block.
+    assert directives.blocks(src, tmp_path / "m.py") == [(1, 6)]
+    # Without the language, that blank line splits it as it always did.
+    assert directives.blocks(src) == [(1, 2), (4, 6)]
+
+
+def test_a_directive_written_inside_a_docstring_still_does_not_fire(tmp_path):
+    """Unchanged, and load-bearing: a docstring is not a comment, so prose
+    that looks like a directive is prose."""
+    src = ('def apply():\n'
+           '    """inactive-ok: ADR-012 — not a comment.\n'
+           '\n'
+           '    Citing ADR-012.\n'
+           '    """\n'
+           '    return 1\n')
+    path = tmp_path / "m.py"
+    path.write_text(src)
+    assert directives.find(path, src) == []
+
+
+def test_unparseable_python_yields_no_docstring_spans(tmp_path):
+    """A directive's scope is not where a syntax error should surface."""
+    assert directives.blocks("def (\n", tmp_path / "m.py") is not None


### PR DESCRIPTION
Your option 4 on #222 — *"can't we just add an `inactive-ok: block` comment above the docstring?"* Yes, and now you can:

```python
# inactive-ok-block: ADR-012 — the decision this replaced
def apply():
    '''First paragraph.

    A later paragraph citing ADR-012.'''
```

## It didn't work before — measured, not assumed

Block scope stopped at the docstring's first blank line. I tried the four placements on the real case:

| placement | before |
|---|---|
| no directive (the control) | warns |
| **`-block` above the `def`** | **reported STALE** |
| `-file` at module top | acknowledged |
| `inactive-ok:` inside the docstring | warns |

So only `-file` reached a citation in a later paragraph — far too blunt for one sentence of prose that happens to name a code. Three times today I hit this scope rule; the third time I **deleted the citation** rather than annotate it, which is the workflow telling you something.

## The fix was already written down, for a different case

The rules say fenced code counts as one block even when it contains blank lines — a syntactic unit is not split by the whitespace inside it. **A docstring is the same shape.** `blocks()` learns the file's language and treats docstring spans as atomic, counted from the `def`/`class` line so a directive above the definition governs what the definition says.

Four lines of real change. It's an existing principle applied to Python, not a new concept.

## Two false starts, both caught by the control

Worth recording because the lesson generalises:

- The first probe reported **every case quiet, including the control** — its replacement string never matched, so nothing was ever mutated.
- The second reported **every case acknowledged, including the control** — `luria lint` writes to stderr and I captured only stdout.

A probe whose control doesn't reproduce the condition is measuring nothing. Checking the control first is what caught both.

## What stays unchanged, deliberately

A directive written *inside* a docstring still does not fire — a docstring is not a comment. That rule exists because prose about the syntax used to invoke it, and a docstring example once silently annotated its own module. There's a test pinning it.

## Fired on the real case

The `ADR-087` citation I had deleted from `derive.value` is back, acknowledged by a `-block` directive above the definition.

## What this does *not* fix

The three suites carrying `unlinted-file:` are a different problem — fixture codes in **string literals and comments**, not docstring prose. #222's options 1–3 still stand for those, and that decision is still yours.

**1031 tests pass.** Lint identical to `main`'s baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_