### PR TITLE
A stack of pull requests lands from the tip

### DIFF
--- a/record/changelog.d/20260909-024928.md
+++ b/record/changelog.d/20260909-024928.md
@@ -1,0 +1,3 @@
+<!-- No user-facing changes: a decision and a devlog entry about the order a
+     stack of pull requests is merged in, which is contributor workflow
+     rather than anything the CLI does. -->

--- a/record/decisions.d/ADR-tmp8tcfw.md
+++ b/record/decisions.d/ADR-tmp8tcfw.md
@@ -1,0 +1,91 @@
+---
+status: Proposed
+title: 'A stack of pull requests lands from the tip'
+version: 1
+tags:
+- process
+date: '2026-09-09'
+issue: '#227'
+summary: >-
+  This project squash-merges, which rewrites a branch's commits into a new
+  one. Merging a stack from the bottom therefore guarantees a conflict on the
+  branch above it, between two commits holding the same text. Merge the tip:
+  it already contains the whole stack, it lands in one operation, and the
+  lower pull request is closed by hand as included.
+---
+
+# ADR-tmp8tcfw: A stack of pull requests lands from the tip
+
+## Context
+
+Work here arrives as a branch and a pull request, and sometimes as two: a
+second branch cut from the first because the second change is only sensible
+on top of the first. [#227](https://github.com/dmarx/luria/issues/227) was cut from [#225](https://github.com/dmarx/luria/issues/225) that way — a Python-specific
+block-scope fix, and then the generic version of it.
+
+Both were green. Landing them looked like a free choice of order, and the
+obvious order — the lower one first, since the upper depends on it — is the
+one that does not work.
+
+`main` takes contributions as **squash** merges. A squash does not put the
+branch's commit on the trunk; it writes a *new* commit holding the same
+content. So after [#225](https://github.com/dmarx/luria/issues/225) landed, its commit was still only on its own branch,
+and the trunk had a different commit saying the same thing. Merging `main`
+into [#227](https://github.com/dmarx/luria/issues/227) then presented git with two unrelated commits that had each
+introduced the same lines, which is exactly the case it cannot resolve:
+
+    CONFLICT (content): Merge conflict in luria/directives.py
+    CONFLICT (content): Merge conflict in tests/test_directives.py
+
+Every hunk was the upper branch adding to text the lower one had written.
+Nothing was in question, and the conflict was still real work: read three
+hunks, resolve, diff against the trunk to prove nothing was dropped,
+revalidate the suite, push, and spend a second CI cycle.
+
+## Decision
+
+**Merge a stack from the tip.** The tip branch already contains every commit
+below it, so one squash lands the whole stack and no branch is ever asked to
+reconcile with a rewritten copy of itself. Close each lower pull request by
+hand, referencing the one that carried it.
+
+The trunk history is not the poorer for it: a squash's message is the
+concatenation of the commits it holds, so `fd1c68c` carries both branches'
+messages, and the two pull requests remain readable at their own numbers.
+
+This holds only because the trunk squashes. A project that merges each pull
+request as a real commit should land a stack from the bottom, since there the
+lower commit *is* on the trunk afterwards and the upper branch fast-forwards
+onto it. The rule is not "tip first" but **"land the stack whichever way
+leaves the trunk's commits as the branch's ancestors"** — and under squash
+that is only ever the tip.
+
+## Alternatives considered
+
+- **Bottom-up, resolving the conflict.** What was done, and it worked. It
+  costs a conflict resolution, a revalidation and an extra CI cycle every
+  time, on a conflict where no decision is ever in question. Paying that
+  repeatedly to record two merge commits instead of one is a bad trade, and
+  the resolution is where a stacked change can quietly lose a line.
+- **Bottom-up, then rebase the upper branch.** Removes the conflict and
+  breaks the rule that history on a shared branch is not rewritten — a
+  reviewer's checkout of the upper branch stops matching what they reviewed.
+- **Merge commits instead of squashes, so bottom-up works.** A real
+  alternative, and a larger change than this decision: the trunk's history
+  is currently one commit per contribution, which is what makes
+  `git log --oneline` on `main` a readable list of changes. Not worth
+  trading for the convenience of stacking.
+- **Don't stack.** Wait for the lower pull request to merge before cutting
+  the upper branch. It serialises work that is ready, for a problem that
+  disappears once the merge order is right.
+
+## Consequences
+
+A lower pull request in a stack will not show as merged, because its head
+commit never reaches the trunk. Close it with a comment naming the pull
+request that carried it, so the trail from its number still leads somewhere.
+
+`luria concretize` is unaffected and worth stating, since it also cares about
+where merges serialize ([ADR-049](ADR-049.md)): a stack lands as one squash, so the
+temporary codes in it are numbered in one trunk run, exactly as a single
+branch's would be.

--- a/record/devlog.d/2026/09/09/024928.md
+++ b/record/devlog.d/2026/09/09/024928.md
@@ -1,0 +1,39 @@
+---
+title: 'Merging a stack bottom-up under squash makes a conflict out of nothing'
+created: '2026-09-09T02:49:28'
+tags:
+- process
+---
+
+[#227](https://github.com/dmarx/luria/issues/227) was cut from [#225](https://github.com/dmarx/luria/issues/225)'s branch, both were green, and I merged the lower one
+first because that is the order the dependency runs in. It is the wrong order
+here, and the reason is one sentence: **a squash merge does not put the
+branch's commit on the trunk, it writes a new commit holding the same text.**
+
+So `main` had `bf84d02` and the [#227](https://github.com/dmarx/luria/issues/227) branch still had `22225e9`, two unrelated
+commits that had each introduced the same lines. Merging `main` in produced
+conflicts in `luria/directives.py` and `tests/test_directives.py` where
+nothing was actually in dispute — every hunk was the upper branch adding to
+what the lower one wrote. Resolving it was mechanical and still cost a
+resolution, a diff against the trunk to prove nothing was dropped, a full
+revalidation and a second CI cycle.
+
+The tip branch already contained the whole stack. One squash of [#227](https://github.com/dmarx/luria/issues/227) would
+have landed both, with no conflict and no second cycle, and the trunk history
+would look almost identical — a squash concatenates the messages of the
+commits it holds, so `fd1c68c` carries both branches' text either way. The
+only thing bottom-up bought was that [#225](https://github.com/dmarx/luria/issues/225) shows as *merged* rather than
+needing a manual close. That is not worth a conflict resolution on a
+stacked change, which is precisely where a quiet dropped line would hide.
+
+Written up as a decision rather than left here, because the rule generalises
+past this instance and the wrong order is the intuitive one: the dependency
+points bottom-up, so merging bottom-up feels like following it. What actually
+matters is whether the trunk's commits end up as the branch's ancestors, and
+under squash they never do.
+
+dmarx caught this immediately — *"why don't you just merge down in the other
+direction... you make things hard for yourself."* Worth recording that the
+cost was invisible from inside the task: resolving the conflict felt like
+ordinary diligence, and none of the care taken over it made it less
+self-inflicted.


### PR DESCRIPTION
Record-only. Your catch on #227, written down before it costs someone a session.

## What happened

#227 was cut from #225's branch. Both green, so I merged the lower one first, because that's the order the dependency runs in. Wrong order here, for one reason:

**A squash merge does not put the branch's commit on the trunk — it writes a new commit holding the same text.**

So `main` had `bf84d02` and the #227 branch still had `22225e9`: two unrelated commits that had each introduced the same lines. Merging `main` in gave conflicts in `luria/directives.py` and `tests/test_directives.py` where nothing was in dispute — every hunk was the upper branch adding to what the lower one wrote. Mechanical to resolve, and it still cost a resolution, a diff against the trunk to prove nothing was dropped, a full revalidation and a second CI cycle.

The tip branch already contained the whole stack. One squash of #227 lands both, no conflict, no second cycle — and the trunk history is barely different, since a squash concatenates the messages of the commits it holds (`fd1c68c` carries both branches' text as it stands). The only thing bottom-up bought was #225 showing as *merged* rather than needing a manual close.

## The rule, stated so it survives the next repo

Not "tip first". **Land the stack whichever way leaves the trunk's commits as the branch's ancestors.** Under squash that is only ever the tip; under real merge commits it is the bottom, because there the lower commit really is on the trunk afterwards and the upper branch fast-forwards. Stating it as "tip first" would be a rule that quietly inverts if this project ever stops squashing.

The alternatives are in the decision, including the two that look reasonable: rebasing the upper branch instead (breaks the no-rewriting-shared-history rule — a reviewer's checkout stops matching what they reviewed) and switching the trunk to merge commits (a real option, and a bigger change than this decision — one commit per contribution is what makes `git log --oneline main` readable).

## Why a decision and not just a devlog note

The wrong order is the intuitive one. The dependency points bottom-up, so merging bottom-up feels like following it, and the cost is invisible from inside the task — resolving that conflict felt like ordinary diligence rather than cleanup after a bad choice. That's the shape of thing worth a document someone can be pointed at.

One consequence worth flagging: `luria concretize` is unaffected. A stack lands as one squash, so its temporary codes are numbered in a single trunk run exactly as one branch's would be — which is `ADR-049`'s premise holding, not an exception to it.

Record: `ADR-tmp8tcfw`, a devlog entry, and a changelog stub (no user-facing change — this is contributor workflow, not anything the CLI does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT


---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_