### PR TITLE
Add [luria.lint] mute: suppress a warning class entirely

### DIFF
--- a/luria/config.py
+++ b/luria/config.py
@@ -115,6 +115,7 @@ DEFAULTS: dict = {
     # promotion, because only unacknowledged rows ever reach a class.
     "lint": {
         "fail_on": [],
+        "mute": [],
         # This project's own concrete nouns, for the `narrow-titles` class.
         # Luria ships NONE: the whole point of the check is that the words are
         # yours, and a shipped list would be some other project's vocabulary
@@ -1451,6 +1452,19 @@ class Config:
     chains: dict[str, Chain]
     stale_days: int
     fail_on: tuple[str, ...]            # warning classes promoted to failures
+    # Warning classes a project has decided it does not want to see at all.
+    # `fail_on` changes a class's CONSEQUENCE; this removes it from the
+    # report. The two are deliberately separate dials, and naming a class in
+    # both is a configuration error rather than a precedence question — a
+    # project cannot both enforce a check and refuse to hear it.
+    #
+    # Muting is a blunter instrument than the acknowledgement directives and
+    # is meant to be: those carry a reason at the site, which is right when
+    # the finding is about a document. A check whose findings a project has
+    # decided are not useful to it has nowhere to put such a reason, and the
+    # alternative to a mute is people learning to skim past a line forever,
+    # which costs the whole report its credibility (DP-1).
+    mute: tuple[str, ...]               # warning classes suppressed entirely
     narrow_terms: tuple[str, ...]       # this project's nouns (narrow-titles)
     network: str                        # "auto" | "never" | "require"
     # Whole records nested inside this one — directory globs, each match
@@ -1765,6 +1779,7 @@ def load(root: Path | None = None, text: str | None = None,
         chains=_chains(raw.get("chains", {}), schemes, root),
         stale_days=int(raw.get("stale_days", 90)),
         fail_on=tuple(raw["lint"]["fail_on"]),
+        mute=tuple(raw["lint"]["mute"]),
         narrow_terms=tuple(raw["lint"].get("narrow_terms", [])),
         network=str(raw["lint"].get("network", "auto")),
         include_records=tuple(raw.get("include_records", ())),

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -445,6 +445,20 @@ FAILABLE = ("retired-citations", "unresolved-codes", "hand-written-urls",
             "pending-documents", "unlinted-files", "workflow-temp-codes",
             "unlinked-site")
 
+# Classes `[luria.lint] mute` may suppress: every failable class, plus
+# `acknowledged-uniformity` — which is not failable (a project cannot promote
+# its own acknowledgement to a failure) and is exactly the kind of standing
+# note a project may reasonably not want repeated on every run.
+#
+# No class is exempt, which is a deliberate choice and the symmetric one:
+# `fail_on` already lets a project make any class fatal and defaults to making
+# none of them so, and a tool that decides for a project which of its own
+# findings it is allowed to stop reading is asserting an authority it has not
+# earned. The cost is that a project can hide something it should not, and
+# `luria reports` still renders the full accounting either way — muting
+# changes what the command prints, not what the record says.
+MUTABLE = FAILABLE + ("acknowledged-uniformity",)
+
 
 def unlinked_site() -> list[str]:
     """A record that publishes a site whose README never names it.
@@ -740,7 +754,28 @@ def report_warnings(errors: list[str]) -> None:
         errors.append(f"luria.toml: `fail_on` names {name!r}, which is no "
                       f"warning class (known: {', '.join(FAILABLE)})")
 
+    # A class the project has decided it does not want reported at all.
+    # `fail_on` changes a finding's consequence; `mute` removes it from the
+    # report. Muting is blunter than the acknowledgement directives on
+    # purpose: those carry a reason at the citing site, which is the right
+    # shape when the finding is about a document, and the wrong shape when a
+    # project has simply decided a whole check is not useful to it.
+    mute = set(current().mute)
+    for name in sorted(mute - set(MUTABLE)):
+        # Same rule as `fail_on`: a dial set to a notch that does not exist
+        # must say so rather than silently do nothing (DP-1).
+        errors.append(f"luria.toml: `mute` names {name!r}, which is no "
+                      f"mutable warning class (known: {', '.join(MUTABLE)})")
+    for name in sorted(mute & fail):
+        # Not a precedence question. A project cannot both enforce a check
+        # and refuse to hear it, and guessing which it meant would make one
+        # of the two settings a lie.
+        errors.append(f"luria.toml: {name!r} is named in both `fail_on` and "
+                      "`mute` — a class cannot be both enforced and hidden")
+
     for name, headline, lines in status_sections():
+        if name in mute and name not in fail:
+            continue
         if name in fail:
             # Name the dial that actually did it: `network = "require"`
             # promotes one class on its own, and blaming `fail_on` would send

--- a/record/changelog.d/20260909-185313.md
+++ b/record/changelog.d/20260909-185313.md
@@ -1,0 +1,23 @@
+### Added
+
+- **`[luria.lint] mute`** — warning classes suppressed from the report
+  entirely. `fail_on` changes a finding's *consequence*; this removes it from
+  the output.
+
+  The two are separate dials, and naming a class in both is a configuration
+  error rather than a precedence question: a project cannot both enforce a
+  check and refuse to hear it, and guessing which it meant would make one of
+  the settings a lie. A conflicting mute never hides an enforced class.
+
+  Mutable classes are every failable one plus `acknowledged-uniformity`,
+  which is not failable — a project cannot promote its own acknowledgement to
+  a failure — and is exactly the standing note a project may not want
+  repeated on every run. No class is exempt, which is the symmetric choice:
+  `fail_on` already lets a project make any class fatal, and a tool that
+  decides which of a project's own findings it may stop reading is asserting
+  an authority it has not earned. `luria reports` still renders the full
+  accounting either way — muting changes what the command prints, not what
+  the record says.
+
+  Like `fail_on`, a `mute` naming a class that does not exist is reported
+  rather than silently suppressing nothing ([DP-1](docs/design-principles.md#dp-1)).

--- a/record/devlog.d/2026/09/09/185314.md
+++ b/record/devlog.d/2026/09/09/185314.md
@@ -1,0 +1,62 @@
+---
+title: 'A mute dial, because fail_on only changes the consequence'
+created: '2026-09-09T18:53:14'
+tags:
+- lint
+- configuration
+---
+
+`inert-status` fired on the anthology's new `NOTE` scheme — 16 of 16 at
+`Read` — and it was correct to. A note there is written when someone finishes
+a paper, so the status genuinely carries no information; the *absence* of a
+note is how that record says "unread".
+
+The scheme has an acknowledgement for exactly this, `uniform_ok`, and setting
+it did what it should: the row stopped being a finding and became a note
+carrying its reason. dmarx's response was that the finding is not especially
+helpful in the first place, and that if it could not be turned off globally,
+it should be able to be.
+
+That was right, and the gap was real. `fail_on` looks like a visibility dial
+and is not — it promotes a class to a failure. There was **no way to say "do
+not report this class at all"**, for any class. A project's only options were
+to see a finding forever or to acknowledge it per-site, and a check whose
+findings a project has decided are not useful to it has no site to comment at.
+
+## What it does
+
+    [luria.lint]
+    mute = ["inert-status"]
+
+Removes the class from the report, headline and detail rows together.
+
+## Three decisions worth recording
+
+**Mute and `fail_on` conflict rather than compose.** Naming a class in both is
+a configuration error. It is tempting to give one precedence, and both
+choices make a setting a lie — if enforcement wins, the mute did nothing; if
+the mute wins, a project asked for a failure and silently got none. Reporting
+the conflict says so. Enforcement still wins in the meantime, because a
+misconfiguration must not be able to hide a check the same file asked to
+enforce.
+
+**No class is exempt.** The first draft had a taxonomy — "judgement" classes
+mutable, "integrity" classes always printed, on the reasoning that hiding
+`stale-directives` is how a report stops meaning anything. Then the comment
+saying so did not match the code, which is how I noticed the taxonomy was
+mine rather than the project's. `fail_on` already lets a project make any
+class fatal and defaults to none, so latitude over consequence is total; the
+symmetric thing is latitude over visibility. `luria reports` renders the
+accounting regardless, so muting changes what a command prints and not what
+the record contains.
+
+**`acknowledged-uniformity` is mutable but not failable.** The two
+vocabularies are deliberately different lists. A project cannot promote its
+own acknowledgement to a failure — that would be strange — but it may
+reasonably not want the standing note repeated on every run.
+
+## The general shape
+
+A dial that changes what happens to a finding is not a dial that changes
+whether you see it, and this codebase had the first while its name suggested
+both. Worth checking the other settings for the same conflation.

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -283,16 +283,17 @@ def test_a_view_the_generator_no_longer_writes_is_not_a_stray(project):
 # ── The enforcement dial (ADR-035) ───────────────────────────────────────
 
 
-def dial_project(project, fail_on: str = "") -> None:
+def dial_project(project, fail_on: str = "", mute: str = "") -> None:
     """A project with a retired decision cited from a docs page, and the
-    dial set to `fail_on` (a TOML list body, e.g. '"retired-citations"')."""
+    dials set to `fail_on` and `mute` (TOML list bodies, e.g.
+    '"retired-citations"')."""
     _scheme.decision(project, 12, "Superseded")
     page = project / "docs" / "notes.md"
     page.parent.mkdir(parents=True, exist_ok=True)
     page.write_text("Still leaning on ADR-012 here.\n")
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
-        f'[luria.lint]\nfail_on = [{fail_on}]\n')
+        f'[luria.lint]\nfail_on = [{fail_on}]\nmute = [{mute}]\n')
     from luria import config
     config.reset()
 
@@ -452,3 +453,63 @@ def test_a_scheme_with_no_form_has_nothing_to_compare(project):
     from tests import _scheme
     _scheme.decision(project, 1, "Active", summary="Whatever the form said.")
     assert form_text_errors() == []
+
+
+# ── The mute dial ────────────────────────────────────────────────────────
+
+
+def test_a_muted_class_is_not_reported(project, capsys):
+    """`mute` removes a class from the report entirely.
+
+    Distinct from `fail_on`, which changes a finding's consequence. A project
+    that has decided a whole check is not useful to it has nowhere to put an
+    acknowledgement — the directives carry a reason at a *site*, and this
+    kind of finding has none."""
+    dial_project(project, mute='"retired-citations"')
+    errors, err = dial_errors(capsys)
+    assert errors == []
+    assert "retired documents cited unacknowledged" not in err
+    assert "ADR-012" not in err, "the detail rows go with the headline"
+
+
+def test_muting_one_class_leaves_the_others(project, capsys):
+    """A mute is per-class, not a global off switch."""
+    dial_project(project, mute='"inert-status"')
+    errors, err = dial_errors(capsys)
+    assert errors == []
+    assert "retired documents cited unacknowledged" in err
+
+
+def test_mute_rejects_a_class_that_does_not_exist(project, capsys):
+    """Same rule as `fail_on`: a dial set to a notch that does not exist must
+    say so rather than silently suppress nothing (DP-1)."""
+    dial_project(project, mute='"no-such-check"')
+    errors, _ = dial_errors(capsys)
+    assert any("`mute` names 'no-such-check'" in e for e in errors), errors
+
+
+def test_a_class_cannot_be_both_enforced_and_hidden(project, capsys):
+    """Not a precedence question. Guessing which the project meant would make
+    one of the two settings a lie, so it is a configuration error."""
+    dial_project(project, fail_on='"retired-citations"',
+                 mute='"retired-citations"')
+    errors, _ = dial_errors(capsys)
+    assert any("both `fail_on` and `mute`" in e for e in errors), errors
+
+
+def test_enforcement_still_wins_over_a_conflicting_mute(project, capsys):
+    """The conflict is reported AND the class still fails — a misconfigured
+    mute must not be able to hide a check the same file asked to enforce."""
+    dial_project(project, fail_on='"retired-citations"',
+                 mute='"retired-citations"')
+    errors, _ = dial_errors(capsys)
+    assert any("failing: `fail_on`" in e for e in errors), errors
+
+
+def test_acknowledged_uniformity_is_mutable(project, capsys):
+    """It is not failable — a project cannot promote its own acknowledgement
+    to a failure — but it is exactly the standing note a project may not want
+    repeated on every run, so the two vocabularies are not the same list."""
+    dial_project(project, mute='"acknowledged-uniformity"')
+    errors, _ = dial_errors(capsys)
+    assert not any("is no mutable warning class" in e for e in errors), errors


### PR DESCRIPTION
`fail_on` looks like a visibility dial and is not — it promotes a class to a **failure**. There was no way to say *"do not report this class at all"*, for any class. A project's only options were to see a finding forever or to acknowledge it per-site, and a check whose findings a project has decided are not useful to it **has no site to comment at**.

```toml
[luria.lint]
mute = ["inert-status"]
```

Removes the class from the report, headline and detail rows together.

## How it came up

`inert-status` fired on the anthology's new `NOTE` scheme — 16 of 16 at `Read` — and it was **correct to**. A note there is written when someone finishes a paper, so the status genuinely carries no information; the *absence* of a note is how that record says "unread".

`uniform_ok` did exactly its job: the row stopped being a finding and became a note carrying its reason. dmarx's response was that the finding isn't especially helpful in the first place, and that if it couldn't be turned off globally, it should be able to be. That was right, and the gap was real for every class, not just this one.

## Three decisions

**Mute and `fail_on` conflict rather than compose.** Naming a class in both is a configuration error. Giving either precedence makes one of the settings a lie — if enforcement wins the mute did nothing; if the mute wins, a project asked for a failure and silently got none. Reporting the conflict says so. Enforcement still wins in the meantime, so a misconfiguration can't hide a check the same file asked to enforce.

**No class is exempt.** The first draft had a taxonomy — "judgement" classes mutable, "integrity" classes always printed, reasoning that hiding `stale-directives` is how a report stops meaning anything. Then the comment describing it didn't match the code, which is how I noticed **the taxonomy was mine rather than the project's**. `fail_on` already lets a project make any class fatal and defaults to none, so latitude over consequence is total; the symmetric thing is latitude over visibility. `luria reports` renders the accounting regardless — muting changes what a *command prints*, not what the record contains.

**`acknowledged-uniformity` is mutable but not failable.** The two vocabularies are deliberately different lists. A project can't promote its own acknowledgement to a failure, but it may reasonably not want the standing note repeated on every run.

Like `fail_on`, a `mute` naming a class that doesn't exist is reported rather than silently suppressing nothing (`DP-001`).

## Verification

- **Nine new tests**, 1070 passing — including the conflict case, the per-class scope (muting one leaves the others), the unknown-notch rejection, and that enforcement survives a conflicting mute.
- **Fired on the anthology's real corpus** before trusting it: both muted classes silent, every other section intact.

## The general shape, for the devlog

A dial that changes *what happens to* a finding is not a dial that changes *whether you see it*, and this codebase had the first while its name suggested both. Worth checking the other settings for the same conflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_