### PR TITLE
`derive` can follow a reference: one hop, against written frontmatter

### DIFF
--- a/luria/adr_index.py
+++ b/luria/adr_index.py
@@ -48,7 +48,7 @@ from pathlib import Path
 
 import yaml
 
-from . import derive
+from . import derive, referents
 from .config import current
 
 # unresolved-ok: ADR-tmp47fje — ADR-049's example of the shape, not a document
@@ -169,7 +169,12 @@ class Adr:
         # Safe to fold into `meta` because nothing writes a document back
         # through this object: frontmatter edits are text surgery
         # (`field_edit`), so a derived value can never be persisted.
-        self.meta = derive.applied(self.meta, scheme.derived)
+        # A `from` derivation reads another document, so the resolver goes in
+        # here too. Built per `Adr` rather than shared: a single reading is
+        # one document and a handful of referents, and a longer-lived cache
+        # would outlive the edit that invalidates it (#233).
+        self.meta = derive.applied(self.meta, scheme.derived,
+                                   referents.Lookup())
         # `title:` is the source of truth; the body's H1 is the fallback, so a
         # document written before the field existed — or in a project that
         # hasn't adopted it — still renders a title rather than a blank cell

--- a/luria/config.py
+++ b/luria/config.py
@@ -115,6 +115,7 @@ DEFAULTS: dict = {
     # promotion, because only unacknowledged rows ever reach a class.
     "lint": {
         "fail_on": [],
+        "mute": [],
         # This project's own concrete nouns, for the `narrow-titles` class.
         # Luria ships NONE: the whole point of the check is that the words are
         # yours, and a shipped list would be some other project's vocabulary
@@ -1451,6 +1452,19 @@ class Config:
     chains: dict[str, Chain]
     stale_days: int
     fail_on: tuple[str, ...]            # warning classes promoted to failures
+    # Warning classes a project has decided it does not want to see at all.
+    # `fail_on` changes a class's CONSEQUENCE; this removes it from the
+    # report. The two are deliberately separate dials, and naming a class in
+    # both is a configuration error rather than a precedence question — a
+    # project cannot both enforce a check and refuse to hear it.
+    #
+    # Muting is a blunter instrument than the acknowledgement directives and
+    # is meant to be: those carry a reason at the site, which is right when
+    # the finding is about a document. A check whose findings a project has
+    # decided are not useful to it has nowhere to put such a reason, and the
+    # alternative to a mute is people learning to skim past a line forever,
+    # which costs the whole report its credibility (DP-1).
+    mute: tuple[str, ...]               # warning classes suppressed entirely
     narrow_terms: tuple[str, ...]       # this project's nouns (narrow-titles)
     network: str                        # "auto" | "never" | "require"
     # Whole records nested inside this one — directory globs, each match
@@ -1765,6 +1779,7 @@ def load(root: Path | None = None, text: str | None = None,
         chains=_chains(raw.get("chains", {}), schemes, root),
         stale_days=int(raw.get("stale_days", 90)),
         fail_on=tuple(raw["lint"]["fail_on"]),
+        mute=tuple(raw["lint"]["mute"]),
         narrow_terms=tuple(raw["lint"].get("narrow_terms", [])),
         network=str(raw["lint"].get("network", "auto")),
         include_records=tuple(raw.get("include_records", ())),

--- a/luria/config.py
+++ b/luria/config.py
@@ -1212,12 +1212,22 @@ def _fields(prefix: str, raw: dict, scheme_dir: Path, root: Path,
         if field in taken:
             raise ValueError(f"{where}: `{field}` is also declared under "
                              f"`references`; a field has one declaration")
+        if spec.get("from") is not None and spec.get("derive") is None:
+            raise ValueError(
+                f"{where}: `from` says which document to read and `derive` "
+                f"says what to read off it — `from` alone renders nothing")
         rule = None
         if spec.get("derive") is not None:
-            rule = parse_derivation(where, str(field), spec["derive"])
+            from .derive import parse_follow
+            follow = (parse_follow(f"{where}.from", spec["from"])
+                      if spec.get("from") is not None else None)
+            rule = parse_derivation(where, str(field), spec["derive"], follow)
             if spec.get("many"):
                 raise ValueError(
-                    f"{where}: `derive = \"{rule.spec}\"` reads one value off "
+                    # `template`, not `spec`: this message quotes the literal
+                    # `derive =` value, and `spec` also names the followed
+                    # reference, which was written on its own line (#233).
+                    f"{where}: `derive = \"{rule.template}\"` reads one value off "
                     f"a list, so the field holds one — drop `many`")
             if spec.get("required"):
                 raise ValueError(
@@ -1905,7 +1915,7 @@ def _check_conditions(prefix: str, scheme) -> None:
                 f"(values: {', '.join(allowed)})")
 
 
-def _check_derivations(prefix: str, scheme) -> None:
+def _check_derivations(prefix: str, scheme, schemes=None) -> None:
     """Every `derive` against the scheme that declares it (#216).
 
     Two things the shape check cannot know on its own: whether the source is a
@@ -1925,8 +1935,33 @@ def _check_derivations(prefix: str, scheme) -> None:
                 *(r.field for r in scheme.references),
                 *(v.field for v in scheme.vocabularies),
                 *(f.field for f in scheme.plain_fields)}
+    references = {r.field: r for r in scheme.references}
     for rule in scheme.derived:
         where = f"luria.toml: schemes.{prefix}.fields.{rule.field}.derive"
+        if rule.follow is not None:
+            # The names in the template belong to the *target* scheme, and
+            # which scheme that is comes from the reference being followed.
+            # Both halves are checkable here and neither is checkable in
+            # `derive`, which never sees a second scheme (#233).
+            ref = references.get(rule.follow.field)
+            if ref is None:
+                raise ValueError(
+                    f"{where}: `from = \"{rule.follow}\"` — `{rule.follow.field}` "
+                    f"is not a reference {prefix} declares, so there is no "
+                    f"document to read (references: "
+                    f"{', '.join(sorted(references)) or 'none'})")
+            if ref.many and rule.follow.index is None:
+                raise ValueError(
+                    f"{where}: `{rule.follow.field}` holds several references, "
+                    f"so `from` has to say which — write "
+                    f"`{rule.follow.field}[0]` for the first")
+            if not ref.many and rule.follow.index is not None:
+                raise ValueError(
+                    f"{where}: `{rule.follow.field}` holds one reference, so "
+                    f"`from = \"{rule.follow}\"` indexes something that is not "
+                    f"a list — write `{rule.follow.field}`")
+            _check_target_fields(where, rule, ref, schemes)
+            continue
         for name in rule.sources:
             if name not in nameable:
                 raise ValueError(
@@ -1938,11 +1973,42 @@ def _check_derivations(prefix: str, scheme) -> None:
         # single-valued fields legitimately. A template that is *only* a
         # single-valued field copies it under a second name, which is the
         # rename this refused before templates existed.
+        #
+        # It does not apply across a reference: `"{published}"` off the
+        # document `source[0]` names is not a second name for this document's
+        # field, it is the only way to read the other one's.
         if lone_field(rule.template) and rule.sources[0] not in plural:
             raise ValueError(
                 f"{where}: `{rule.template}` is just `{rule.sources[0]}` under "
                 f"another name — a template that reads one single-valued field "
                 f"and nothing else renames a field rather than deriving one")
+
+
+def _check_target_fields(where: str, rule, ref, schemes) -> None:
+    """A followed template against the scheme it actually renders against.
+
+    Takes the schemes being built rather than reading `current()`: this runs
+    *during* load, and asking the loader for the config it is still assembling
+    recurses until the stack ends.
+
+    Skipped when the target is a scheme this project does not declare — a
+    remote, or a prefix configured elsewhere — because there is nothing local
+    to check the names against and refusing would forbid a legitimate shape."""
+    target = (schemes or {}).get(ref.scheme)
+    if target is None:
+        return
+    nameable = {*BUILT_IN_CONDITION_FIELDS, "number", *target.requires,
+                *(r.field for r in target.references),
+                *(v.field for v in target.vocabularies),
+                *(f.field for f in target.plain_fields),
+                *(d.field for d in target.derived)}
+    for name in rule.sources:
+        if name not in nameable:
+            raise ValueError(
+                f"{where}: `{name}` is not a field {ref.scheme} declares, and "
+                f"`from = \"{rule.follow}\"` reads a {ref.scheme} document — "
+                f"so `{rule.field}` resolves to nothing on every document "
+                f"(nameable: {', '.join(sorted(nameable))})")
 
 
 def _alias_template(prefix: str, raw) -> str:
@@ -2035,7 +2101,7 @@ def _schemes(raw: dict, root: Path,
         )
     for prefix, scheme in schemes.items():
         _check_conditions(prefix, scheme)
-        _check_derivations(prefix, scheme)
+        _check_derivations(prefix, scheme, schemes)
         for ref in scheme.references:
             if ref.scheme not in schemes:
                 raise ValueError(

--- a/luria/contract.py
+++ b/luria/contract.py
@@ -319,7 +319,10 @@ def describe(contract: Contract) -> list[str]:
         if field.builtin:
             continue
         if (rule := contract.derivation(field.name)) is not None:
-            what = f"derived — `{rule.template}`, never written"
+            # `spec` rather than `template`: a followed derivation reads
+            # another document, and a record page saying only `{published}`
+            # would not say whose (#233).
+            what = f"derived — `{rule.spec}`, never written"
             if field.vocabulary is not None:
                 what += (", and one of "
                          + ", ".join(f"`{v}`" for v in field.values))
@@ -465,11 +468,13 @@ def _any_scheme_violations(contract: Contract, field: Field, rel: str, raw,
 
 
 def violations(contract: Contract, rel: str, meta: dict,
-               known: dict[str, set[str]]) -> list[str]:
+               known: dict[str, set[str]], resolve=None) -> list[str]:
     """One document against its scheme's contract, one line per breach.
 
     `known` maps a target prefix to its resolvable codes; the caller loads
-    each once per run rather than once per document.
+    each once per run rather than once per document. `resolve` is how a
+    `from` derivation reads the document it follows (#233), and for the same
+    reason belongs to the run: one shared reader, not one per document.
 
     A derived field (#216) is read off the document before anything else runs,
     so every check below sees one field whether it was computed or written —
@@ -483,7 +488,7 @@ def violations(contract: Contract, rel: str, meta: dict,
             f"{contract.scheme} derives it (`{rule.spec}`) — the value has "
             f"one source and this is not it; drop the line and order "
             f"the fields it reads to say it")
-    meta = derive.applied(meta, contract.derived)
+    meta = derive.applied(meta, contract.derived, resolve)
     for field in contract.fields:
         raw = meta.get(field.name)
         if field.vocabulary is not None:

--- a/luria/derive.py
+++ b/luria/derive.py
@@ -31,6 +31,25 @@ is one template language in luria, not a second grammar per feature, and
 `{tags[0]}`, `{first_author}`, `{published:.4}` all mean what they mean
 everywhere else.
 
+**Across a reference (#233).** A second declaration says which document to
+render against:
+
+    [luria.schemes.SOTA.fields.published]
+    derive = "{published}"
+    from   = "source[0]"
+
+The template is unchanged — `{published}` still means what it means
+everywhere — and only the *values* it renders against move, to the frontmatter
+of the document `source[0]` names. That keeps the promise above: one template
+language, and the new capability is a second variable source rather than a
+second grammar.
+
+**One hop, and it reads written frontmatter.** The target's own derivations
+are not resolved first. So a cycle is impossible by construction rather than
+by detection, and there is no order in which schemes must be evaluated. The
+cost is that derivations do not chain; the case that motivated this does not
+need them to, and a chain is a decision to take when something does.
+
 **A lone field returns the value, not a string.** `"{tags[0]}"` yields the
 tag itself, so it stays identical to the vocabulary member a check compares
 it against and to the value another document's tag list intersects with.
@@ -44,15 +63,49 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
+class Follow:
+    """Which referenced document a derivation reads: `source[0]`, `paper`.
+
+    `index` is None for a scalar reference and an integer for one element of
+    a plural one. There is no "every element" spelling: a field holds one
+    value, so collecting across a list would need somewhere to put the
+    others."""
+    field: str
+    index: int | None = None
+
+    def __str__(self) -> str:
+        return self.field if self.index is None else f"{self.field}[{self.index}]"
+
+    def code(self, meta: dict) -> str | None:
+        """The code this document points at, or None when it points nowhere."""
+        raw = meta.get(self.field)
+        if self.index is None:
+            if isinstance(raw, list):
+                return None      # a list where the declaration said one
+            return str(raw).strip() or None if raw else None
+        if not isinstance(raw, list):
+            raw = [raw] if raw else []
+        if self.index >= len(raw):
+            return None
+        got = raw[self.index]
+        return str(got).strip() or None if got else None
+
+
+@dataclass(frozen=True)
 class Derived:
-    """One derivation: `field` is what it defines, `template` how."""
+    """One derivation: `field` is what it defines, `template` how, and
+    `follow` which document — None for this one (#216), a reference to
+    render against for another (#233)."""
     field: str
     template: str
+    follow: Follow | None = None
 
     @property
     def spec(self) -> str:
         """The declaration as written, for messages that name it."""
-        return self.template
+        if self.follow is None:
+            return self.template
+        return f"{self.template}` from `{self.follow}"
 
     @property
     def sources(self) -> tuple[str, ...]:
@@ -104,10 +157,31 @@ def render(template: str, values: dict):
     return out or None
 
 
-def parse(where: str, field: str, raw) -> Derived:
+def parse_follow(where: str, raw) -> Follow:
+    """A `from = "source[0]"` declaration, or a ValueError naming the fault.
+
+    Shape only. Whether the name is a reference the scheme declares, and
+    whether it holds one value or several, needs the whole scheme."""
+    import re
+    text = str(raw).strip()
+    if not text:
+        raise ValueError(f"{where}: `from` is empty")
+    m = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)(?:\[(\d+)\])?", text)
+    if not m:
+        raise ValueError(
+            f"{where}: `from = {text!r}` is not a reference — write the field "
+            f"name, and an index when it holds several (`source[0]`)")
+    return Follow(field=m.group(1),
+                  index=None if m.group(2) is None else int(m.group(2)))
+
+
+def parse(where: str, field: str, raw, follow=None) -> Derived:
     """One `derive = "{template}"` declaration, or a ValueError naming what
     was wrong with it. Shape only — whether the names are fields the scheme
-    can hold needs the whole scheme, so that is checked there."""
+    can hold needs the whole scheme, so that is checked there.
+
+    `follow` is the parsed `from`, when the template renders against a
+    referenced document rather than this one (#233)."""
     text = str(raw).strip()
     if not text:
         raise ValueError(f"{where}: `derive` is empty")
@@ -121,11 +195,19 @@ def parse(where: str, field: str, raw) -> Derived:
         raise ValueError(
             f"{where}: `derive = {text!r}` reads no field, so every document "
             f"would get the same value — which is a default, not a derivation")
-    if field in read:
+    # Self-reference is a cycle within one document and an ordinary read
+    # across two — `published` from its source's `published` is the whole
+    # point of `from`, and is what this rule must not catch.
+    if follow is None and field in read:
         raise ValueError(
             f"{where}: `{field}` derives from itself, which resolves to "
             f"nothing")
-    return Derived(field=str(field), template=text)
+    if follow is not None and follow.field in read:
+        raise ValueError(
+            f"{where}: the template reads `{follow.field}`, which is the "
+            f"reference it follows — that is this document's field, not the "
+            f"referenced document's, and reading it here says nothing")
+    return Derived(field=str(field), template=text, follow=follow)
 
 
 class _Probe(dict):
@@ -148,19 +230,36 @@ class _Probe(dict):
 
 # inactive-ok-block: ADR-087 — Proposed, from the same plan; cited for the
 # capability it added, not as settled evidence
-def value(meta: dict, rule: Derived):
+def value(meta: dict, rule: Derived, resolve=None):
     """The derived value for one document, or None when the template cannot
     be filled.
 
     Absence is not an error here. A document with no `tags:` has no primary
     topic to compute, and saying so is the tags field's job — reporting it
-    twice would name the wrong line as the fix.
+    twice would name the wrong line as the fix. The same holds across a
+    reference: pointing at nothing, at a code that resolves to nothing, or at
+    a document that does not carry the field all derive nothing, because each
+    already has a check whose finding names the right line.
 
-    Only the document's own frontmatter is in scope, and that is enough for
-    `{number}` too, now that identity is a field a document carries rather
-    than a filename it is parsed out of (ADR-087) — a capability this step
-    inherits rather than adds."""
-    return render(rule.template, meta)
+    Without `from`, only the document's own frontmatter is in scope, and that
+    is enough for `{number}` too, now that identity is a field a document
+    carries rather than a filename it is parsed out of (ADR-087) — a
+    capability this step inherits rather than adds.
+
+    With `from`, `resolve` maps a code to that document's *written*
+    frontmatter. A caller that cannot resolve (none was supplied) derives
+    nothing rather than guessing."""
+    if rule.follow is None:
+        return render(rule.template, meta)
+    if resolve is None:
+        return None
+    code = rule.follow.code(meta)
+    if code is None:
+        return None
+    target = resolve(code)
+    if not target:
+        return None
+    return render(rule.template, target)
 
 
 def written(meta: dict, rules) -> list[str]:
@@ -169,16 +268,20 @@ def written(meta: dict, rules) -> list[str]:
     return [r.field for r in rules if meta.get(r.field) not in (None, "", [])]
 
 
-def applied(meta: dict, rules) -> dict:
+def applied(meta: dict, rules, resolve=None) -> dict:
     """`meta` with every derivation resolved onto it.
 
     A copy: the caller's dict is what the document says, and several checks
-    still need to tell the two apart."""
+    still need to tell the two apart.
+
+    `resolve` is what a `from` derivation reads the other document through;
+    every rule sees the document's *written* frontmatter, never a partially
+    derived one, so the order rules are applied in cannot matter."""
     if not rules:
         return meta
     out = dict(meta)
     for rule in rules:
-        got = value(meta, rule)
+        got = value(meta, rule, resolve)
         if got is None:
             out.pop(rule.field, None)
         else:

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -445,6 +445,20 @@ FAILABLE = ("retired-citations", "unresolved-codes", "hand-written-urls",
             "pending-documents", "unlinted-files", "workflow-temp-codes",
             "unlinked-site")
 
+# Classes `[luria.lint] mute` may suppress: every failable class, plus
+# `acknowledged-uniformity` — which is not failable (a project cannot promote
+# its own acknowledgement to a failure) and is exactly the kind of standing
+# note a project may reasonably not want repeated on every run.
+#
+# No class is exempt, which is a deliberate choice and the symmetric one:
+# `fail_on` already lets a project make any class fatal and defaults to making
+# none of them so, and a tool that decides for a project which of its own
+# findings it is allowed to stop reading is asserting an authority it has not
+# earned. The cost is that a project can hide something it should not, and
+# `luria reports` still renders the full accounting either way — muting
+# changes what the command prints, not what the record says.
+MUTABLE = FAILABLE + ("acknowledged-uniformity",)
+
 
 def unlinked_site() -> list[str]:
     """A record that publishes a site whose README never names it.
@@ -740,7 +754,28 @@ def report_warnings(errors: list[str]) -> None:
         errors.append(f"luria.toml: `fail_on` names {name!r}, which is no "
                       f"warning class (known: {', '.join(FAILABLE)})")
 
+    # A class the project has decided it does not want reported at all.
+    # `fail_on` changes a finding's consequence; `mute` removes it from the
+    # report. Muting is blunter than the acknowledgement directives on
+    # purpose: those carry a reason at the citing site, which is the right
+    # shape when the finding is about a document, and the wrong shape when a
+    # project has simply decided a whole check is not useful to it.
+    mute = set(current().mute)
+    for name in sorted(mute - set(MUTABLE)):
+        # Same rule as `fail_on`: a dial set to a notch that does not exist
+        # must say so rather than silently do nothing (DP-1).
+        errors.append(f"luria.toml: `mute` names {name!r}, which is no "
+                      f"mutable warning class (known: {', '.join(MUTABLE)})")
+    for name in sorted(mute & fail):
+        # Not a precedence question. A project cannot both enforce a check
+        # and refuse to hear it, and guessing which it meant would make one
+        # of the two settings a lie.
+        errors.append(f"luria.toml: {name!r} is named in both `fail_on` and "
+                      "`mute` — a class cannot be both enforced and hidden")
+
     for name, headline, lines in status_sections():
+        if name in mute and name not in fail:
+            continue
         if name in fail:
             # Name the dial that actually did it: `network = "require"`
             # promotes one class on its own, and blaming `fail_on` would send

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -50,7 +50,7 @@ import re
 import sys
 
 from . import adr_index as builder
-from . import (adr_pending, badges, chains, ci, contract, doc_refs, journal,
+from . import (adr_pending, badges, chains, ci, contract, doc_refs, journal, referents,
                link_targets, narrow_titles, pins, ref_status, remotes,
                relations, sources, statuses, templates)
 from . import aliases as aliases_mod
@@ -199,6 +199,9 @@ def check_contracts(errors: list[str]) -> None:
     was the opt-in (ADR-054)."""
     cfg = current()
     known: dict[str, set[str]] = {}
+    # One reader for the whole run: a much-cited paper is otherwise re-parsed
+    # once per document that cites it (#233).
+    resolve = referents.Lookup()
     for scheme in cfg.schemes.values():
         c = contract.for_scheme(scheme)
         # Not `c.empty`: that ignores the built-in `superseded_by` field,
@@ -218,7 +221,8 @@ def check_contracts(errors: list[str]) -> None:
             # finding, raised where the repair is named. Reading it apart
             # here keeps the contract's checker generic (#181).
             meta = statuses.normalised(meta)
-            errors.extend(contract.violations(c, cfg.rel(path), meta, known))
+            errors.extend(contract.violations(c, cfg.rel(path), meta, known,
+                                              resolve))
 
 
 def check_numbers(errors: list[str]) -> None:

--- a/luria/referents.py
+++ b/luria/referents.py
@@ -1,0 +1,75 @@
+# luria/referents.py
+"""The written frontmatter of a document named by a code (#233).
+
+What a `from` derivation reads through. Small and separate for two reasons.
+
+`derive` is pure — templates, no I/O, no config — which is what lets its rules
+be tested against dictionaries. Following a reference is the opposite: it
+needs the scheme table to find the directory and the disk to read the file. So
+the resolution lives here and reaches `derive` as a callable, and neither
+module grows the other's dependencies.
+
+**Written frontmatter, never derived.** A referenced document is parsed and
+handed over as it was typed. That is the one-hop rule from `derive`, enforced
+where the reading happens: a derivation cannot see another derivation, so
+there is no cycle to detect and no order in which schemes must be resolved.
+
+**Cached per resolver, not globally.** A `Lookup` holds one run's readings.
+The lint parses hundreds of documents and would otherwise re-read a
+much-cited paper once per citing document; a module-level cache would instead
+outlive the edit that invalidates it, which is the bug this shape avoids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .config import current
+
+
+@dataclass
+class Lookup:
+    """Code → that document's written frontmatter, read at most once each."""
+
+    _seen: dict[str, dict] = field(default_factory=dict)
+
+    def __call__(self, code: str) -> dict:
+        """The frontmatter for `code`, or `{}` when it names no document.
+
+        `{}` rather than an exception: a code that resolves to nothing is
+        already the reference check's finding, and raising here would report
+        one fault twice — on the line that cites it and on the line that
+        derives from it."""
+        if code in self._seen:
+            return self._seen[code]
+        self._seen[code] = meta = _read(code)
+        return meta
+
+
+def _read(code: str) -> dict:
+    from .adr_index import parse_frontmatter
+    path = path_of(code)
+    if path is None:
+        return {}
+    try:
+        meta, _ = parse_frontmatter(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+    return meta or {}
+
+
+def path_of(code: str) -> Path | None:
+    """The file a local code names, or None — a remote, an unknown scheme, or
+    a number no document carries.
+
+    Temporary codes resolve too (ADR-049): a merge-allocated document is a
+    real document that has not been numbered yet, and a derivation off one
+    should not go blank until the merge that numbers it."""
+    prefix, _, tail = str(code).strip().partition("-")
+    scheme = current().schemes.get(prefix.upper())
+    if scheme is None or not tail:
+        return None
+    if tail.isdigit():
+        return scheme.documents().get(int(tail))
+    return scheme.temp_documents().get(tail)

--- a/record/changelog.d/20260909-185313.md
+++ b/record/changelog.d/20260909-185313.md
@@ -1,0 +1,23 @@
+### Added
+
+- **`[luria.lint] mute`** — warning classes suppressed from the report
+  entirely. `fail_on` changes a finding's *consequence*; this removes it from
+  the output.
+
+  The two are separate dials, and naming a class in both is a configuration
+  error rather than a precedence question: a project cannot both enforce a
+  check and refuse to hear it, and guessing which it meant would make one of
+  the settings a lie. A conflicting mute never hides an enforced class.
+
+  Mutable classes are every failable one plus `acknowledged-uniformity`,
+  which is not failable — a project cannot promote its own acknowledgement to
+  a failure — and is exactly the standing note a project may not want
+  repeated on every run. No class is exempt, which is the symmetric choice:
+  `fail_on` already lets a project make any class fatal, and a tool that
+  decides which of a project's own findings it may stop reading is asserting
+  an authority it has not earned. `luria reports` still renders the full
+  accounting either way — muting changes what the command prints, not what
+  the record says.
+
+  Like `fail_on`, a `mute` naming a class that does not exist is reported
+  rather than silently suppressing nothing ([DP-1](docs/design-principles.md#dp-1)).

--- a/record/changelog.d/20260910-154749.md
+++ b/record/changelog.d/20260910-154749.md
@@ -1,0 +1,43 @@
+### Added
+
+- **`derive` can follow a reference (`#233`).** A second declaration says which
+  document the template renders against:
+
+      [luria.schemes.SOTA.fields.published]
+      derive = "{published}"
+      from   = "source[0]"
+
+  `from` names a reference field the scheme declares, indexed when that field
+  holds several. So a fact one scheme owns — a paper's publication date, on the
+  note that is about that paper — can be **read** by the documents that need it
+  instead of copied into each of them.
+
+  The template is unchanged: `{published}` still means what it means
+  everywhere, and only the values it renders against move. `derive` promised
+  one template language rather than a second grammar per feature, and this
+  keeps that promise by adding a second *variable source*.
+
+  **One hop, against written frontmatter.** The target's own derivations are
+  not resolved first, so a cycle is impossible by construction rather than by
+  detection and no evaluation order across schemes has to exist. Derivations do
+  not chain; `ADR-tmpk3zby` records why that is deferred rather than refused.
+
+  **The target field must be declared**, so a typo is a load error rather than
+  a field that resolves to nothing on every document. Refused at load, with the
+  reason named: a `from` that names no reference, a plural reference with no
+  index, a scalar one with an index, and a template reading a field the target
+  scheme cannot hold.
+
+### Fixed
+
+- **A record page for a followed derivation now says which document it reads.**
+  It rendered the template alone — `{published}` — which does not say whose.
+
+### Found
+
+- **`concretize` rewrites references, not values**, and the lint had no rule
+  relating one document's field to another's. That is why a copied field could
+  disagree with its original indefinitely with every mechanical check green.
+  Measured in the motivating record: eight practices carrying the publication
+  date of a source they had stopped citing, two of them left behind by passes
+  whose entire purpose was correcting the source list.

--- a/record/decisions.d/ADR-tmpk3zby.md
+++ b/record/decisions.d/ADR-tmpk3zby.md
@@ -1,0 +1,128 @@
+---
+status: Proposed
+title: 'A derivation may follow a reference: one hop, against written frontmatter'
+version: 1
+tags:
+- record
+- mechanism
+date: '2026-09-10'
+issue: '#233'
+summary: >-
+  `derive` gains `from`, naming a reference to render the template against, so
+  a fact one scheme owns can be read by another instead of copied into it.
+  Rejected: a `ref.` namespace inside the template, which would have made the
+  template language grow a second grammar; and resolving the target's own
+  derivations first, which buys chaining at the cost of cycle detection and an
+  evaluation order.
+---
+
+# ADR-tmpk3zby: A derivation may follow a reference: one hop, against written frontmatter
+
+## Context
+
+`derive` computes a field from **the document's own frontmatter**. There was
+no way to say *take this from the document you point at*, so a fact one scheme
+owns had to be copied by hand into every document that needed it.
+
+A copy goes stale when its original moves, and nothing in luria could notice:
+`concretize` rewrites **references**, not **values**, and the lint has no rule
+relating one document's field to another's.
+
+The cost is measured rather than hypothetical. `anthology-of-the-sota` stores a
+paper's publication date on its `LIT` notes and copies it onto practices and
+reading notes. Backfilling that field across 281 documents found **eight
+practices carrying the date of a source they no longer cite** — one of them a
+paper absent from its `source:` list entirely. Two were left behind by passes
+whose entire purpose was correcting `source:`: a pass that fixes a field does
+not think about the fields derived from it, and nothing made it.
+
+That project shipped a bespoke checker. It works, and it is a per-project
+reimplementation of something the schema should be able to state.
+
+## Decision
+
+A derivation may name the reference it reads through:
+
+    [luria.schemes.SOTA.fields.published]
+    derive = "{published}"
+    from   = "source[0]"
+
+`from` names a reference field the scheme declares, indexed when that field
+holds several. The template renders against the referenced document's
+frontmatter instead of this one's.
+
+Three parts are load-bearing.
+
+**The template does not change.** `{published}` means what it means
+everywhere; only the values it renders against move. `derive` already promised
+one template language rather than a second grammar per feature, and this keeps
+it — the new capability is a second *variable source*, which is the same shape
+`#219` took when it fed `str.format` from frontmatter instead of from a remote.
+
+**One hop, against written frontmatter.** The target's own derivations are not
+resolved first. A cycle is therefore impossible **by construction** rather than
+by detection, and no evaluation order over schemes has to exist. Derivations
+do not chain.
+
+**The target field must be declared.** A followed template's names are checked
+against the target scheme, so a typo is a load error rather than a field that
+silently resolves to nothing on every document — the quiet failure eager
+validation exists to remove.
+
+## Alternatives considered
+
+- **A `ref.` namespace inside the template** — `"{ref.source[0].published}"`.
+  Valid `str.format`, and it needs no second declaration. Rejected because it
+  makes the template carry two different kinds of name: `published` meaning
+  this document's, `ref.source[0].published` meaning another's, distinguished
+  by a prefix a reader has to know. It also reserves a field name project-wide.
+  Splitting the question in two — `from` says *which document*, `derive` says
+  *what to read* — keeps each declaration answering one thing, and leaves the
+  template a template.
+
+- **Resolve the target's derivations first, so derivations chain.** Strictly
+  more capable, and it costs cycle detection, a defined evaluation order across
+  schemes, and a new class of error message about a cycle a reader must then
+  trace. Nothing yet needs a chain. Deferring it keeps the mechanism explicable
+  in one sentence, and the day something needs it, that is a decision with
+  evidence behind it rather than a capability shipped on speculation.
+
+- **A `many` derivation collecting the field from every reference.** A field
+  holds one value, so this needs somewhere to put the rest and a rule for
+  ordering and de-duplicating them. That is a different feature; `from` takes
+  an index and says so.
+
+- **Let a followed template read an undeclared field.** Cheaper to adopt — the
+  motivating project's `published:` on `LIT` was convention rather than a
+  declaration. Rejected for the reason the eager checks exist: an undeclared
+  name resolves to nothing on *every* document, which reads exactly like a
+  record with no findings. Adopting costs one `required = true`, and buys that
+  field a contract of its own.
+
+- **Status quo: every project writes its own checker.** What the anthology did.
+  It leaves the rule in a script rather than in the schema, so nothing scaffolds
+  from it, no record page mentions it, and the next project reinvents it. The
+  same argument `#216` made for `derive` in the first place.
+
+## Consequences
+
+**A copied field stops existing.** The motivating record drops 281
+hand-maintained values to zero, and the eight stale dates cannot recur: writing
+the field down is already a finding, and the value now has exactly one home.
+
+**Verified on the real corpus, not only on fixtures.** With the declaration in
+place and every stored copy removed, all 207 practices and all 74 reading notes
+resolve, and six spot-checks — including four of the eight that had been stale
+— derive the value the backfill had computed by hand. Reinstating one stale
+value makes the lint exit non-zero and name the derivation.
+
+**Adopting costs a declaration.** The target field has to be declared on the
+target scheme. That is the migration, and it is small.
+
+**Derivations do not chain**, and a project that wants one will find nothing
+resolves rather than a diagnostic explaining why. If that recurs, it is the
+evidence the deferred alternative above is waiting for.
+
+**A resolver is a run-scoped cache.** `referents.Lookup` reads each referenced
+document once per run rather than once per citing document; a module-level
+cache would outlive the edit that invalidates it.

--- a/record/devlog.d/2026/09/09/185314.md
+++ b/record/devlog.d/2026/09/09/185314.md
@@ -1,0 +1,62 @@
+---
+title: 'A mute dial, because fail_on only changes the consequence'
+created: '2026-09-09T18:53:14'
+tags:
+- lint
+- configuration
+---
+
+`inert-status` fired on the anthology's new `NOTE` scheme — 16 of 16 at
+`Read` — and it was correct to. A note there is written when someone finishes
+a paper, so the status genuinely carries no information; the *absence* of a
+note is how that record says "unread".
+
+The scheme has an acknowledgement for exactly this, `uniform_ok`, and setting
+it did what it should: the row stopped being a finding and became a note
+carrying its reason. dmarx's response was that the finding is not especially
+helpful in the first place, and that if it could not be turned off globally,
+it should be able to be.
+
+That was right, and the gap was real. `fail_on` looks like a visibility dial
+and is not — it promotes a class to a failure. There was **no way to say "do
+not report this class at all"**, for any class. A project's only options were
+to see a finding forever or to acknowledge it per-site, and a check whose
+findings a project has decided are not useful to it has no site to comment at.
+
+## What it does
+
+    [luria.lint]
+    mute = ["inert-status"]
+
+Removes the class from the report, headline and detail rows together.
+
+## Three decisions worth recording
+
+**Mute and `fail_on` conflict rather than compose.** Naming a class in both is
+a configuration error. It is tempting to give one precedence, and both
+choices make a setting a lie — if enforcement wins, the mute did nothing; if
+the mute wins, a project asked for a failure and silently got none. Reporting
+the conflict says so. Enforcement still wins in the meantime, because a
+misconfiguration must not be able to hide a check the same file asked to
+enforce.
+
+**No class is exempt.** The first draft had a taxonomy — "judgement" classes
+mutable, "integrity" classes always printed, on the reasoning that hiding
+`stale-directives` is how a report stops meaning anything. Then the comment
+saying so did not match the code, which is how I noticed the taxonomy was
+mine rather than the project's. `fail_on` already lets a project make any
+class fatal and defaults to none, so latitude over consequence is total; the
+symmetric thing is latitude over visibility. `luria reports` renders the
+accounting regardless, so muting changes what a command prints and not what
+the record contains.
+
+**`acknowledged-uniformity` is mutable but not failable.** The two
+vocabularies are deliberately different lists. A project cannot promote its
+own acknowledgement to a failure — that would be strange — but it may
+reasonably not want the standing note repeated on every run.
+
+## The general shape
+
+A dial that changes what happens to a finding is not a dial that changes
+whether you see it, and this codebase had the first while its name suggested
+both. Worth checking the other settings for the same conflation.

--- a/record/devlog.d/2026/09/10/154749.md
+++ b/record/devlog.d/2026/09/10/154749.md
@@ -1,0 +1,70 @@
+---
+title: 'Firing the reference derivation on 281 real documents'
+created: '2026-09-10T15:47:49'
+tags:
+- mechanism
+---
+
+**`derive` learned to follow a reference (`#233`).** The tests pin the rules;
+this is what the guard did against a real corpus, and the three things the
+implementation taught that the design did not predict.
+
+## The real case
+
+`anthology-of-the-sota`, at the commit that had just backfilled `published:`
+by hand across 281 documents. The trial: declare the derivation, delete every
+stored copy, and see whether the record still knows the dates.
+
+    stripped stored published: from 281 documents
+    practices resolving: 207/207
+    notes resolving:     74/74
+
+Six spot-checks against the hand-computed values, including four of the eight
+that had been **stale**, all correct. Then the negative half — reinstating
+`SOTA-150`'s actual stale value, `2024-01-01`:
+
+    luria: 1 violation(s)
+      record/practices.d/SOTA-150.md: `published:` is written in frontmatter,
+      but SOTA derives it (`{published}` from `source[0]`) — the value has one
+      source and this is not it
+
+Exit 1. That is the defect the feature was written for, not a synthetic one.
+
+The trial also produced a finding nobody asked for and which is **correct**:
+declaring `published` required on `LIT` makes the scheme's own template a
+violation, because the form does not scaffold the field. A record adopting
+this will meet that on day one, and it is the scaffold check doing its job.
+
+## Three things the implementation taught
+
+**The eager check recursed.** `_check_derivations` runs *during* config load,
+and checking a followed template's names against the target scheme meant asking
+for the target scheme — via `current()`, which re-enters the loader. Stack
+exhaustion, no useful traceback. The fix is to thread the schemes dict being
+built through the check rather than reading the config that is still being
+assembled. Anything else added to that pass will hit the same wall.
+
+**Two existing rules were about the same document and had to learn it.**
+`derive` refuses `field` deriving from `field` (a cycle) and refuses a lone
+template reading a single-valued field (a rename under a second name). Both are
+correct *within* one document and both are wrong across a reference —
+`published` from its source's `published` is a cycle in the first reading and
+the entire point in the second. Neither would have shown up as a test failure
+in the new file; they showed up as the new feature's own valid config being
+refused at load.
+
+**The motivating field was not declared.** The anthology's `published:` on
+`LIT` was convention, never a declaration. So the first draft of the eager
+check — the target's fields must be nameable — rejected the exact case the
+feature existed for. That is the decision `ADR-tmpk3zby` records: require the
+declaration anyway, because the alternative is a typo that resolves to nothing
+on every document and reads like a clean record.
+
+## What is deliberately not here
+
+Chaining. A followed template reads **written** frontmatter, so a target's own
+derivations are invisible. That is what makes cycles impossible by construction
+instead of by detection, and it means no evaluation order over schemes has to
+be defined or maintained. A project that wants a chain will see nothing resolve
+rather than a diagnostic — worth knowing, and worth revisiting when something
+actually needs one.

--- a/tests/test_derive_reference.py
+++ b/tests/test_derive_reference.py
@@ -1,0 +1,286 @@
+"""A field derived from a document this one references (#233).
+
+`derive` computes a field from the document's own frontmatter. These tests
+pin the second source: `from = "source[0]"` renders the same template against
+the document that reference names, so a fact owned by one scheme can be read
+by another instead of copied into it.
+
+The copy is what this replaces, and the copy is what goes wrong — the
+anthology found eight practices carrying the publication date of a source
+they had stopped citing, invisible to every mechanical check because nothing
+related one document's field to another's.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from luria import adr_index, config, contract
+
+
+def write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+FOLLOW = """
+[luria.schemes.SOTA.fields.published]
+derive = "{published}"
+from   = "source[0]"
+"""
+
+
+def project(tmp_path, monkeypatch, extra: str = FOLLOW) -> Path:
+    write(tmp_path, "luria.toml", f"""
+[luria]
+issue_url = "https://example.test/issues/{{n}}"
+
+[luria.schemes.LIT]
+dir = "record/literature.d"
+output = "docs/literature"
+
+# A followed template reads the TARGET scheme's fields, so the target has to
+# declare them. That is the point: an undeclared name would resolve to
+# nothing on every document, which is the quiet failure eager validation
+# exists to turn into a load error.
+[luria.schemes.LIT.fields.published]
+required = true
+
+[luria.schemes.SOTA]
+dir = "record/practices.d"
+output = "docs/practices"
+
+[luria.schemes.SOTA.references]
+source = {{ scheme = "LIT", required = true, many = true }}
+paper  = {{ scheme = "LIT", required = false, many = false }}
+{extra}
+""")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+    return tmp_path
+
+
+def paper(root: Path, number: int, published: str | None = "2020-10-01",
+          extra: str = "") -> Path:
+    front = ["---", "status: Active", f"title: 'Paper {number}'",
+             "date: '2026-01-01'"]
+    if published:
+        front.append(f"published: '{published}'")
+    if extra:
+        front.append(extra)
+    front += ["---", "", f"# LIT-{number:03d}: Paper {number}", "", "Body."]
+    return write(root, f"record/literature.d/LIT-{number:03d}.md",
+                 "\n".join(front) + "\n")
+
+
+def practice(root: Path, number: int, *, source=(), paper_code: str = "",
+             extra: str = "") -> Path:
+    front = ["---", "status: Active", f"title: 'Practice {number}'",
+             "date: '2026-01-01'"]
+    if source:
+        front.append("source:")
+        front += [f"- {c}" for c in source]
+    if paper_code:
+        front.append(f"paper: {paper_code}")
+    if extra:
+        front.append(extra)
+    front += ["---", "", f"# SOTA-{number:03d}: Practice {number}", "", "Body."]
+    return write(root, f"record/practices.d/SOTA-{number:03d}.md",
+                 "\n".join(front) + "\n")
+
+
+def sota():
+    return config.current().schemes["SOTA"]
+
+
+def meta_of(path: Path) -> dict:
+    return adr_index.Adr(path, sota()).meta
+
+
+def findings(path: Path) -> list[str]:
+    c = contract.for_scheme(sota())
+    doc_meta, _ = adr_index.parse_frontmatter(path.read_text())
+    known = {"LIT": contract.resolvable("LIT")}
+    return contract.violations(c, config.current().rel(path), doc_meta, known)
+
+
+# --- following the reference -------------------------------------------------
+
+def test_an_indexed_reference_supplies_the_value(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, "2020-10-01")
+    path = practice(root, 1, source=["LIT-001"])
+    assert meta_of(path)["published"] == "2020-10-01"
+
+
+def test_the_index_picks_which_reference(tmp_path, monkeypatch):
+    """A practice with several sources takes its primary's date, and which
+    one that is is the list's order — the property the whole feature rests on."""
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, "2020-10-01")
+    paper(root, 2, "2023-03-01")
+    first = practice(root, 1, source=["LIT-001", "LIT-002"])
+    second = practice(root, 2, source=["LIT-002", "LIT-001"])
+    assert meta_of(first)["published"] == "2020-10-01"
+    assert meta_of(second)["published"] == "2023-03-01"
+
+
+def test_a_scalar_reference_needs_no_index(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"paper"'))
+    paper(root, 7, "2019-05-01")
+    path = practice(root, 1, source=["LIT-007"], paper_code="LIT-007")
+    assert meta_of(path)["published"] == "2019-05-01"
+
+
+def test_the_referenced_document_is_untouched(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    target = paper(root, 1, "2020-10-01")
+    before = target.read_text()
+    meta_of(practice(root, 1, source=["LIT-001"]))
+    assert target.read_text() == before
+
+
+# --- absence is absence, never a guess ---------------------------------------
+
+def test_no_reference_derives_nothing(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    path = practice(root, 1)
+    assert "published" not in meta_of(path)
+
+
+def test_an_index_past_the_end_derives_nothing(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"source[2]"'))
+    paper(root, 1)
+    path = practice(root, 1, source=["LIT-001"])
+    assert "published" not in meta_of(path)
+
+
+def test_a_dangling_reference_derives_nothing(tmp_path, monkeypatch):
+    """The code resolves to no document. That is the reference check's
+    finding to report, not this one's — deriving nothing keeps one fault to
+    one line."""
+    root = project(tmp_path, monkeypatch)
+    path = practice(root, 1, source=["LIT-404"])
+    assert "published" not in meta_of(path)
+
+
+def test_a_target_without_the_field_derives_nothing(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, published=None)
+    path = practice(root, 1, source=["LIT-001"])
+    assert "published" not in meta_of(path)
+
+
+# --- one hop, deliberately ---------------------------------------------------
+
+def test_it_reads_written_frontmatter_not_the_target_s_own_derivation(
+        tmp_path, monkeypatch):
+    """One hop. The target's `published` here is itself derived, and this
+    resolves to nothing rather than chaining — which is what makes a cycle
+    impossible by construction rather than by detection."""
+    extra = FOLLOW + """
+[luria.schemes.LIT.fields.issued]
+required = true
+
+[luria.schemes.LIT.references]
+origin = { scheme = "LIT", required = false, many = false }
+"""
+    root = project(tmp_path, monkeypatch, extra)
+    write(root, "record/literature.d/LIT-009.md",
+          "---\nstatus: Active\ntitle: 'Paper 9'\ndate: '2026-01-01'\n"
+          "issued: '1999-01-01'\n---\n\n# LIT-009: Paper 9\n")
+    paper(root, 1, published=None, extra="origin: LIT-009")
+    path = practice(root, 1, source=["LIT-001"])
+    assert "published" not in meta_of(path)
+
+
+# --- still read-only ---------------------------------------------------------
+
+def test_writing_it_down_is_still_a_finding(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, "2020-10-01")
+    path = practice(root, 1, source=["LIT-001"], extra="published: '2020-10-01'")
+    out = findings(path)
+    assert any("`published:` is written in frontmatter" in line for line in out)
+
+
+def test_a_written_value_that_disagrees_is_the_motivating_defect(
+        tmp_path, monkeypatch):
+    """The anthology's eight stale dates, in one test: the practice says one
+    thing, the paper it cites says another, and before this the record had no
+    way to notice."""
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, "2017-01-01")
+    path = practice(root, 1, source=["LIT-001"], extra="published: '2024-01-01'")
+    assert any("`published:` is written in frontmatter" in line
+               for line in findings(path))
+
+
+# --- refused at load ---------------------------------------------------------
+
+def test_from_must_name_a_reference_this_scheme_holds(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"nope"'))
+    with pytest.raises(ValueError, match="`nope` is not a reference"):
+        config.current()
+
+
+def test_a_plural_reference_needs_an_index(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"source"'))
+    with pytest.raises(ValueError, match="holds several"):
+        config.current()
+
+
+def test_a_scalar_reference_refuses_an_index(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"paper[0]"'))
+    with pytest.raises(ValueError, match="holds one"):
+        config.current()
+
+
+def test_the_template_is_checked_against_the_target_scheme(tmp_path, monkeypatch):
+    """`{nonesuch}` is not a field LIT can hold, so this would resolve to
+    nothing on every document — the quiet failure eager validation exists for."""
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"{published}"', '"{nonesuch}"'))
+    with pytest.raises(ValueError, match="nonesuch"):
+        config.current()
+
+
+def test_reading_the_same_name_is_not_self_derivation(tmp_path, monkeypatch):
+    """`published` from `published` is a cycle within one document and a
+    perfectly ordinary read across two. The rule has to know the difference."""
+    root = project(tmp_path, monkeypatch)
+    paper(root, 1, "2020-10-01")
+    assert meta_of(practice(root, 1, source=["LIT-001"]))["published"] == "2020-10-01"
+
+
+def test_a_lone_field_across_a_reference_is_not_a_rename(tmp_path, monkeypatch):
+    """Within a document `"{x}"` copies a field under a second name and is
+    refused. Across a reference it is the entire point."""
+    root = project(tmp_path, monkeypatch)
+    assert config.current().schemes["SOTA"].derived
+
+
+def test_many_on_a_followed_derivation_names_the_derive_line(tmp_path, monkeypatch):
+    """The refusal quotes the literal `derive =` value. `spec` also names the
+    followed reference, which was written on its own line — quoting it here
+    would print backticks inside a quoted string."""
+    root = project(tmp_path, monkeypatch, FOLLOW + "many = true\n")
+    with pytest.raises(ValueError) as caught:
+        config.current()
+    assert 'derive = "{published}"' in str(caught.value)
+
+
+def test_from_alone_renders_nothing(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch,
+                   '[luria.schemes.SOTA.fields.published]\nfrom = "source[0]"\n')
+    with pytest.raises(ValueError, match="renders nothing"):
+        config.current()
+
+
+def test_a_malformed_from_says_so(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch, FOLLOW.replace('"source[0]"', '"source[]"'))
+    with pytest.raises(ValueError, match="is not a reference"):
+        config.current()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -283,16 +283,17 @@ def test_a_view_the_generator_no_longer_writes_is_not_a_stray(project):
 # ── The enforcement dial (ADR-035) ───────────────────────────────────────
 
 
-def dial_project(project, fail_on: str = "") -> None:
+def dial_project(project, fail_on: str = "", mute: str = "") -> None:
     """A project with a retired decision cited from a docs page, and the
-    dial set to `fail_on` (a TOML list body, e.g. '"retired-citations"')."""
+    dials set to `fail_on` and `mute` (TOML list bodies, e.g.
+    '"retired-citations"')."""
     _scheme.decision(project, 12, "Superseded")
     page = project / "docs" / "notes.md"
     page.parent.mkdir(parents=True, exist_ok=True)
     page.write_text("Still leaning on ADR-012 here.\n")
     (project / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
-        f'[luria.lint]\nfail_on = [{fail_on}]\n')
+        f'[luria.lint]\nfail_on = [{fail_on}]\nmute = [{mute}]\n')
     from luria import config
     config.reset()
 
@@ -452,3 +453,63 @@ def test_a_scheme_with_no_form_has_nothing_to_compare(project):
     from tests import _scheme
     _scheme.decision(project, 1, "Active", summary="Whatever the form said.")
     assert form_text_errors() == []
+
+
+# ── The mute dial ────────────────────────────────────────────────────────
+
+
+def test_a_muted_class_is_not_reported(project, capsys):
+    """`mute` removes a class from the report entirely.
+
+    Distinct from `fail_on`, which changes a finding's consequence. A project
+    that has decided a whole check is not useful to it has nowhere to put an
+    acknowledgement — the directives carry a reason at a *site*, and this
+    kind of finding has none."""
+    dial_project(project, mute='"retired-citations"')
+    errors, err = dial_errors(capsys)
+    assert errors == []
+    assert "retired documents cited unacknowledged" not in err
+    assert "ADR-012" not in err, "the detail rows go with the headline"
+
+
+def test_muting_one_class_leaves_the_others(project, capsys):
+    """A mute is per-class, not a global off switch."""
+    dial_project(project, mute='"inert-status"')
+    errors, err = dial_errors(capsys)
+    assert errors == []
+    assert "retired documents cited unacknowledged" in err
+
+
+def test_mute_rejects_a_class_that_does_not_exist(project, capsys):
+    """Same rule as `fail_on`: a dial set to a notch that does not exist must
+    say so rather than silently suppress nothing (DP-1)."""
+    dial_project(project, mute='"no-such-check"')
+    errors, _ = dial_errors(capsys)
+    assert any("`mute` names 'no-such-check'" in e for e in errors), errors
+
+
+def test_a_class_cannot_be_both_enforced_and_hidden(project, capsys):
+    """Not a precedence question. Guessing which the project meant would make
+    one of the two settings a lie, so it is a configuration error."""
+    dial_project(project, fail_on='"retired-citations"',
+                 mute='"retired-citations"')
+    errors, _ = dial_errors(capsys)
+    assert any("both `fail_on` and `mute`" in e for e in errors), errors
+
+
+def test_enforcement_still_wins_over_a_conflicting_mute(project, capsys):
+    """The conflict is reported AND the class still fails — a misconfigured
+    mute must not be able to hide a check the same file asked to enforce."""
+    dial_project(project, fail_on='"retired-citations"',
+                 mute='"retired-citations"')
+    errors, _ = dial_errors(capsys)
+    assert any("failing: `fail_on`" in e for e in errors), errors
+
+
+def test_acknowledged_uniformity_is_mutable(project, capsys):
+    """It is not failable — a project cannot promote its own acknowledgement
+    to a failure — but it is exactly the standing note a project may not want
+    repeated on every run, so the two vocabularies are not the same list."""
+    dial_project(project, mute='"acknowledged-uniformity"')
+    errors, _ = dial_errors(capsys)
+    assert not any("is no mutable warning class" in e for e in errors), errors


### PR DESCRIPTION
Closes #233.

```toml
[luria.schemes.SOTA.fields.published]
derive = "{published}"
from   = "source[0]"
```

`from` names a reference field the scheme declares, indexed when it holds several. The template renders against **that** document's frontmatter. So a fact one scheme owns can be read by the documents that need it instead of copied into each of them.

## The three decisions

Recorded in `ADR-tmpk3zby`, with what each rejected.

**The template does not change.** `{published}` still means what it means everywhere; only the *values* it renders against move. `derive` promised one template language rather than a second grammar per feature, and this keeps it by adding a second variable source — the same shape #219 took.

> The alternative was a `ref.` namespace inside the template: `"{ref.source[0].published}"`. Valid `str.format`, needs no second declaration, and rejected because it makes a template carry two kinds of name distinguished by a prefix the reader must know — plus it reserves a field name project-wide. Splitting the question keeps each declaration answering one thing.

**One hop, against written frontmatter.** The target's own derivations are not resolved first. A cycle is impossible **by construction** rather than by detection, and no evaluation order across schemes has to exist.

> Resolving the target's derivations first is strictly more capable and costs cycle detection, a defined evaluation order, and a new class of error about a cycle someone must trace. Nothing needs a chain yet. Deferred with the reason written down, not refused.

**The target field must be declared.** A followed template's names are checked against the target scheme, so a typo is a load error rather than a field that silently resolves to nothing everywhere.

> This has a real migration cost — the motivating project's `published:` on `LIT` was convention, not a declaration, so the first draft of this check rejected the exact case the feature exists for. Adopting costs one `required = true` and buys that field a contract.

## Fired on a real corpus before being trusted

Per the working agreement, against `anthology-of-the-sota` at the commit that had just backfilled the field by hand. Declare the derivation, delete every stored copy, see whether the record still knows the dates:

```
stripped stored published: from 281 documents
practices resolving: 207/207
notes resolving:     74/74
```

Six spot-checks against the hand-computed values — including four of the eight that had been **stale** — all correct. Then the negative half, reinstating `SOTA-150`'s actual stale value:

```
luria: 1 violation(s)
  record/practices.d/SOTA-150.md: `published:` is written in frontmatter, but SOTA
  derives it (`{published}` from `source[0]`) — the value has one source and this
  is not it
```

Exit 1. That is the defect the feature was written for, not a synthetic one.

The trial also produced a correct finding nobody asked for: declaring `published` required on `LIT` makes that scheme's own template a violation, because the form does not scaffold the field. A record adopting this meets it on day one — the scaffold check working.

## Three things the implementation taught

Written up in the devlog, because none of them is visible from the design.

1. **The eager check recursed.** It runs *during* config load, and checking a followed template against the target scheme meant asking `current()` — which re-enters the loader. It now takes the schemes dict under construction. Anything else added to that pass hits the same wall.

2. **Two existing rules were about the same document and had to learn it.** `derive` refuses a field deriving from itself (a cycle) and refuses a lone template reading a single-valued field (a rename). Both are right *within* one document and wrong across a reference. Neither showed up as a test failure — they showed up as the feature's own valid config being refused at load.

3. **The motivating field was not declared**, which is what forced the third decision above into the open.

## Also fixed

A record page for a followed derivation rendered the template alone — `{published}` — which does not say whose. And the `many` refusal quotes the literal `derive =` value, so it now uses `template` rather than `spec`; `spec` also names the followed reference and would have printed backticks inside a quoted string. Both pinned by tests.

## Verification

- **1090 tests pass** (20 new, in `tests/test_derive_reference.py`).
- `luria lint` **matches its baseline exactly**, apart from `pending decisions: 8 → 9` — this branch's own `Proposed` decision.
- Generated files (`README.md` badges, `docs/`) deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_