### PR TITLE
Group the pending-decisions report by scheme

### DIFF
--- a/luria/reports.py
+++ b/luria/reports.py
@@ -154,6 +154,37 @@ def reference_status(base: Path | None = None) -> str:
     return "\n".join(out)
 
 
+def _pending_table(rows, base: Path) -> list[str]:
+    """One table of undecided documents. Shared by the flat rendering and the
+    per-scheme one, so the columns cannot drift apart between them."""
+    out = ["| Open since | Status | Code | Cited | Unack. | Title |",
+           "|---|---|---|--:|--:|---|"]
+    for r in rows:
+        since = r.date.isoformat() if r.date is not None else "undated"
+        link = f"[{r.code}]({_link(r.path, base)})"
+        out.append(f"| {since} | {r.status} | {link} | {r.cites} | "
+                   f"{r.unacknowledged} | {r.title} |")
+    out.append("")
+    return out
+
+
+def _pending_by_scheme(rows) -> list[tuple[str, list]]:
+    """`(prefix, rows)` for each scheme that has an undecided document, in the
+    order `luria.toml` declares the schemes (#230).
+
+    Declaration order rather than alphabetical, for the reason `tags.yaml`
+    orders topics: which family a reader meets first is the project's
+    statement about itself, not something to sort.
+
+    A prefix `pending()` returned that no scheme declares still gets a group
+    — the collector is the authority on what is undecided, and a renderer
+    that silently dropped rows would be the worse failure."""
+    groups: dict[str, list] = {prefix: [] for prefix in current().schemes}
+    for row in rows:
+        groups.setdefault(row.code.split("-")[0], []).append(row)
+    return [(prefix, group) for prefix, group in groups.items() if group]
+
+
 def pending_decisions(base: Path | None = None) -> str:
     base = current().reports if base is None else base
     rows = adr_pending.pending()
@@ -170,15 +201,18 @@ def pending_decisions(base: Path | None = None) -> str:
         + (f", {undated} undated" if undated else "") + ".**",
         "",
     ]
-    if rows:
-        out += ["| Open since | Status | Code | Cited | Unack. | Title |",
-                "|---|---|---|--:|--:|---|"]
-        for r in rows:
-            since = r.date.isoformat() if r.date is not None else "undated"
-            link = f"[{r.code}]({_link(r.path, base)})"
-            out.append(f"| {since} | {r.status} | {link} | {r.cites} | "
-                       f"{r.unacknowledged} | {r.title} |")
-        out.append("")
+    # Grouped only when there is something to group. A `Proposed` decision
+    # and a `Proposed` practice are open questions for different readers
+    # (#230) — but a record with one family gains nothing from a heading
+    # naming the only family it has, and this project is one of those.
+    groups = _pending_by_scheme(rows)
+    if len(groups) > 1:
+        for prefix, group in groups:
+            out += [f"## {prefix}s", "",
+                    f"{len(group)} of the {len(rows)}.", ""]
+            out += _pending_table(group, base)
+    elif rows:
+        out += _pending_table(rows, base)
     out += [
         "The citation count is the second axis, and it flips the priority: an "
         "old proposal nothing references is a stalled idea worth closing, while "

--- a/record/changelog.d/20260910-221041.md
+++ b/record/changelog.d/20260910-221041.md
@@ -1,0 +1,27 @@
+### Changed
+
+- **The pending-decisions report groups its table by scheme (`#230`).** A
+  `Proposed` decision and a `Proposed` practice are open questions for
+  different readers, and an adopting record's report intermixed them — 33
+  practices, two notes and two decisions in one table sorted only by date.
+
+  Each scheme that has an undecided document now gets its own section, in the
+  order `luria.toml` declares the schemes. Declaration order rather than
+  alphabetical, for the reason `tags.yaml` orders topics: which family a
+  reader meets first is the project's statement about itself, not something to
+  sort.
+
+  **Rendering only.** `adr_pending.pending()` already spanned every scheme
+  deliberately — *"a report that covered one scheme would go quietly blind the
+  day a project configured a second"* — and it is unchanged. The badge and the
+  lint headline read the collector, never the rendered file, so the counts
+  they publish do not move; a test pins that.
+
+  A record with one family renders exactly as before: a heading naming the
+  only scheme a project has is nesting for nothing, and luria's own record is
+  one of those. A declared scheme with nothing pending gets no empty section.
+
+  Considered and not taken: **one file per scheme.** It would break every
+  existing link to the report, multiply the files a reader has to visit, and
+  lose the one place that can state a cross-scheme total — which is what the
+  badge publishes.

--- a/record/devlog.d/2026/09/10/221041.md
+++ b/record/devlog.d/2026/09/10/221041.md
@@ -1,0 +1,60 @@
+---
+title: 'Grouping the pending report, and being caught twice by the specimen-code hazard'
+created: '2026-09-10T22:10:41'
+tags:
+- mechanism
+---
+
+**`#230`, which is a small rendering change, and the thing that actually cost
+the time.**
+
+## The change
+
+`pending()` collects undecided documents from every scheme on purpose. The
+report rendered them as one table. Splitting the *presentation* by scheme is
+the whole fix; the collector, the badge and the lint headline are untouched,
+and a test pins that the published counts do not move.
+
+Two judgements worth having written down:
+
+- **Sections, not files.** One file per scheme breaks existing links,
+  multiplies what a reader visits, and removes the only place a cross-scheme
+  total can live — and that total is what the badge publishes.
+- **Grouped only when there is something to group.** A single-scheme record
+  gets the old flat table. A heading naming the only family a project has is
+  nesting that carries no information, and this record is that case: every one
+  of its undecided documents is a decision.
+
+Verified on the adopting record rather than only on fixtures: 37 undecided,
+rendering as 33 / 2 / 2 across three sections in declaration order, with the
+fourth declared scheme correctly absent.
+
+## What actually cost the time
+
+**The suite caught me with `#231`, twice.**
+
+The first draft's fixture used this record's own scheme prefix and filed a
+specimen numbered like a real decision. The reference scanner read it as a
+citation; the decision it named is Superseded; the lint gained a
+retired-citation warning that had nothing to do with the change. That is
+`#231` exactly — a suite writes codes down because that is what it tests.
+
+The fix was **not** a fourth `unlinted-file:` beside the three that issue is
+already about. The fixture now declares prefixes this record does not use, so
+nothing in the file is a code the scanner recognises and no directive is
+needed.
+
+Then the comment explaining all of that spelled the offending code out, and
+**re-earned the same warning**. Same lesson, ten lines later: the mitigation is
+not writing it down.
+
+## The part worth carrying to `#231`
+
+The escape hatch I used does not generalise, and it would be easy to mistake
+it for a fix.
+
+It works here only because this record declares two schemes, leaving every
+other prefix invisible to the scanner. **A project that declared `RFC` and
+`SPEC` would have no free prefix to test with** — its suite would be back to
+directives, which is the state `#231` is about. "Use a prefix you don't
+declare" is a property of this repository, not a technique.

--- a/tests/test_reports_by_scheme.py
+++ b/tests/test_reports_by_scheme.py
@@ -1,0 +1,165 @@
+"""The pending-decisions report, grouped by scheme (#230).
+
+`adr_pending.pending()` deliberately spans every scheme — "a report that
+covered one scheme would go quietly blind the day a project configured a
+second". Collecting them together is right; rendering them in one table is
+not. A `Proposed` decision and a `Proposed` practice are open questions for
+different readers, and an anthology's report intermixed ADRs and SOTAs.
+
+So this is a rendering change and nothing else. The badge and the lint
+headline read `pending()`, never the rendered file, and these tests pin that
+the counts they publish do not move.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from luria import adr_pending, badges, config, reports
+
+
+# The fixture's schemes are deliberately RFC/SPEC/LIT rather than the one this
+# record declares for itself. A suite that writes a real decision's code down
+# as a specimen is read by the reference scanner as citing it (#231) — and the
+# number this test first used names a Superseded decision, so it earned a
+# retired-citation warning and would have wanted a fourth `unlinted-file:`
+# beside the three that issue is already about. A prefix this record does not
+# declare is invisible to the scanner and needs no directive.
+#
+# The first draft of this comment spelled that code out and re-earned the
+# warning, which is the same lesson twice: the mitigation is not writing it.
+
+
+def write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+STATUSES = ("Active:\n  blurb: in force\nProposed:\n  blurb: not yet\n"
+            "Deferred:\n  blurb: parked\nSuperseded:\n  blurb: replaced\n"
+            "Rejected:\n  blurb: declined\n")
+
+
+def project(tmp_path, monkeypatch, schemes=("RFC", "SPEC")) -> Path:
+    """A record with one or two schemes, declared in the order given."""
+    tables = "\n".join(f"""
+[luria.schemes.{p}]
+dir = "record/{p.lower()}.d"
+output = "docs/{p.lower()}"
+""" for p in schemes)
+    write(tmp_path, "luria.toml", f"""
+[luria]
+issue_url = "https://example.test/issues/{{n}}"
+{tables}
+""")
+    for p in schemes:
+        write(tmp_path, f"record/{p.lower()}.d/statuses.yaml", STATUSES)
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+    return tmp_path
+
+
+def doc(root: Path, prefix: str, number: int, status: str = "Proposed",
+        date: str = "2026-01-01") -> Path:
+    return write(root, f"record/{prefix.lower()}.d/{prefix}-{number:03d}.md",
+                 f"---\nstatus: {status}\ntitle: '{prefix} {number}'\n"
+                 f"date: '{date}'\n---\n\n# {prefix}-{number:03d}: {prefix} {number}\n")
+
+
+# --- the grouping ------------------------------------------------------------
+
+def test_two_schemes_render_as_separate_sections(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    text = reports.pending_decisions(root / "docs")
+    assert "## RFCs" in text
+    assert "## SPECs" in text
+
+
+def test_a_row_sits_under_its_own_scheme(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "RFC", 7)
+    doc(root, "SPEC", 9)
+    text = reports.pending_decisions(root / "docs")
+    adr, sota = text.index("## RFCs"), text.index("## SPECs")
+    assert adr < text.index("RFC-007") < sota
+    assert sota < text.index("SPEC-009")
+
+
+def test_section_order_follows_the_config_not_the_alphabet(tmp_path, monkeypatch):
+    """`pending()` walks `current().schemes`, which is declaration order. A
+    project decides which of its families a reader meets first, the same way
+    `tags.yaml` decides the order of topics."""
+    root = project(tmp_path, monkeypatch, schemes=("SPEC", "RFC"))
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    text = reports.pending_decisions(root / "docs")
+    assert text.index("## SPECs") < text.index("## RFCs")
+
+
+def test_a_scheme_with_nothing_pending_gets_no_section(tmp_path, monkeypatch):
+    """Three declared schemes, two with an open question. The third is not an
+    empty heading — a section per declared scheme would report absence as a
+    row of nothing."""
+    root = project(tmp_path, monkeypatch, schemes=("RFC", "SPEC", "LIT"))
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    doc(root, "LIT", 2, status="Active")
+    text = reports.pending_decisions(root / "docs")
+    assert "## RFCs" in text and "## SPECs" in text
+    assert "## LITs" not in text
+
+
+def test_one_scheme_stays_flat(tmp_path, monkeypatch):
+    """A single-scheme record gains nothing from a heading naming the only
+    family it has, and luria's own record is one of those."""
+    root = project(tmp_path, monkeypatch, schemes=("RFC",))
+    doc(root, "RFC", 1)
+    doc(root, "RFC", 2)
+    text = reports.pending_decisions(root / "docs")
+    assert "## RFCs" not in text
+    assert "RFC-001" in text and "RFC-002" in text
+
+
+def test_rows_stay_oldest_first_within_a_section(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "SPEC", 1, date="2026-03-01")
+    doc(root, "SPEC", 2, date="2026-01-01")
+    doc(root, "RFC", 1)
+    text = reports.pending_decisions(root / "docs")
+    assert text.index("SPEC-002") < text.index("SPEC-001")
+
+
+# --- what must not move ------------------------------------------------------
+
+def test_the_headline_still_counts_every_scheme(tmp_path, monkeypatch):
+    """The total is what the badge publishes, and it is a fact about the
+    record rather than about any one family."""
+    root = project(tmp_path, monkeypatch)
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    doc(root, "SPEC", 2)
+    text = reports.pending_decisions(root / "docs")
+    assert "**3 document(s) awaiting a decision.**" in text
+
+
+def test_the_badge_count_is_unchanged_by_the_grouping(tmp_path, monkeypatch):
+    root = project(tmp_path, monkeypatch)
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    assert badges.counts()[0] == len(adr_pending.pending()) == 2
+
+
+def test_every_code_is_still_a_link(tmp_path, monkeypatch):
+    """The reader arrived from a badge, not a grep prompt — the report's own
+    standing rule."""
+    root = project(tmp_path, monkeypatch)
+    doc(root, "RFC", 1)
+    doc(root, "SPEC", 1)
+    text = reports.pending_decisions(root / "docs")
+    assert "[RFC-001](" in text and "[SPEC-001](" in text


### PR DESCRIPTION
Closes #230.

A `Proposed` decision and a `Proposed` practice are open questions for different readers. The adopting record's report intermixed them — **33 practices, two notes and two decisions in one table**, sorted only by date.

Each scheme with an undecided document now gets its own section:

```
**37 document(s) awaiting a decision.**

## SOTAs
33 of the 37.
…
## LITs
2 of the 37.
…
## ADRs
2 of the 37.
```

## The two judgements

**Declaration order, not alphabetical.** `pending()` walks `current().schemes`, which is the order `luria.toml` declares them — the same reason `tags.yaml` orders topics: which family a reader meets first is the project's statement about itself, not something to sort.

**Grouped only when there is something to group.** A single-scheme record renders exactly as before. A heading naming the only family a project has is nesting that carries no information — and *this* record is that case, since every one of its undecided documents is a decision. A declared scheme with nothing pending gets no empty section either.

## Rendering only — and pinned as such

`adr_pending.pending()` already spanned every scheme deliberately:

> a report that covered one scheme would go quietly blind the day a project configured a second

It is untouched. The **badge** and the **lint headline** read the collector, never the rendered file, so their published counts cannot move — `test_the_badge_count_is_unchanged_by_the_grouping` pins it.

**Considered and not taken: one file per scheme.** It breaks every existing link to the report, multiplies what a reader visits, and loses the one place a cross-scheme total can live — which is exactly what the badge publishes.

## Verification

- **9 new tests**, 1099 total, all passing. Lint at its baseline.
- **Checked on the adopting record, not only fixtures:** 37 undecided rendering as 33 / 2 / 2 across three sections in declaration order, with the fourth declared scheme (`NOTE`, nothing pending) correctly absent.

## The suite caught me with #231 — twice

Worth reading, because it bears on that issue's design.

The fixture first filed specimens under **this record's own scheme prefix**, numbered like a real decision. The reference scanner read that as a citation; the decision it named is `Superseded`; the lint gained a retired-citation warning with nothing to do with this change. That is #231 precisely.

The fix was **not** a fourth `unlinted-file:` beside the three that issue is already about — the fixture now declares prefixes this record does not use, so nothing in it is a code the scanner recognises.

Then the comment *explaining* that spelled the offending code out and **re-earned the same warning**. Same lesson ten lines later: the mitigation is not writing it down.

**The part that matters for #231:** this escape hatch does not generalise. It works only because this record declares two schemes, leaving every other prefix invisible. A project that declared `RFC` and `SPEC` would have no free prefix to test with, and would be straight back to directives. "Use a prefix you don't declare" is a property of this repository, not a technique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_