### PR TITLE
Reserve the FX namespace for fixture schemes (#231)

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -144,6 +144,22 @@ name = "fixtures"
 url  = "https://github.com/dmarx/luria/blob/main/docs/directives.md#fixture-codes"
 ```
 
+That covers a fixture code that should *resolve somewhere harmless*. A test
+suite usually wants the opposite: a code belonging to a scheme it declares
+itself, in a `tmp_path` project, which the project running the suite has never
+heard of. So the whole `FX` prefix is a reserved **namespace**, and no
+project declares a scheme whose prefix begins with it:
+
+- `FXL` is the local fixture scheme by convention.
+- `FXM` is the second one, for a fixture that needs two prefixes at once —
+  a `rename_scheme` migration, say.
+- Any other `FX…` name is available for the same purpose. `AFX` is not
+  reserved: the match is on the leading prefix, not a substring.
+
+`luria lint` refuses a declared scheme in the namespace, at the config rather
+than at each citation, so the guarantee cannot be taken away by accident.
+See [ADR-tmpgody7](../record/decisions.d/ADR-tmpgody7.md).
+
 ## Design notes
 
 - Directives are found by tokenising real comment syntax per file type, so

--- a/luria/config.py
+++ b/luria/config.py
@@ -200,6 +200,20 @@ def _merge(base: dict, override: dict) -> dict:
 # false-matching six-letter English after a prefix — `[a-z][a-z0-9]{5}`, the
 # first shape, read "the ADR-review process" as a temporary reference.
 TEMP_TAIL = r"tmp[a-z0-9]{5}"
+
+# The fixture namespace (ADR-tmpgody7). `FX` is the remote prefix whose every
+# composed code resolves to the note saying it is an example (ADR-034); the
+# names under it — `FXL` by convention, `FXM` where a second is needed — are
+# for a fixture project's OWN schemes, so that a code a test suite writes is
+# claimed by no scheme of the project running the suite. A leading match, not
+# a substring one: reserving `FX` at the front of a prefix costs a project
+# nothing it would have chosen, and reserving it anywhere would cost `AFX`.
+FIXTURE_NAMESPACE = "FX"
+
+
+def in_fixture_namespace(prefix: str) -> bool:
+    """Whether a scheme prefix falls in the reserved fixture namespace."""
+    return prefix.upper().startswith(FIXTURE_NAMESPACE)
 _TEMP_TAIL_RE = re.compile(rf"^{TEMP_TAIL}$")
 
 

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -186,6 +186,26 @@ def check_status_vocabulary(errors: list[str]) -> None:
         errors.extend(statuses.problems(scheme))
 
 
+def check_reserved_prefix(errors: list[str]) -> None:
+    """A scheme declared in the reserved fixture namespace (ADR-tmpgody7).
+
+    Always wrong and always mechanically fixable, which is why it is an error
+    and not a report: the namespace exists so that a project's test suite can
+    spell codes nobody claims, and a project that claims one has quietly taken
+    that guarantee away from itself — its own fixture codes start resolving,
+    and the failure looks exactly like success until a real document lands on
+    the number.
+
+    The check reads the config, not the record, so it fires at declaration
+    time, before the first document makes the prefix expensive to change."""
+    for prefix in current().schemes:
+        if config_mod.in_fixture_namespace(prefix):
+            errors.append(
+                f"luria.toml: scheme {prefix} is in the reserved fixture "
+                f"namespace {config_mod.FIXTURE_NAMESPACE}\u2026 — pick another "
+                "prefix, or `rename_scheme` it if it already has documents")
+
+
 def check_contracts(errors: list[str]) -> None:
     """Each scheme's contract, enforced — what it `requires`, what its
     `references` hold, which of its `tag_groups` combine (ADR-040, ADR-060,
@@ -802,6 +822,7 @@ def run() -> None:
     check_frontmatter(errors)
     check_form_text(errors)
     check_status_vocabulary(errors)
+    check_reserved_prefix(errors)
     check_contracts(errors)
     check_view_dirs(errors)
     check_numbers(errors)

--- a/record/changelog.d/20260911-012259.md
+++ b/record/changelog.d/20260911-012259.md
@@ -1,0 +1,16 @@
+### Added
+
+- The `FX` prefix is a reserved **namespace**: no project declares a scheme
+  whose prefix begins with it. `FXL` is the local fixture scheme by
+  convention, `FXM` the second one where a fixture needs two prefixes at
+  once, and `luria lint` refuses a declared scheme in the namespace so the
+  guarantee cannot be lost by accident ([ADR-tmpgody7](record/decisions.d/ADR-tmpgody7.md), [#231](https://github.com/dmarx/luria/issues/231)). The match is on
+  the leading prefix — `AFX` is nobody's business but yours.
+
+### Removed
+
+- The three `unlinted-file:` opt-outs on `tests/test_number.py`,
+  `tests/test_alias_inference.py` and `tests/test_migrations.py`. Their
+  specimen codes now come from `FXL`/`FXM`, so 1,038 lines of test file
+  return to reference checking and the reference report's opt-out section is
+  empty.

--- a/record/decisions.d/ADR-tmpgody7.md
+++ b/record/decisions.d/ADR-tmpgody7.md
@@ -1,0 +1,203 @@
+---
+# Don't copy this file by hand — run `luria new adr`, which assigns the
+# identity and fills in the fields a machine can compute. WHICH identity
+# depends on the scheme's `allocate` mode: `filing` (the default) takes the
+# next free number on the spot, `merge` mints a temporary code that
+# `luria concretize` numbers where merges serialize (ADR-049). The kinds are the
+# config: every scheme, fragment directory and journal in luria.toml is one, so
+# `luria new <kind>` works for a scheme the moment it is declared.
+#
+# Numbering is sequential and carries information (it's the order decisions were
+# made). The filename is the code and nothing else; the title goes in `title:`
+# below, where correcting it costs an edit rather than a rename plus every link
+# (ADR-013).
+#
+# This frontmatter is the ONLY place these facts live. The index and the per-tag
+# pages are generated from it (ADR-004) — never edit them by hand; run
+# `luria index`.
+
+# Active | Proposed | Deferred | Superseded | Rejected. Supersede when the
+# CHOICE changes: set the old one to `status: Superseded`, name the successor
+# in `superseded_by: ADR-tmpgody7` (a reference field: checked, resolved, an edge
+# the index and the site render), and leave its body intact. A qualifying
+# note for anything the field cannot say goes in `status_note:` — prose,
+# like `summary:`, so a code in it is a citation. When the
+# choice stands and only a REASON was wrong, correct this body in place and
+# bump `version:` below — the rule objects to silent revision, not to editing.
+status: Active
+
+# What the index shows in place of the code. Repeat it as the body's `# ADR-tmpgody7:`
+# heading — someone reading the file alone needs one — and `luria lint` checks
+# that the two agree, because two copies of a string is a projection that drifts.
+title: 'Fixture schemes come from a reserved namespace'
+
+# Which revision of this decision's claim you are reading. Standard frontmatter
+# for every scheme, and it moves rarely here: a decision that CHANGES is
+# superseded by a new one, not edited. Bump it when the same choice is restated
+# more broadly — scope widened, wording generalized — and say what changed in a
+# `history:` entry. Shown in the index only when it is not 1.
+version: 1
+
+# Browsing categories, pushed down onto the decision itself. One is normal; more
+# than one is fine. A tag not listed in tags.yaml still works.
+tags:
+- record
+- mechanism
+
+date: '2026-09-11'
+
+# Optional. The issue(s) this decision came from: '#123'.
+issue: '#231'
+
+# Optional but wanted: the one-blob description the index table shows. Without
+# it the table falls back to the title, which is usually too terse to browse by.
+# Say what was decided AND what was rejected — the index is read far more often
+# than the decision, and "why not the obvious thing" is what people come for.
+# This field is prose, so it carries links like any other prose; the rest of the
+# frontmatter is data and stays plain. (`origin:` on a principle is
+# prose for the same reason — the generator renders it.)
+summary: >-
+  `FX` is reserved for fixture codes that RESOLVE ([ADR-034](ADR-034.md)); the names under
+  it — `FXL`, and `FXM` where a migration fixture needs a second — are
+  reserved for a fixture project's own SCHEMES, the codes that must resolve to
+  nothing and be claimed by nobody. A leading-prefix reservation, checked by
+  `luria lint` at the config rather than at each citation, so a project cannot
+  quietly take the guarantee away from itself. Retires the three
+  `unlinted-file:` opt-outs that stood in for it, which blanked whole suites to
+  excuse a handful of specimen codes and are the one suppression the reports
+  cannot converge past ([ADR-033](ADR-033.md)). Rejected: masking string literals in the
+  tree-sitter grammar (narrows what a directive governs, against the stated
+  invariant, and CI has no grammar installed, so it would be inert exactly
+  where the codes are), one reserved name rather than a namespace (a migration
+  fixture needs two prefixes, and the second would be invisible only by luck),
+  a per-site `unresolved-ok:` (93 acknowledgement directives already live in
+  21 test files), and refusing the prefix at config load (fixtures declare it
+  deliberately, so the refusal would break the mechanism it protects).
+---
+
+<!-- inactive-ok-file: ADR-007 — the specimen the three suites borrowed; being retired is what made it a finding -->
+<!-- unresolved-ok-file: ADR-tmpabcde, DP-018 — the other two specimens, quoted as the evidence for the decision -->
+# ADR-tmpgody7: Fixture schemes come from a reserved namespace
+
+## Context
+
+A scheme's own test suite has to write codes to test how codes are read, and
+every code it writes is read back by the scanners as a citation of this
+repository's documents. Three suites had reached for the blunt instrument:
+
+| Suite | Directive | What it blanked |
+|---|---|---|
+| `tests/test_number.py` | `unlinted-file:` | 229 lines, to excuse `ADR-007` and `ADR-tmpabcde` |
+| `tests/test_alias_inference.py` | `unlinted-file:` | 264 lines, to excuse `LIT-…` spellings |
+| `tests/test_migrations.py` | `unlinted-file:` | 545 lines, to excuse `DP-4`, `DP-018`, `LU-DP-004` |
+
+`unlinted-file:` is file-scoped by design and counted rather than hidden
+([ADR-033](ADR-033.md)), which is the honest bargain — but it is also the one suppression the
+reports cannot converge past. Three files paying it to excuse a handful of
+specimen codes is the wrong trade, and the third file's directive had already
+been *read as a finding*: writing a new report suite, a fixture built on
+`ADR-007` reported a citation of a Superseded decision, and the comment
+explaining why that was fine re-earned the warning by spelling the code out
+([#231](https://github.com/dmarx/luria/issues/231)).
+
+The dangerous half is quieter. `ADR-007` at least warned. `DP-4` and
+`LU-DP-004` **resolved** — silently counted as citations of real documents by
+a suite that meant neither. A specimen that resolves is indistinguishable from
+a citation, and stays that way until the document it borrowed moves.
+
+[ADR-034](ADR-034.md) already solved the resolving case: the `FX` remote makes `FX-ADR-032`
+an example *by construction*, pointing at the note that says so. It solved the
+wrong half for a fixture project. A fixture does not want its codes to resolve
+somewhere harmless — it wants its codes to belong to a scheme **of its own**,
+whose documents it writes and deletes in a `tmp_path`, and which the project
+running the suite has never heard of.
+
+## Decision
+
+**The `FX` namespace is reserved: no project declares a scheme whose prefix
+begins with `FX`.** Within it, `FXL` is the local fixture scheme by convention
+and `FXM` the second one where a migration fixture needs both an old and a new
+prefix. `luria lint` refuses a declared scheme in the namespace
+(`check_reserved_prefix`).
+
+The three suites now declare `FXL` (and `FXM`) instead of `ADR`, `LIT` and
+`DP`/`GP`, and all three `unlinted-file:` directives are deleted. Nothing else
+about them changed: they still build real scheme configs in `tmp_path`, so the
+local-code path — a bare `FXL-004`, a temp `FXL-tmpabcde`, an alias template,
+a `rename_scheme` across two prefixes — is exercised exactly as before. That
+is the load-bearing detail, and it is why this is a *scheme* reservation and
+not a second remote: a remote code is composed (`FX-ADR-032`) and exercises
+the remote path, which is not the path these suites test.
+
+Three constraints make the namespace hold:
+
+- **Leading match, not substring.** `AFX` is somebody's scheme; `FXM` is not.
+  Reserving `FX` at the front of a prefix costs a project nothing it would
+  have chosen.
+- **A namespace, not a name.** A migration fixture needs two prefixes at once.
+  Reserving only `FXL` would leave the second one invisible by luck, which is
+  the property this decision exists to stop relying on.
+- **Checked at the config, not at the citation.** The finding fires at
+  declaration time, before the first document makes the prefix expensive to
+  change, and names `rename_scheme` ([ADR-040](ADR-040.md)) as the remedy for when it
+  already is.
+
+## Alternatives considered
+
+- **Mask string literals in the tree-sitter grammar.** The narrowest-looking
+  fix: a code inside a Python string is a specimen, so stop scanning string
+  literals. It loses on two counts. `pyproject.toml` states the invariant
+  that the optional grammar *"can only widen what a directive governs, never
+  narrow it"* — a code in a string is bare prose everywhere the grammar is not
+  installed, and CI installs `.[dev]`, not `.[syntax]`. So the fix would be
+  inert precisely where the specimen codes are, and where it did apply it
+  would silently stop checking real citations that happen to sit in strings.
+- **One reserved name, `FXL`.** What [#231](https://github.com/dmarx/luria/issues/231)'s comment proposed, and nearly
+  right. `tests/test_migrations.py` renames a scheme, so it needs an old
+  prefix and a new one in the same fixture; with one reserved name the second
+  falls back to `GP`, which is invisible here only because nobody has declared
+  it. The whole point is to stop being invisible by luck.
+- **A per-site `unresolved-ok:` / `inactive-ok:` on each specimen.** This is
+  what the directives are for, and the test suites already carry **93
+  acknowledgement directives across 21 files**. Two of those suites
+  (`test_directives.py`, `test_ref_status.py`) are testing the directive
+  machinery itself and will always carry them. The rest are per-site
+  maintenance that detonates together when the sequence reaches the borrowed
+  number — the exact failure [ADR-034](ADR-034.md) was written after.
+- **Refuse the prefix at config load.** Stronger and self-defeating: fixture
+  projects declare `FXL` on purpose, so a load-time refusal would break the
+  mechanism it was protecting. The check has to run where a human reads it,
+  which is `luria lint`, and the test suites call individual checks rather
+  than `lint.run()`, so it never fires on a fixture.
+- **Rename `FX` to `FXR` for symmetry** (remote/local). Proposed in [#231](https://github.com/dmarx/luria/issues/231) and
+  not taken: the eight `FX` sites include two dated devlog entries, which are
+  observations that stand, and the bodies of [ADR-014](ADR-014.md), [ADR-034](ADR-034.md) and [ADR-072](ADR-072.md),
+  which would need version bumps for a spelling. `FX` reads as the namespace's
+  own name; nothing about the decision needs it renamed, and the namespace is
+  forward-compatible if that changes.
+- **Status quo.** Three whole suites unchecked, growing by one per new
+  scheme-shaped feature — and a class of specimen (`DP-4`) that resolves
+  silently, so the cost is not the directives but the citations nobody can
+  tell from the real ones.
+
+## Consequences
+
+**Measured.** Three `unlinted-file:` directives deleted, none added: the
+reference report's opt-out section goes from three files to zero, and
+`luria lint` gains no new finding from removing them. 1,038 lines of test file
+return to reference checking. The guard was fired once on the real case before
+being trusted — declaring `[luria.schemes.FXL]` in this project's own
+`luria.toml` produced the violation *and*, in the same run, made **ten fixture
+codes across 96 citation sites** start reporting as dangling, which is the
+hazard the reservation prevents, observed rather than argued.
+
+**What is now harder.** A new scheme-shaped test suite has one more thing to
+know: use `FXL`, not the prefix of whatever it is testing. The docstrings say
+so at the top of each of the three suites, and the check says so to anyone who
+declares one for real.
+
+**What this obliges.** The reservation is only as good as its documentation
+for adopting projects: `docs/directives.md` describes both halves under
+*Fixture codes*, beside the `FX` remote that the same section already
+explains. Anything reserving more of the namespace later — `FXR` for the
+remote — is a spelling change inside a namespace that already holds.

--- a/record/devlog.d/2026/09/11/012308.md
+++ b/record/devlog.d/2026/09/11/012308.md
@@ -1,0 +1,67 @@
+---
+title: 'Reserving a namespace instead of blanking three suites'
+created: '2026-09-11T01:23:08'
+tags: []
+---
+
+[#231](https://github.com/dmarx/luria/issues/231) asked how a test suite is supposed to write codes without those codes
+being read as citations. Three suites had answered it with `unlinted-file:`,
+which blanks the whole file — 1,038 lines between them, to excuse a couple of
+dozen specimen codes. The user's answer in the issue thread was better than
+mine: stop trying to make the *codes* invisible and give the fixtures a
+*scheme* nobody else can declare.
+
+**What I measured before changing anything.** Deleting the three directives
+and running the lint produced exactly three new findings, not the flood I
+expected: `ADR-007` (Superseded, 14 sites), `ADR-tmpabcde`, and `DP-018`.
+That number is the trap. The other fixture codes in those files —
+`DP-4`, `DP-004`, `DP-1`, and the composed `LU-DP-004` — were **silent
+because they resolved**. A specimen that resolves is counted as a citation of
+a real document and looks exactly like one, forever, until the document it
+borrowed moves. The loud findings were the safe ones.
+
+`tests/test_alias_inference.py` turned out to need no directive at all: its
+`LIT-…` spellings match nothing here, because this project has no `LIT`
+scheme. Invisible by luck, which is the property the whole exercise exists to
+stop depending on.
+
+**Why a namespace and not a name.** [#231](https://github.com/dmarx/luria/issues/231)'s comment proposed one reserved
+prefix, `FXL`. `tests/test_migrations.py` renames a scheme, so it needs an old
+prefix and a new one in the same fixture — with one reserved name the second
+falls back to `GP`, which is safe here only because nobody has declared it.
+Reserving everything that starts with `FX` costs nothing (the match is on the
+leading prefix, so `AFX` is untouched) and makes the second prefix safe by
+construction.
+
+**Where the guard could not go.** The obvious place for "refuse this prefix"
+is config load. That is self-defeating: fixture projects declare `FXL` on
+purpose, so a load-time refusal breaks the mechanism it is protecting. The
+check had to run where a human reads it — `lint.run()` — and it is only
+harmless there because the suites call individual `check_*` functions rather
+than the whole run. That is worth knowing before anyone adds a check the
+other way around.
+
+**Fired once on the real case**, as this file's own rule requires. Adding
+`[luria.schemes.FXL]` to this project's `luria.toml` and running
+`python -m luria.cli lint` produced the violation — and, in the same run, made
+**ten fixture codes across 96 citation sites** start reporting as dangling.
+That second half is the better evidence: it is the hazard, demonstrated, not
+argued.
+
+**Backticks do not mask a reference-status citation, and that is on
+purpose.** Writing the ADR, I quoted the specimen codes as evidence —
+`` `ADR-007` ``, `` `ADR-tmpabcde` ``, `` `DP-018` `` — assuming inline code
+made them mentions. `luria link --fix` agreed and left them alone;
+`ref_status.scan()` counted all four sites anyway. Its docstring says so
+("deliberately unmasked, unlike the link lint"), and eleven other decisions
+already carry `inactive-ok-file: ADR-007` for the same reason. The shorthand
+in CLAUDE.md — "codes in backticks are mentions, not citations" — is true of
+the *fixer* and not of the *report*, which is the stricter of the two on
+purpose: a retired code quoted in prose is still a reader following it
+somewhere retired.
+
+**A trap that cost me twenty minutes.** `luria` on `PATH` is a non-editable
+install in `dist-packages`, so `luria lint` was running the released 0.15.0
+and reporting the new check as absent. It reads the working tree's *record*,
+so every measurement of the directive removal above was still valid — but any
+measurement of new *code* has to go through `python -m luria.cli`.

--- a/tests/test_alias_inference.py
+++ b/tests/test_alias_inference.py
@@ -1,10 +1,10 @@
-# unlinted-file: — alias fixtures; the codes and spellings written here are
-# specimens of what a template renders, not citations of this repository's
-# documents. Same case as `tests/test_migrations.py` and `test_number.py`.
 """A spelling a reader can interpret, rendered from frontmatter (#219).
 
 The identifier stays the number `luria concretize` assigns; the alias is a
 second spelling of it, recomputed on every read and therefore always true.
+
+The fixtures use the reserved local fixture prefix `FXL` (ADR-tmpgody7), so a
+specimen spelling here cannot read as a citation of any real document.
 """
 
 from __future__ import annotations
@@ -23,14 +23,14 @@ def write(root: Path, rel: str, text: str) -> Path:
     return path
 
 
-def project(tmp_path, monkeypatch, alias: str = 'alias = "LIT-{authors[0]}-{year}-{number}"') -> Path:
+def project(tmp_path, monkeypatch, alias: str = 'alias = "FXL-{authors[0]}-{year}-{number}"') -> Path:
     write(tmp_path, "luria.toml", f"""
 [luria]
 issue_url = "https://example.test/issues/{{n}}"
 
-[luria.schemes.LIT]
-dir = "record/literature.d"
-output = "docs/literature"
+[luria.schemes.FXL]
+dir = "record/fixtures.d"
+output = "docs/fixtures"
 {alias}
 """)
     monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
@@ -46,13 +46,13 @@ def note(root: Path, number: int, *, author="Kingma", year=2014,
     if formerly:
         front.append("formerly:")
         front += [f"- {c}" for c in formerly]
-    front += ["---", "", f"# LIT-{number:03d}: {title}", "", "Body."]
-    return write(root, f"record/literature.d/LIT-{number:03d}.md",
+    front += ["---", "", f"# FXL-{number:03d}: {title}", "", "Body."]
+    return write(root, f"record/fixtures.d/FXL-{number:03d}.md",
                  "\n".join(front) + "\n")
 
 
 def scheme():
-    return config.current().schemes["LIT"]
+    return config.current().schemes["FXL"]
 
 
 # --- rendering ---------------------------------------------------------------
@@ -60,8 +60,8 @@ def scheme():
 def test_the_alias_renders_from_the_document(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
     note(root, 41)
-    entry = aliases.alias_map()["LIT-Kingma-2014-41"]
-    assert entry.code == "LIT-041"
+    entry = aliases.alias_map()["FXL-Kingma-2014-41"]
+    assert entry.code == "FXL-041"
     assert entry.kind == aliases.ALSO_KNOWN_AS
 
 
@@ -69,7 +69,7 @@ def test_a_template_naming_a_missing_field_renders_nothing(tmp_path, monkeypatch
     """Half a spelling would resolve for some documents and not others, with
     nothing saying which — so a template that cannot be filled yields none."""
     root = project(tmp_path, monkeypatch,
-                   'alias = "LIT-{editor}-{number}"')
+                   'alias = "FXL-{editor}-{number}"')
     note(root, 41)
     assert aliases.alias_map() == {}
 
@@ -85,30 +85,30 @@ def test_correcting_the_source_moves_the_alias(tmp_path, monkeypatch):
     stops resolving, which is why `formerly:` has to catch it."""
     root = project(tmp_path, monkeypatch)
     note(root, 41, author="Askell")
-    assert "LIT-Askell-2014-41" in aliases.alias_map()
+    assert "FXL-Askell-2014-41" in aliases.alias_map()
     note(root, 41, author="Bai")
     config.reset(); aliases.reset()
     entries = aliases.alias_map()
-    assert "LIT-Askell-2014-41" not in entries
-    assert "LIT-Bai-2014-41" in entries
+    assert "FXL-Askell-2014-41" not in entries
+    assert "FXL-Bai-2014-41" in entries
 
 
 def test_a_superseded_spelling_kept_in_formerly_still_resolves(
         tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    note(root, 41, author="Bai", formerly=["LIT-Askell-2014-41"])
+    note(root, 41, author="Bai", formerly=["FXL-Askell-2014-41"])
     entries = aliases.alias_map()
-    assert entries["LIT-Bai-2014-41"].kind == aliases.ALSO_KNOWN_AS
-    assert entries["LIT-Askell-2014-41"].kind == aliases.FORMERLY
-    assert entries["LIT-Askell-2014-41"].code == "LIT-041"
+    assert entries["FXL-Bai-2014-41"].kind == aliases.ALSO_KNOWN_AS
+    assert entries["FXL-Askell-2014-41"].kind == aliases.FORMERLY
+    assert entries["FXL-Askell-2014-41"].code == "FXL-041"
 
 
 def test_a_real_code_outranks_another_document_s_nickname(tmp_path, monkeypatch):
     """A document's own name wins: an alias that happens to spell a code
     must never shadow the document that code belongs to."""
-    root = project(tmp_path, monkeypatch, 'alias = "LIT-{year}"')
+    root = project(tmp_path, monkeypatch, 'alias = "FXL-{year}"')
     note(root, 41, year=2014)
-    assert "LIT-2014" not in aliases.alias_map()
+    assert "FXL-2014" not in aliases.alias_map()
 
 
 # --- resolution and the fixer ------------------------------------------------
@@ -135,31 +135,31 @@ def test_the_fixer_leaves_a_derived_alias_written(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
     note(root, 41)
     ref = doc_refs.Ref(kind="scheme", num=0, start=0, end=0,
-                       text="LIT-Kingma-2014-41", line=1, prefix="LIT",
+                       text="FXL-Kingma-2014-41", line=1, prefix="FXL",
                        code="Kingma-2014-41")
-    assert doc_refs._label(ref) == "LIT-Kingma-2014-41"
+    assert doc_refs._label(ref) == "FXL-Kingma-2014-41"
 
 
 def test_the_fixer_still_upgrades_a_past_spelling(tmp_path, monkeypatch):
     """The opposite instruction, over the same map — which is why an entry
     carries its kind rather than the caller guessing from shape."""
     root = project(tmp_path, monkeypatch)
-    note(root, 41, formerly=["LIT-tmpabcde"])
+    note(root, 41, formerly=["FXL-tmpabcde"])
     ref = doc_refs.Ref(kind="scheme", num=0, start=0, end=0,
-                       text="LIT-tmpabcde", line=1, prefix="LIT",
+                       text="FXL-tmpabcde", line=1, prefix="FXL",
                        code="tmpabcde")
-    assert doc_refs._label(ref) == "LIT-041"
+    assert doc_refs._label(ref) == "FXL-041"
 
 
 # --- collisions --------------------------------------------------------------
 
 def test_two_documents_on_one_spelling_is_a_violation(tmp_path, monkeypatch):
-    root = project(tmp_path, monkeypatch, 'alias = "LIT-{authors[0]}-{year}"')
+    root = project(tmp_path, monkeypatch, 'alias = "FXL-{authors[0]}-{year}"')
     note(root, 41); note(root, 42)
     errors: list[str] = []
     lint.check_alias_collisions(errors)
     assert len(errors) == 1
-    assert "renders `LIT-Kingma-2014` for LIT-041, LIT-042" in errors[0]
+    assert "renders `FXL-Kingma-2014` for FXL-041, FXL-042" in errors[0]
 
 
 def test_the_number_makes_collisions_impossible(tmp_path, monkeypatch):
@@ -176,12 +176,12 @@ def test_a_template_without_the_prefix_is_refused(tmp_path, monkeypatch):
     """Every scanner finds a code by its prefix first, so a spelling without
     one is unreachable however well it resolves."""
     project(tmp_path, monkeypatch, 'alias = "{authors[0]}-{year}"')
-    with pytest.raises(ValueError, match="does not start with 'LIT-'"):
+    with pytest.raises(ValueError, match="does not start with 'FXL-'"):
         config.current()
 
 
 def test_an_unrenderable_template_is_refused(tmp_path, monkeypatch):
-    project(tmp_path, monkeypatch, 'alias = "LIT-{authors[0"')
+    project(tmp_path, monkeypatch, 'alias = "FXL-{authors[0"')
     with pytest.raises(ValueError, match="not a template"):
         config.current()
 
@@ -214,13 +214,13 @@ def test_a_changed_source_field_retires_the_old_spelling(tmp_path, monkeypatch):
     note(root, 41, author="Bai")          # the attribution is corrected
     config.reset(); aliases.reset()
     changed = repair.retire_aliases(scheme())
-    assert [p.name for p in changed] == ["LIT-041.md"]
+    assert [p.name for p in changed] == ["FXL-041.md"]
 
     config.reset(); aliases.reset()
     entries = aliases.alias_map()
-    assert entries["LIT-Bai-2014-41"].kind == aliases.ALSO_KNOWN_AS
-    assert entries["LIT-Askell-2014-41"].kind == aliases.FORMERLY
-    assert entries["LIT-Askell-2014-41"].code == "LIT-041"
+    assert entries["FXL-Bai-2014-41"].kind == aliases.ALSO_KNOWN_AS
+    assert entries["FXL-Askell-2014-41"].kind == aliases.FORMERLY
+    assert entries["FXL-Askell-2014-41"].code == "FXL-041"
 
 
 def test_the_retirement_is_idempotent(tmp_path, monkeypatch):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -7,11 +7,11 @@ modernize pass. The guards here are fired on the failure they exist for
 (DP-6): a reference written in last year's spelling, a fixture code that must
 survive, a composed remote code that is another project's namespace, and a
 journal link whose frame the sweep must not disturb (#57).
+
+The fixture schemes are `FXL` and `FXM`, from the reserved fixture namespace
+(ADR-tmpgody7): a migration needs two prefixes, and neither may read as a
+citation of a real document.
 """
-# unlinted-file: — migration fixtures; every code spelling in this suite is a
-# deliberate specimen of a pre- or post-migration state, not a claim about
-# this repository's documents. The sweep honors this for the same reason the
-# scanners do: a quote is not an address.
 import json
 import subprocess
 from pathlib import Path
@@ -21,21 +21,21 @@ from luria import (aliases, concretize, config, doc_refs, lint, migrate,
 
 
 def _record_project(tmp_path, monkeypatch):
-    """A project whose GP-004 used to be DP-4 — the post-migration shape."""
+    """A project whose FXM-004 used to be FXL-4 — the post-migration shape."""
     (tmp_path / "docs").mkdir()
     (tmp_path / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.paths]\ndesign_principles = "docs/guiding-principles.md"\n'
-        '[luria.schemes.GP]\ndir = "record/principles.d"\n'
+        '[luria.schemes.FXM]\ndir = "record/principles.d"\n'
         'render = "document"\noutput = "docs/guiding-principles.md"\n'
         '[luria.remotes.SG]\nrepo = "example/strata-g"\n'
     )
-    gp_dir = tmp_path / "record" / "principles.d"
-    gp_dir.mkdir(parents=True)
-    (gp_dir / "GP-004.md").write_text(
+    fxm_dir = tmp_path / "record" / "principles.d"
+    fxm_dir.mkdir(parents=True)
+    (fxm_dir / "FXM-004.md").write_text(
         "---\nstatus: Active\ntitle: 'A principle'\ntags:\n- record\n"
-        "date: '2026-01-01'\nformerly:\n- DP-4\n---\n\n"
-        "# GP-004: A principle\n\nBody.\n")
+        "date: '2026-01-01'\nformerly:\n- FXL-4\n---\n\n"
+        "# FXM-004: A principle\n\nBody.\n")
     monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
     config.reset()
     aliases.reset()
@@ -45,11 +45,11 @@ def _record_project(tmp_path, monkeypatch):
 def test_the_alias_map_derives_from_formerly(tmp_path, monkeypatch):
     _record_project(tmp_path, monkeypatch)
     entries = aliases.alias_map()
-    assert {k: v.code for k, v in entries.items()} == {"DP-004": "GP-004"}
+    assert {k: v.code for k, v in entries.items()} == {"FXL-004": "FXM-004"}
     # A past spelling, so the fixer rewrites it away — the opposite of what
     # it does with a derived one (#219).
-    assert entries["DP-004"].kind == aliases.FORMERLY
-    assert entries["DP-004"].superseded
+    assert entries["FXL-004"].kind == aliases.FORMERLY
+    assert entries["FXL-004"].superseded
 
 
 def _git(root, *args):
@@ -57,7 +57,7 @@ def _git(root, *args):
 
 
 def _premigration_project(tmp_path, monkeypatch):
-    """A project the day before its DP scheme becomes GP — documents,
+    """A project the day before its FXL scheme becomes FXM — documents,
     citations in three frames, a fixture number, and two remotes: SG is
     another project (its namespace survives), LU mirrors this one (its
     composed codes follow the rename)."""
@@ -65,43 +65,43 @@ def _premigration_project(tmp_path, monkeypatch):
     (tmp_path / "luria.toml").write_text(
         '[luria]\nissue_url = "https://example.test/issues/{n}"\n'
         '[luria.paths]\ndesign_principles = "docs/design-principles.md"\n'
-        '[luria.schemes.DP]\ndir = "record/principles.d"\n'
+        '[luria.schemes.FXL]\ndir = "record/principles.d"\n'
         'render = "document"\noutput = "docs/design-principles.md"\n'
         '[luria.remotes.SG]\nrepo = "example/strata-g"\n'
-        '[luria.remotes.SG.schemes.DP]\n'
+        '[luria.remotes.SG.schemes.FXL]\n'
         'document = "docs/design-principles.md"\n'
         '[luria.remotes.LU]\nrepo = "example/this-project"\n'
-        '[luria.remotes.LU.schemes.DP]\n'
+        '[luria.remotes.LU.schemes.FXL]\n'
         'document = "docs/design-principles.md"\n'
     )
     (tmp_path / "docs" / "design-principles.md").write_text(
         "<!-- GENERATED -->\n\n# Principles\n\n"
-        '<a name="dp-4"></a>\n\n## 4. Fourth value\n')
-    dp_dir = tmp_path / "record" / "principles.d"
-    dp_dir.mkdir(parents=True)
+        '<a name="fxl-4"></a>\n\n## 4. Fourth value\n')
+    fxl_dir = tmp_path / "record" / "principles.d"
+    fxl_dir.mkdir(parents=True)
     for n, title in ((1, "First value"), (4, "Fourth value")):
-        (dp_dir / f"DP-{n:03d}.md").write_text(
+        (fxl_dir / f"FXL-{n:03d}.md").write_text(
             f"---\nstatus: Active\ntitle: '{title}'\ntags:\n- record\n"
-            f"date: '2026-01-01'\n---\n\n# DP-{n:03d}: {title}\n\n"
-            f"Body citing DP-1 sometimes.\n")
+            f"date: '2026-01-01'\n---\n\n# FXL-{n:03d}: {title}\n\n"
+            f"Body citing FXL-1 sometimes.\n")
     (tmp_path / "docs" / "notes.md").write_text(
         "# Notes\n\n"
-        "Bare DP-4 and a link [DP-4](design-principles.md#dp-4).\n"
-        "Fixture DP-018 is nobody's document.\n"
-        "Foreign SG-DP-4 belongs to strata-g.\n"
-        "Mirrored LU-DP-004 follows this project.\n"
+        "Bare FXL-4 and a link [FXL-4](design-principles.md#fxl-4).\n"
+        "Fixture FXL-018 is nobody's document.\n"
+        "Foreign SG-FXL-4 belongs to strata-g.\n"
+        "Mirrored LU-FXL-004 follows this project.\n"
         "[theirs](https://example.test/sg/docs/design-principles.md#x)\n")
     entry_dir = tmp_path / "record" / "devlog.d" / "2026" / "08" / "01"
     entry_dir.mkdir(parents=True)
     (entry_dir / "120000.md").write_text(
         "---\ntitle: 'An entry'\ncreated: '2026-08-01T12:00:00'\ntags: []\n"
-        "---\n\nBook-frame link: [DP-4](../../record/../docs/"
-        "design-principles.md#dp-4).\n")
+        "---\n\nBook-frame link: [FXL-4](../../record/../docs/"
+        "design-principles.md#fxl-4).\n")
     mig_dir = tmp_path / "record" / "migrations.d"
     mig_dir.mkdir(parents=True)
-    (mig_dir / "0001-dp-to-gp.toml").write_text(
-        'title = "DP becomes GP"\nissue = "#29"\n\n'
-        '[[operations]]\nop = "rename_scheme"\nfrom = "DP"\nto = "GP"\n'
+    (mig_dir / "0001-fxl-to-fxm.toml").write_text(
+        'title = "FXL becomes FXM"\nissue = "#29"\n\n'
+        '[[operations]]\nop = "rename_scheme"\nfrom = "FXL"\nto = "FXM"\n'
         'output = "docs/guiding-principles.md"\nremotes = ["LU"]\n')
     _git(tmp_path, "init", "-q")
     _git(tmp_path, "add", "-A")
@@ -119,11 +119,11 @@ def _locked_project(tmp_path, monkeypatch):
     root = _premigration_project(tmp_path, monkeypatch)
     lock = root / "remotes.lock.json"
     lock.write_text(json.dumps({
-        "remotes": {"LU": {"DP-004": "DP-004.md"},
-                    "SG": {"DP-004": "dp-004-a-slug.md"}},
-        "pins": {"LU": {"DP-004": {"endorsed": "sha256:bbb",
+        "remotes": {"LU": {"FXL-004": "FXL-004.md"},
+                    "SG": {"FXL-004": "fxl-004-a-slug.md"}},
+        "pins": {"LU": {"FXL-004": {"endorsed": "sha256:bbb",
                                    "seen": "sha256:ccc"}},
-                 "SG": {"DP-004": {"endorsed": "sha256:aaa",
+                 "SG": {"FXL-004": {"endorsed": "sha256:aaa",
                                    "seen": "sha256:aaa"}}}},
         indent=2) + "\n")
     _git(root, "add", "-A")
@@ -137,20 +137,20 @@ def test_endorsements_travel_with_a_claimed_rename(tmp_path, monkeypatch):
     the mirrored LU pin is re-keyed with both hashes intact (drift state
     included: prune-and-re-endorse would have laundered the unreviewed
     `seen`). The foreign SG entries survive byte-for-byte: the lockfile is
-    never swept as text, which is what protects `"DP-004"` under `"SG"`
+    never swept as text, which is what protects `"FXL-004"` under `"SG"`
     from a mask that cannot see nested keys as another project's
     namespace (#135)."""
     root, lock = _locked_project(tmp_path, monkeypatch)
     migrate.run("0001")
     data = json.loads(lock.read_text())
-    assert data["pins"]["LU"] == {"GP-004": {"endorsed": "sha256:bbb",
+    assert data["pins"]["LU"] == {"FXM-004": {"endorsed": "sha256:bbb",
                                              "seen": "sha256:ccc"}}
-    assert data["pins"]["SG"] == {"DP-004": {"endorsed": "sha256:aaa",
+    assert data["pins"]["SG"] == {"FXL-004": {"endorsed": "sha256:aaa",
                                              "seen": "sha256:aaa"}}
     # The claimed remote's filename map spells the old world in keys AND
     # values — dropped for re-discovery, while the foreign map stands.
     assert "LU" not in data["remotes"]
-    assert data["remotes"]["SG"] == {"DP-004": "dp-004-a-slug.md"}
+    assert data["remotes"]["SG"] == {"FXL-004": "fxl-004-a-slug.md"}
 
 
 def test_dry_run_plans_the_pin_move_and_keeps_the_lockfile(tmp_path,
@@ -160,7 +160,7 @@ def test_dry_run_plans_the_pin_move_and_keeps_the_lockfile(tmp_path,
     before = lock.read_text()
     migrate.run("0001", dry_run=True)
     out = capsys.readouterr().out
-    assert "LU pin DP-004 -> GP-004" in out and "endorsement travels" in out
+    assert "LU pin FXL-004 -> FXM-004" in out and "endorsement travels" in out
     assert lock.read_text() == before
 
 
@@ -169,8 +169,8 @@ def test_dry_run_prints_the_plan_and_changes_nothing(tmp_path, monkeypatch, caps
     before = {p: p.read_text() for p in root.rglob("*.md")}
     migrate.run("0001", dry_run=True)
     out = capsys.readouterr().out
-    assert "DP-001 -> GP-001" in out and "DP-004 -> GP-004" in out
-    assert "LU-DP-004 -> LU-GP-004" in out
+    assert "FXL-001 -> FXM-001" in out and "FXL-004 -> FXM-004" in out
+    assert "LU-FXL-004 -> LU-FXM-004" in out
     assert "design-principles.md -> guiding-principles.md" in out
     assert {p: p.read_text() for p in root.rglob("*.md")} == before
 
@@ -179,21 +179,21 @@ def test_rename_scheme_end_to_end(tmp_path, monkeypatch, capsys):
     root = _premigration_project(tmp_path, monkeypatch)
     migrate.run("0001")
 
-    dp_dir = root / "record" / "principles.d"
-    assert not (dp_dir / "DP-004.md").exists()
-    moved = (dp_dir / "GP-004.md").read_text()
-    assert "formerly:\n- DP-4\n" in moved, "identity stamped"
-    assert "# GP-004: Fourth value" in moved, "own heading swept"
-    assert "citing GP-1 sometimes" in moved, "cross-citations swept"
+    fxl_dir = root / "record" / "principles.d"
+    assert not (fxl_dir / "FXL-004.md").exists()
+    moved = (fxl_dir / "FXM-004.md").read_text()
+    assert "formerly:\n- FXL-4\n" in moved, "identity stamped"
+    assert "# FXM-004: Fourth value" in moved, "own heading swept"
+    assert "citing FXM-1 sometimes" in moved, "cross-citations swept"
 
     config_text = (root / "luria.toml").read_text()
-    assert "[luria.schemes.GP]" in config_text
-    assert "[luria.schemes.DP]" not in config_text
+    assert "[luria.schemes.FXM]" in config_text
+    assert "[luria.schemes.FXL]" not in config_text
     assert 'design_principles = "docs/guiding-principles.md"' in config_text
     assert 'output = "docs/guiding-principles.md"' in config_text
-    assert "[luria.remotes.LU.schemes.GP]" in config_text, "mirror follows"
+    assert "[luria.remotes.LU.schemes.FXM]" in config_text, "mirror follows"
     assert config_text.count('document = "docs/guiding-principles.md"') == 1
-    assert "[luria.remotes.SG.schemes.DP]" in config_text, "theirs stays"
+    assert "[luria.remotes.SG.schemes.FXL]" in config_text, "theirs stays"
     assert 'document = "docs/design-principles.md"' in config_text, \
         "SG's own path untouched by the section-aware pass"
 
@@ -201,29 +201,29 @@ def test_rename_scheme_end_to_end(tmp_path, monkeypatch, capsys):
         "a generated view is removed, not renamed — the next index rebuilds it"
 
     notes = (root / "docs" / "notes.md").read_text()
-    assert "Bare GP-4 and a link [GP-4](guiding-principles.md#gp-4)." in notes
-    assert "Fixture DP-018 is nobody's document." in notes, "not in the mapping"
-    assert "Foreign SG-DP-4 belongs to strata-g." in notes, "their namespace"
-    assert "Mirrored LU-GP-004 follows this project." in notes
+    assert "Bare FXM-4 and a link [FXM-4](guiding-principles.md#fxm-4)." in notes
+    assert "Fixture FXL-018 is nobody's document." in notes, "not in the mapping"
+    assert "Foreign SG-FXL-4 belongs to strata-g." in notes, "their namespace"
+    assert "Mirrored LU-FXM-004 follows this project." in notes
     assert "https://example.test/sg/docs/design-principles.md#x" in notes, \
         "a foreign URL never follows a local path pair"
 
     entry = next((root / "record" / "devlog.d").rglob("1*.md")).read_text()
-    assert "[GP-4](../../record/../docs/guiding-principles.md#gp-4)" in entry, \
+    assert "[FXM-4](../../record/../docs/guiding-principles.md#fxm-4)" in entry, \
         "history swept, and the link's frame untouched (#57)"
 
-    spec = (root / "record" / "migrations.d" / "0001-dp-to-gp.toml").read_text()
-    assert 'from = "DP"' in spec, "the spec remembers the old spelling"
+    spec = (root / "record" / "migrations.d" / "0001-fxl-to-fxm.toml").read_text()
+    assert 'from = "FXL"' in spec, "the spec remembers the old spelling"
 
     # Full circle into rung 1: the fresh config resolves old spellings.
     config.reset()
     aliases.reset()
     assert {k: v.code for k, v in aliases.alias_map().items()} == {
-        "DP-001": "GP-001", "DP-004": "GP-004"}
+        "FXL-001": "FXM-001", "FXL-004": "FXM-004"}
 
 
 def test_a_rename_mirrors_each_citation_s_padding(tmp_path, monkeypatch):
-    """`DP-004` stays padded, `DP-4` stays bare, and the anchor stays bare.
+    """`FXL-004` stays padded, `FXL-4` stays bare, and the anchor stays bare.
 
     The tail is one string with two spellings in play at once — the padded
     filename form and the bare prose form — so a rewrite has to answer
@@ -231,16 +231,16 @@ def test_a_rename_mirrors_each_citation_s_padding(tmp_path, monkeypatch):
     provisional-tail work touched exactly this branch."""
     root = _premigration_project(tmp_path, monkeypatch)
     page = root / "docs" / "padding.md"
-    page.write_text("Padded DP-004, bare DP-4, anchor "
-                    "[x](design-principles.md#dp-4).\n")
+    page.write_text("Padded FXL-004, bare FXL-4, anchor "
+                    "[x](design-principles.md#fxl-4).\n")
     _git(root, "add", "-A")
     _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
          "-qm", "padding")
     migrate.run("0001")
     out = page.read_text()
-    assert "Padded GP-004" in out, out
-    assert "bare GP-4," in out, out
-    assert "#gp-4)" in out, out
+    assert "Padded FXM-004" in out, out
+    assert "bare FXM-4," in out, out
+    assert "#fxm-4)" in out, out
 
 
 def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
@@ -260,16 +260,16 @@ def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
     config.reset()
     aliases.reset()
     mig = root / "record" / "migrations.d" / "0002-promote.toml"
-    mig.write_text('title = "DP-4 becomes a value"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+    mig.write_text('title = "FXL-4 becomes a value"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "FXL-4"\n'
                    'to = "VAL"\n')
     migrate.run("0002")
 
     landed = list((root / "record" / "values.d").glob("VAL-tmp*.md"))
     assert len(landed) == 1, "the move lands provisional, never numbered"
-    assert "formerly:\n- DP-4\n" in landed[0].read_text()
-    assert not (root / "record" / "principles.d" / "DP-004.md").exists()
-    # DP renders as a document and VAL as an index, so the citation's SHAPE
+    assert "formerly:\n- FXL-4\n" in landed[0].read_text()
+    assert not (root / "record" / "principles.d" / "FXL-004.md").exists()
+    # FXL renders as a document and VAL as an index, so the citation's SHAPE
     # changed: `page.md#anchor` → `dir/CODE.md`. The sweep drops the stale
     # link and the fixer rebuilds it from the resolver.
     notes = (root / "docs" / "notes.md").read_text()
@@ -284,12 +284,12 @@ def test_move_doc_lands_provisional_then_concretizes(tmp_path, monkeypatch):
     concretize.run()
 
     final = (root / "record" / "values.d" / "VAL-001.md").read_text()
-    assert "- DP-4" in final and "- VAL-tmp" in final, \
+    assert "- FXL-4" in final and "- VAL-tmp" in final, \
         "both the migrated-from code and the provisional one stay resolvable"
     notes = (root / "docs" / "notes.md").read_text()
     assert "[VAL-001](../record/values.d/VAL-001.md)" in notes, notes
     assert "val-tmp" not in notes, "no provisional spelling survives the sweep"
-    assert "Fixture DP-018" in notes, "a fixture number is not in the mapping"
+    assert "Fixture FXL-018" in notes, "a fixture number is not in the mapping"
 
 
 def test_two_moves_into_one_scheme_do_not_collide(tmp_path, monkeypatch):
@@ -308,15 +308,15 @@ def test_two_moves_into_one_scheme_do_not_collide(tmp_path, monkeypatch):
     aliases.reset()
     mig = root / "record" / "migrations.d" / "0002-promote-both.toml"
     mig.write_text('title = "Both principles become values"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-1"\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "FXL-1"\n'
                    'to = "VAL"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "FXL-4"\n'
                    'to = "VAL"\n')
     migrate.run("0002")
 
     landed = sorted((root / "record" / "values.d").glob("VAL-tmp*.md"))
     assert len(landed) == 2, [p.name for p in landed]
-    assert not list((root / "record" / "principles.d").glob("DP-*.md"))
+    assert not list((root / "record" / "principles.d").glob("FXL-*.md"))
 
     _git(root, "add", "-A")
     _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
@@ -343,14 +343,14 @@ def test_move_doc_supersede_copies_and_tombstones(tmp_path, monkeypatch):
     config.reset()
     aliases.reset()
     mig = root / "record" / "migrations.d" / "0002-supersede.toml"
-    mig.write_text('title = "DP-4 superseded by a value"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+    mig.write_text('title = "FXL-4 superseded by a value"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "FXL-4"\n'
                    'to = "VAL"\nstrategy = "supersede"\n')
     migrate.run("0002")
-    old = (root / "record" / "principles.d" / "DP-004.md").read_text()
+    old = (root / "record" / "principles.d" / "FXL-004.md").read_text()
     assert "status: Superseded\nsuperseded_by:\n- VAL-tmp" in old
     assert len(list((root / "record" / "values.d").glob("VAL-tmp*.md"))) == 1
-    assert "Bare DP-4" in (root / "docs" / "notes.md").read_text(), \
+    assert "Bare FXL-4" in (root / "docs" / "notes.md").read_text(), \
         "supersede mode rewrites nothing"
 
     _git(root, "add", "-A")
@@ -359,9 +359,9 @@ def test_move_doc_supersede_copies_and_tombstones(tmp_path, monkeypatch):
     config.reset()
     aliases.reset()
     concretize.run()
-    old = (root / "record" / "principles.d" / "DP-004.md").read_text()
+    old = (root / "record" / "principles.d" / "FXL-004.md").read_text()
     assert "status: Superseded\nsuperseded_by:\n- VAL-001" in old
-    assert "Bare DP-4" in (root / "docs" / "notes.md").read_text()
+    assert "Bare FXL-4" in (root / "docs" / "notes.md").read_text()
 
 
 def test_new_migration_scaffolds_a_numbered_spec(tmp_path, monkeypatch):
@@ -379,10 +379,10 @@ def test_the_sweep_honors_unlinted_file(tmp_path, monkeypatch, capsys):
     specimen = root / "docs" / "specimens.md"
     specimen.write_text(
         "<!-- unlinted-file: — every code here is a specimen -->\n\n"
-        "# Specimens\n\nThe old spelling DP-4 preserved verbatim.\n")
+        "# Specimens\n\nThe old spelling FXL-4 preserved verbatim.\n")
     _git(root, "add", "-A")
     migrate.run("0001")
-    assert "The old spelling DP-4 preserved verbatim." in specimen.read_text()
+    assert "The old spelling FXL-4 preserved verbatim." in specimen.read_text()
 
 
 def test_provisional_is_decided_in_one_place(tmp_path, monkeypatch):
@@ -394,9 +394,9 @@ def test_provisional_is_decided_in_one_place(tmp_path, monkeypatch):
     from luria.config import is_temp_tail
     assert is_temp_tail("tmp47fje") and not is_temp_tail("004")
     assert not is_temp_tail("nonsense"), "not-a-number is not the same test"
-    assert migrate.Pair("DP-004", "VAL-tmp47fje").new_is_provisional
-    assert not migrate.Pair("DP-004", "VAL-007").new_is_provisional
-    assert not migrate.Pair("DP-004", "VAL-nonsense").new_is_provisional
+    assert migrate.Pair("FXL-004", "VAL-tmp47fje").new_is_provisional
+    assert not migrate.Pair("FXL-004", "VAL-007").new_is_provisional
+    assert not migrate.Pair("FXL-004", "VAL-nonsense").new_is_provisional
 
 
 def test_a_same_render_move_keeps_its_links_untouched(tmp_path, monkeypatch):
@@ -437,7 +437,7 @@ def test_a_worded_citation_of_a_moved_document_is_rebuilt(tmp_path,
                                                           monkeypatch):
     """A citation labelled in prose, not spelled as the code, still follows.
 
-    `[design-principles #17](../design-principles.md#dp-17)` is a live link to
+    `[design-principles #17](../design-principles.md#fxl-17)` is a live link to
     an anchor the move just vacated, and a code-shaped pattern walks straight
     past it. Worse, stripping it to its LABEL resurrects the problem: the bare
     `#17` left behind is itself a design-principle reference, which the fixer
@@ -450,26 +450,26 @@ def test_a_worded_citation_of_a_moved_document_is_rebuilt(tmp_path,
     (root / "record" / "values.d").mkdir(parents=True)
     page = root / "docs" / "worded.md"
     page.write_text(
-        "The fix ([design-principles #4](design-principles.md#dp-4)) held.\n")
+        "The fix ([design-principles #4](design-principles.md#fxl-4)) held.\n")
     config.reset()
     aliases.reset()
     _git(root, "add", "-A")
     _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
          "-qm", "worded")
     mig = root / "record" / "migrations.d" / "0002-worded.toml"
-    mig.write_text('title = "DP-4 becomes a value"\n\n'
-                   '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\n'
+    mig.write_text('title = "FXL-4 becomes a value"\n\n'
+                   '[[operations]]\nop = "move_doc"\ndoc = "FXL-4"\n'
                    'to = "VAL"\n')
     migrate.run("0002")
     out = page.read_text()
-    assert "design-principles.md#dp-4" not in out, out
-    assert "#dp-4" not in out, "the vacated anchor must not survive anywhere"
+    assert "design-principles.md#fxl-4" not in out, out
+    assert "#fxl-4" not in out, "the vacated anchor must not survive anywhere"
     assert "VAL-tmp" in out, out
 
 
 def _worded_move_project(tmp_path, monkeypatch):
-    """The premigration project plus a SOURCE FILE that cites DP-4 two ways —
-    by code and in prose — and a spec that moves DP-4 into an index-rendered
+    """The premigration project plus a SOURCE FILE that cites FXL-4 two ways —
+    by code and in prose — and a spec that moves FXL-4 into an index-rendered
     scheme."""
     root = _premigration_project(tmp_path, monkeypatch)
     (root / "luria.toml").write_text(
@@ -480,7 +480,7 @@ def _worded_move_project(tmp_path, monkeypatch):
     (root / "src").mkdir()
     (root / "src" / "engine.py").write_text(
         "# Selection rides undo by decision (design-principles #4), not by\n"
-        "# accident. DP-4 is the claim; DP-1 is a different one.\n"
+        "# accident. FXL-4 is the claim; FXL-1 is a different one.\n"
         "SELECTION_RIDES_UNDO = True\n")
     config.reset()
     aliases.reset()
@@ -488,8 +488,8 @@ def _worded_move_project(tmp_path, monkeypatch):
     _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit",
          "-qm", "src")
     (root / "record" / "migrations.d" / "0002-worded-code.toml").write_text(
-        'title = "DP-4 becomes a value"\n\n'
-        '[[operations]]\nop = "move_doc"\ndoc = "DP-4"\nto = "VAL"\n')
+        'title = "FXL-4 becomes a value"\n\n'
+        '[[operations]]\nop = "move_doc"\ndoc = "FXL-4"\nto = "VAL"\n')
     return root
 
 
@@ -507,8 +507,8 @@ def test_the_relink_pass_stops_where_the_hyperlink_lint_stops(tmp_path,
     migrate.run("0002")
     src = (root / "src" / "engine.py").read_text()
     assert "](" not in src, f"no markdown links in a source file:\n{src}"
-    # DP-1 did not move, and stays exactly as the author left it.
-    assert "DP-1 is a different one" in src, src
+    # FXL-1 did not move, and stays exactly as the author left it.
+    assert "FXL-1 is a different one" in src, src
 
 
 def test_a_worded_citation_in_code_follows_the_move(tmp_path, monkeypatch):
@@ -525,13 +525,13 @@ def test_a_worded_citation_in_code_follows_the_move(tmp_path, monkeypatch):
     assert "design-principles #4" not in src, src
     assert "#4" not in src, "the vacated anchor number must not survive"
     assert src.count("VAL-tmp") == 2, f"both spellings respelled:\n{src}"
-    assert "DP-1 is a different one" in src, "an unmoved code is left alone"
+    assert "FXL-1 is a different one" in src, "an unmoved code is left alone"
 
 
 def test_a_formerly_stamp_is_not_a_dangling_citation(tmp_path, monkeypatch):
     """The alias a move writes must not be reported as a broken reference.
 
-    `formerly: DP-004` names a code that resolves to no document *because the
+    `formerly: FXL-004` names a code that resolves to no document *because the
     alias exists* — that is what the stamp is for. Counting it made every
     migration hand back one fresh "resolves to no document" warning per moved
     document, pointing at the files the migration had just written."""
@@ -541,5 +541,5 @@ def test_a_formerly_stamp_is_not_a_dangling_citation(tmp_path, monkeypatch):
     aliases.reset()
     moved = next((root / "record" / "values.d").glob("VAL-*.md"))
     assert "formerly:" in moved.read_text(), moved.read_text()
-    assert "DP-004" not in ref_status.scan().dangling, \
+    assert "FXL-004" not in ref_status.scan().dangling, \
         "the stamp is a declaration, not a citation"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2,13 +2,11 @@
 
 Schemes now work the way journals always have: the frontmatter carries the
 truth, the path is a projection of it, and the lint guards the agreement.
-"""
 
-# unlinted-file: — identity fixtures; `ADR-007` and `ADR-tmpabcde` here are
-# specimens of a filename shape, not citations of this repository's ADR-007
-# (Superseded) or of any temporary document. Same case as
-# `tests/test_migrations.py`: a scheme's own suite has to write codes to test
-# how codes are read.
+The fixtures use the reserved local fixture prefix `FXL` (ADR-tmpgody7), so a
+specimen filename here cannot read as a citation of this repository's own
+decisions.
+"""
 
 from __future__ import annotations
 
@@ -31,9 +29,9 @@ def project(tmp_path, monkeypatch, allocate: str = "filing") -> Path:
 [luria]
 issue_url = "https://example.test/issues/{{n}}"
 
-[luria.schemes.ADR]
-dir = "record/decisions.d"
-output = "docs/decisions"
+[luria.schemes.FXL]
+dir = "record/fixtures.d"
+output = "docs/fixtures"
 allocate = "{allocate}"
 """)
     monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
@@ -47,28 +45,28 @@ def doc(root: Path, name: str, *, number: int | None = None,
     if number is not None:
         front.insert(1, f"number: {number}")
     front += ["date: '2026-01-01'", "---", "", f"# {name}: {title}", "", "Body."]
-    return write(root, f"record/decisions.d/{name}.md", "\n".join(front) + "\n")
+    return write(root, f"record/fixtures.d/{name}.md", "\n".join(front) + "\n")
 
 
 def scheme():
-    return config.current().schemes["ADR"]
+    return config.current().schemes["FXL"]
 
 
 # --- the field is the identity ----------------------------------------------
 
 def test_the_field_wins_over_the_filename(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007", number=42)
+    path = doc(root, "FXL-007", number=42)
     assert scheme().number_of(path) == 42
     assert scheme().documents() == {42: path}
-    assert adr_index.Adr(path, scheme()).code == "ADR-042"
+    assert adr_index.Adr(path, scheme()).code == "FXL-042"
 
 
 def test_the_filename_answers_when_the_field_is_absent(tmp_path, monkeypatch):
     """A record written before `number:` existed still reads — which is what
     makes the field introducible without a migration anyone has to run."""
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007")
+    path = doc(root, "FXL-007")
     assert scheme().number_of(path) == 7
     assert scheme().documents() == {7: path}
 
@@ -79,9 +77,9 @@ def test_a_number_in_the_body_is_prose_not_a_claim(tmp_path, monkeypatch):
     optimizer practices..."). The frontmatter boundary is what keeps prose
     from claiming an identity."""
     root = project(tmp_path, monkeypatch)
-    path = write(root, "record/decisions.d/ADR-007.md",
+    path = write(root, "record/fixtures.d/FXL-007.md",
                  "---\nstatus: Active\ntitle: 'A decision'\ndate: '2026-01-01'\n"
-                 "---\n\n# ADR-007: A decision\n\nhere mainly for the 10%\n"
+                 "---\n\n# FXL-007: A decision\n\nhere mainly for the 10%\n"
                  "number: the record's optimizer practices trade convergence\n")
     assert scheme().number_of(path) == 7
 
@@ -90,7 +88,7 @@ def test_a_temporary_document_has_no_number_yet(tmp_path, monkeypatch):
     """By design: a merge-allocated document holds no claim on the sequence
     until `luria concretize` assigns one (ADR-049)."""
     root = project(tmp_path, monkeypatch, allocate="merge")
-    doc(root, "ADR-tmpabcde")
+    doc(root, "FXL-tmpabcde")
     assert scheme().documents() == {}
     assert scheme().temp_documents().keys() == {"tmpabcde"}
 
@@ -99,7 +97,7 @@ def test_the_cache_expires_when_the_file_changes(tmp_path, monkeypatch):
     """Keyed on the stat rather than reset by hand, so a writer that forgets
     to invalidate cannot serve a stale identity."""
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007", number=42)
+    path = doc(root, "FXL-007", number=42)
     assert scheme().number_of(path) == 42
     import os
     path.write_text(path.read_text().replace("number: 42", "number: 43"))
@@ -111,7 +109,7 @@ def test_the_cache_expires_when_the_file_changes(tmp_path, monkeypatch):
 
 def test_a_disagreement_is_a_finding(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007", number=42)
+    doc(root, "FXL-007", number=42)
     errors: list[str] = []
     lint.check_numbers(errors)
     assert len(errors) == 1
@@ -120,7 +118,7 @@ def test_a_disagreement_is_a_finding(tmp_path, monkeypatch):
 
 def test_agreement_is_silent(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007", number=7)
+    doc(root, "FXL-007", number=7)
     errors: list[str] = []
     lint.check_numbers(errors)
     assert errors == []
@@ -130,7 +128,7 @@ def test_an_absent_field_is_not_a_disagreement(tmp_path, monkeypatch):
     """It is the repairable case, and reporting it here would name a finding
     whose remedy is a different command."""
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007")
+    doc(root, "FXL-007")
     errors: list[str] = []
     lint.check_numbers(errors)
     assert errors == []
@@ -140,7 +138,7 @@ def test_an_absent_field_is_not_a_disagreement(tmp_path, monkeypatch):
 
 def test_repair_populates_the_field_from_the_path(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    path = doc(root, "ADR-007")
+    path = doc(root, "FXL-007")
     assert repair.populate_numbers(scheme()) == [path]
     assert "number: 7\n" in path.read_text()
     assert path.read_text().startswith("---\nnumber: 7\n")
@@ -148,14 +146,14 @@ def test_repair_populates_the_field_from_the_path(tmp_path, monkeypatch):
 
 def test_repair_is_idempotent(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch)
-    doc(root, "ADR-007")
+    doc(root, "FXL-007")
     repair.populate_numbers(scheme())
     assert repair.populate_numbers(scheme()) == []
 
 
 def test_repair_leaves_a_temporary_document_alone(tmp_path, monkeypatch):
     root = project(tmp_path, monkeypatch, allocate="merge")
-    path = doc(root, "ADR-tmpabcde")
+    path = doc(root, "FXL-tmpabcde")
     before = path.read_text()
     assert repair.populate_numbers(scheme()) == []
     assert path.read_text() == before
@@ -172,19 +170,19 @@ def test_repair_never_invents_a_number(tmp_path, monkeypatch):
 
 def test_new_writes_the_field(tmp_path, monkeypatch):
     project(tmp_path, monkeypatch)
-    path = new.new_entry("adr", {"title": "First"}, None)
+    path = new.new_entry("fxl", {"title": "First"}, None)
     assert path.read_text().startswith("---\nnumber: 1\n")
     assert scheme().number_of(path) == 1
 
 
 def test_new_leaves_it_out_for_a_merge_allocated_scheme(tmp_path, monkeypatch):
     project(tmp_path, monkeypatch, allocate="merge")
-    path = new.new_entry("adr", {"title": "First"}, None)
+    path = new.new_entry("fxl", {"title": "First"}, None)
     assert "number:" not in path.read_text()
 
 
 def test_write_number_replaces_rather_than_duplicates(tmp_path, monkeypatch):
-    text = "---\nnumber: 3\nstatus: Active\n---\n\n# ADR-003\n"
+    text = "---\nnumber: 3\nstatus: Active\n---\n\n# FXL-003\n"
     out = new.write_number(text, 9)
     assert out.count("number:") == 1
     assert "number: 9" in out
@@ -199,10 +197,10 @@ def test_concretize_writes_the_field_when_it_assigns_the_number(
     """The one moment a merge-allocated document acquires a number at all."""
     from luria import concretize
     root = project(tmp_path, monkeypatch, allocate="merge")
-    doc(root, "ADR-001", number=1)
-    doc(root, "ADR-tmpabcde", title="Landed from a branch")
+    doc(root, "FXL-001", number=1)
+    doc(root, "FXL-tmpabcde", title="Landed from a branch")
     concretize.run()
-    landed = root / "record/decisions.d/ADR-002.md"
+    landed = root / "record/fixtures.d/FXL-002.md"
     assert landed.exists()
     assert "number: 2\n" in landed.read_text()
     assert scheme().number_of(landed) == 2
@@ -212,8 +210,8 @@ def test_unterminated_frontmatter_declares_nothing(tmp_path, monkeypatch):
     """`parse_frontmatter` treats an unclosed block as no frontmatter; reading
     identity has to agree, or the two disagree about what a document says."""
     root = project(tmp_path, monkeypatch)
-    path = write(root, "record/decisions.d/ADR-007.md",
-                 "---\nstatus: Active\nnumber: 42\n\n# ADR-007\n")
+    path = write(root, "record/fixtures.d/FXL-007.md",
+                 "---\nstatus: Active\nnumber: 42\n\n# FXL-007\n")
     assert config._declared_number(path) is None
     assert scheme().number_of(path) == 7
 
@@ -222,8 +220,8 @@ def test_an_indented_number_is_inside_another_field(tmp_path, monkeypatch):
     """A block scalar's continuation lines are indented, so the column-zero
     anchor is what keeps prose out of the identity."""
     root = project(tmp_path, monkeypatch)
-    path = write(root, "record/decisions.d/ADR-007.md",
+    path = write(root, "record/fixtures.d/FXL-007.md",
                  "---\nstatus: Active\nsummary: >-\n  we rejected\n"
-                 "  number: 42\ndate: '2026-01-01'\n---\n\n# ADR-007\n")
+                 "  number: 42\ndate: '2026-01-01'\n---\n\n# FXL-007\n")
     assert config._declared_number(path) is None
     assert scheme().number_of(path) == 7

--- a/tests/test_reserved_prefix.py
+++ b/tests/test_reserved_prefix.py
@@ -1,0 +1,89 @@
+# tests/test_reserved_prefix.py
+"""The fixture namespace, reserved against a project's own schemes (#231).
+
+A test suite has to write codes to test how codes are read, and every code it
+writes is read back by the scanners as a citation. `FX` already answers that
+for a code that should resolve — a remote whose every code points at the note
+saying it is an example (ADR-034). The other half is a code that should
+resolve to NOTHING and be claimed by nobody, which is what a fixture scheme's
+own documents are. The namespace is the guarantee: a project that never
+declares an `FX…` scheme can spell fixture codes in its tests without any of
+them landing in its record.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from luria import config, lint
+
+
+def project(tmp_path, monkeypatch, prefix: str) -> Path:
+    (tmp_path / "luria.toml").write_text(f"""
+[luria]
+issue_url = "https://example.test/issues/{{n}}"
+
+[luria.schemes.{prefix}]
+dir = "record/{prefix.lower()}.d"
+output = "docs/{prefix.lower()}"
+""")
+    monkeypatch.setenv("LURIA_ROOT", str(tmp_path))
+    config.reset()
+    return tmp_path
+
+
+def errors_for(tmp_path, monkeypatch, prefix: str) -> list[str]:
+    project(tmp_path, monkeypatch, prefix)
+    errors: list[str] = []
+    lint.check_reserved_prefix(errors)
+    return errors
+
+
+# --- the reservation ---------------------------------------------------------
+
+def test_an_ordinary_prefix_is_fine(tmp_path, monkeypatch):
+    assert errors_for(tmp_path, monkeypatch, "ADR") == []
+
+
+def test_the_fixture_prefix_itself_is_refused(tmp_path, monkeypatch):
+    errors = errors_for(tmp_path, monkeypatch, "FXL")
+    assert len(errors) == 1
+    assert "FXL" in errors[0] and "fixture" in errors[0]
+
+
+def test_the_bare_namespace_is_refused(tmp_path, monkeypatch):
+    """`FX` is the remote prefix (ADR-034); a scheme of the same name would
+    make every composed `FX-ADR-032` ambiguous as well."""
+    assert len(errors_for(tmp_path, monkeypatch, "FX")) == 1
+
+
+def test_any_other_name_in_the_namespace_is_refused(tmp_path, monkeypatch):
+    """A migration fixture needs two prefixes at once, so the reservation is a
+    namespace rather than one name — and a namespace has to hold at its edges
+    or the second prefix is invisible only by luck."""
+    assert len(errors_for(tmp_path, monkeypatch, "FXM")) == 1
+
+
+def test_a_prefix_that_merely_starts_with_f_is_fine(tmp_path, monkeypatch):
+    assert errors_for(tmp_path, monkeypatch, "FAQ") == []
+
+
+def test_a_prefix_containing_fx_elsewhere_is_fine(tmp_path, monkeypatch):
+    """The reservation is a leading namespace, not a substring search."""
+    assert errors_for(tmp_path, monkeypatch, "AFX") == []
+
+
+def test_the_finding_names_the_remedy(tmp_path, monkeypatch):
+    """A scheme that already has documents is renamed by `rename_scheme`
+    (ADR-040), not by hand — the finding has to say so, because the obvious
+    reading of "pick another prefix" is to edit the config and orphan the
+    filenames."""
+    errors = errors_for(tmp_path, monkeypatch, "FXL")
+    assert "rename_scheme" in errors[0]
+
+
+# --- it runs as part of the lint ---------------------------------------------
+
+def test_the_check_is_wired_into_the_run(tmp_path, monkeypatch):
+    import inspect
+    assert "check_reserved_prefix(errors)" in inspect.getsource(lint.run)


### PR DESCRIPTION
Closes #231.

Your comment settled the design: *"just define a non-remote fixture scheme as well."* Implemented, with one widening — the reservation is a **namespace**, not a single name, because `tests/test_migrations.py` renames a scheme and so needs two prefixes in the same fixture. With one reserved name the second falls back to `GP`, which is safe here only because nobody has declared it, and depending on luck is the thing this removes.

## What changed

**`FX` is reserved at the leading prefix.** No project declares a scheme whose prefix begins with it. `FXL` is the local fixture scheme by convention, `FXM` the second where one is needed, and any other `FX…` name is available for the same purpose. `AFX` is untouched — the match is on the leading prefix, not a substring. `luria lint` refuses a declared scheme in the namespace (`check_reserved_prefix`), naming `rename_scheme` as the remedy for a scheme that already has documents.

**Three `unlinted-file:` directives deleted, none added.** `tests/test_number.py`, `tests/test_alias_inference.py` and `tests/test_migrations.py` now declare `FXL`/`FXM` instead of `ADR`, `LIT` and `DP`/`GP`. The reference report's opt-out section now reads *"None. Every scanned file is checked. ✅"*; 1,038 lines of test file return to reference checking, and `luria lint` gains no finding from the removal.

Nothing else about those suites changed. They still build real scheme configs in `tmp_path`, so the local-code path — a bare `FXL-004`, a temp `FXL-tmpabcde`, an alias template, a `rename_scheme` across two prefixes — is exercised exactly as before. That is why this is a *scheme* reservation and not a second remote: a remote code is composed (`FX-ADR-032`) and exercises the remote path, which is not the path these suites test.

## What the measurement actually said

Deleting the three directives cold produced **three** new findings, not the flood I expected: `ADR-007` (Superseded, 14 sites), `ADR-tmpabcde`, `DP-018`.

That number is the trap. The other fixture codes in those files — `DP-4`, `DP-004`, `DP-1`, and the composed `LU-DP-004` — were **silent because they resolved**, counted as citations of real documents by a suite that meant nothing of the kind. The loud findings were the safe ones.

`tests/test_alias_inference.py` turned out to need no directive at all: its `LIT-…` spellings match nothing here, because this project has no `LIT` scheme. Invisible by luck again.

## The guard, fired once on the real case

Adding `[luria.schemes.FXL]` to this project's own `luria.toml` produced the violation — **and**, in the same run, made ten fixture codes across 96 citation sites start reporting as dangling. The hazard, demonstrated rather than argued.

It could not go where it belongs on first reading. A config-load refusal is self-defeating: fixture projects declare `FXL` on purpose, so it would break the mechanism it protects. It runs in `lint.run()`, and is only harmless there because the suites call individual `check_*` functions.

## Two things I did not do

- **`tests/test_edges.py` is not covered, and shouldn't be.** It asserts about the real corpus (`assert {("ADR-007", "ADR-035"), ("ADR-010", "ADR-011")} <= succession`), so its codes are genuine citations. Its `inactive-ok-file:` stays.
- **No `FX` → `FXR` rename.** The eight sites include two dated devlog entries — observations that stand — and the bodies of ADR-014, ADR-034 and ADR-072, which would need version bumps for a spelling. `FX` reads as the namespace's own name, and the namespace is forward-compatible if you want the rename later.

## Filed with the work

- [`ADR-tmpgody7`](https://github.com/dmarx/luria/blob/claude/fxl-local-fixtures-e6evzh/record/decisions.d/ADR-tmpgody7.md) — the decision, with the rejected alternatives (grammar masking, one name, per-site directives, load-time refusal, the `FXR` rename).
- A devlog entry, including a trap worth having written down: **backticks do not mask a reference-status citation, and that is on purpose.** `ref_status.scan()` is deliberately unmasked; CLAUDE.md's "codes in backticks are mentions" is true of the *fixer*, not the *report*.
- A changelog fragment, and the `FXL`/`FXM` half of `docs/directives.md` § Fixture codes.

`python -m pytest tests -q`: 1107 passed. `luria lint`: identical to `main`, minus the three opt-outs.

Generated views are not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_