### PR TITLE
Promote seven decisions to Active

### DIFF
--- a/luria/derive.py
+++ b/luria/derive.py
@@ -228,8 +228,6 @@ class _Probe(dict):
         return ""
 
 
-# inactive-ok-block: ADR-087 — Proposed, from the same plan; cited for the
-# capability it added, not as settled evidence
 def value(meta: dict, rule: Derived, resolve=None):
     """The derived value for one document, or None when the template cannot
     be filled.

--- a/record/changelog.d/20260911-023537.md
+++ b/record/changelog.d/20260911-023537.md
@@ -1,0 +1,10 @@
+### Changed
+
+- Seven decisions move from `Proposed` to `Active`: [ADR-084](record/decisions.d/ADR-084.md) (a relation
+  declares its converse), [ADR-085](record/decisions.d/ADR-085.md) (status is an ordinary controlled
+  vocabulary), [ADR-086](record/decisions.d/ADR-086.md) (a marked region carries a derived fact in the README),
+  [ADR-087](record/decisions.d/ADR-087.md) (identity is a field), [ADR-088](record/decisions.d/ADR-088.md) (a derived alias is kept, a former
+  spelling rewritten), [ADR-090](record/decisions.d/ADR-090.md) (the block below a directive is a syntactic
+  unit) and [ADR-091](record/decisions.d/ADR-091.md) (a stack of pull requests lands from the tip). Each is
+  implemented and in use; the status was the scaffold default nobody had gone
+  back to change. [ADR-089](record/decisions.d/ADR-089.md) and [ADR-092](record/decisions.d/ADR-092.md) stay `Proposed`.

--- a/record/decisions.d/ADR-084.md
+++ b/record/decisions.d/ADR-084.md
@@ -25,7 +25,7 @@ number: 84
 # like `summary:`, so a code in it is a citation. When the
 # choice stands and only a REASON was wrong, correct this body in place and
 # bump `version:` below — the rule objects to silent revision, not to editing.
-status: Proposed
+status: Active
 formerly:
 - ADR-tmphedn4
 

--- a/record/decisions.d/ADR-085.md
+++ b/record/decisions.d/ADR-085.md
@@ -25,7 +25,7 @@ number: 85
 # like `summary:`, so a code in it is a citation. When the
 # choice stands and only a REASON was wrong, correct this body in place and
 # bump `version:` below — the rule objects to silent revision, not to editing.
-status: Proposed
+status: Active
 formerly:
 - ADR-tmpv6jcf
 

--- a/record/decisions.d/ADR-086.md
+++ b/record/decisions.d/ADR-086.md
@@ -1,6 +1,6 @@
 ---
 number: 86
-status: Proposed
+status: Active
 formerly:
 - ADR-tmp2rbag
 title: 'A marked region is how the README carries a derived fact'

--- a/record/decisions.d/ADR-087.md
+++ b/record/decisions.d/ADR-087.md
@@ -1,6 +1,6 @@
 ---
 number: 87
-status: Proposed
+status: Active
 formerly:
 - ADR-tmp9ljfi
 title: 'Identity is a field; the filename is a projection of it'

--- a/record/decisions.d/ADR-088.md
+++ b/record/decisions.d/ADR-088.md
@@ -1,6 +1,6 @@
 ---
 number: 88
-status: Proposed
+status: Active
 formerly:
 - ADR-tmp1643l
 title: 'A derived alias is kept; a former spelling is rewritten'
@@ -69,7 +69,6 @@ Three constraints fall out and are enforced:
 - **Canonicalize aliases in the fixer, like every other spelling.** The
   consistent choice, and it defeats the feature: the readable identifier
   would survive exactly until someone ran `luria link --fix`.
-<!-- inactive-ok: ADR-087 — Proposed as step 1 of this same plan; the rule it states is what this decision rests on -->
 - **Derive the code itself rather than an alias.** Rejected in [ADR-087](ADR-087.md):
   a value may participate in identity only if it is recomputed, and may only
   be recomputed if it is not identity.

--- a/record/decisions.d/ADR-089.md
+++ b/record/decisions.d/ADR-089.md
@@ -96,7 +96,6 @@ Two parts are load-bearing:
   case in hand, `last` fell out for free, and the closed set is a starting
   point rather than a ceiling. The general form is planned rather than
   forbidden: one template vocabulary over `str.format`, which luria already
-  <!-- inactive-ok: ADR-088 — Proposed alongside this, from the same plan; cited for what it built, not as settled evidence -->
   uses for URIs and now for aliases ([ADR-088](ADR-088.md)), with `derive` folding into it.
 - **Keep `exactly-one` and add a `primary:` field people write.** Solves the
   reading problem and keeps the writing problem — two fields saying one thing,

--- a/record/decisions.d/ADR-090.md
+++ b/record/decisions.d/ADR-090.md
@@ -1,6 +1,6 @@
 ---
 number: 90
-status: Proposed
+status: Active
 formerly:
 - ADR-tmpk3eyn
 title: 'The block below a directive is a syntactic unit, read from a grammar when one is installed'

--- a/record/decisions.d/ADR-091.md
+++ b/record/decisions.d/ADR-091.md
@@ -1,6 +1,6 @@
 ---
 number: 91
-status: Proposed
+status: Active
 formerly:
 - ADR-tmp8tcfw
 title: 'A stack of pull requests lands from the tip'


### PR DESCRIPTION
`Proposed` → `Active` for seven decisions that shipped and never had their status changed back from the scaffold default:

| | |
|---|---|
| ADR-084 | A relation declares its converse; symmetry is the self-converse case |
| ADR-085 | Status is an ordinary controlled vocabulary; a built-in is a declaration nobody wrote |
| ADR-086 | A marked region is how the README carries a derived fact |
| ADR-087 | Identity is a field; the filename is a projection of it |
| ADR-088 | A derived alias is kept; a former spelling is rewritten |
| ADR-090 | The block below a directive is a syntactic unit, read from a grammar when one is installed |
| ADR-091 | A stack of pull requests lands from the tip |

ADR-089 and ADR-092 stay `Proposed`.

## Three directives went with them

Each existed *only* because the document it named was Proposed, and the lint reported all three as no longer applying the moment the statuses changed:

- `luria/derive.py:231` — `inactive-ok-block: ADR-087 — Proposed, from the same plan`
- `record/decisions.d/ADR-088.md:72` — `inactive-ok: ADR-087 — Proposed as step 1 of this same plan`
- `record/decisions.d/ADR-089.md:99` — `inactive-ok: ADR-088 — Proposed alongside this`

Deleted rather than reworded: with the cited decision Active there is nothing left to acknowledge.

## Effect on the lint

The retired-citation warning section disappears entirely — ADR-085 was its only remaining entry. Pending decisions falls from 9 undecided to 2.

`python -m pytest tests -q`: 1107 passed. Generated views are not in this branch.

Unrelated and still standing on `main`: three directives naming `DP-017`, which resolves (`luria/doc_refs.py:38`, `luria/migrate.py:58`, `record/decisions.d/ADR-046.md:51`). Left alone — clearing them needs a judgement about whether the directive or the annotation is the wrong half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP4P3m8rzVFb8idnTE4FfT)_