### PR TITLE
lint: reject HTML comments and duplicate keys in YAML frontmatter

### DIFF
--- a/luria/frontmatter_shape.py
+++ b/luria/frontmatter_shape.py
@@ -1,0 +1,51 @@
+"""Frontmatter shape checks that PyYAML's default loader will not raise.
+
+PyYAML treats a line that opens with `<!--` as a mapping key and keeps the
+last of two identical keys. Quartz (and other strict YAML parsers) reject
+both, so `luria lint` used to report a document clean while the downstream
+Pages build went red (#164).
+"""
+
+from __future__ import annotations
+
+
+def frontmatter_raw(text: str) -> str | None:
+    """The YAML block between the opening and closing `---` fences, or None
+    when the document has no well-formed frontmatter. Kept as raw text so a
+    check can see what PyYAML silently rewrites."""
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        return None
+    return text[4:end + 1]
+
+
+def check(errors: list[str], rel: str, text: str) -> None:
+    """Reject HTML comments and duplicate mapping keys in YAML frontmatter."""
+    block = frontmatter_raw(text)
+    if block is None:
+        return
+    seen: dict[str, int] = {}
+    for line in block.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("<!--"):
+            errors.append(
+                f"{rel}: HTML comment in YAML frontmatter — use a `#` "
+                f"comment (PyYAML treats `<!--` as a mapping key)")
+        # Top-level mapping keys only: unindented, not a YAML `#` comment
+        # or a list item, and carrying a colon. Nested keys are indented.
+        if (not line or line[0].isspace() or stripped.startswith("#")
+                or stripped.startswith("-")):
+            continue
+        if ":" not in line:
+            continue
+        key = line.split(":", 1)[0].rstrip()
+        if not key:
+            continue
+        seen[key] = seen.get(key, 0) + 1
+    for key, count in seen.items():
+        if count > 1:
+            errors.append(
+                f"{rel}: duplicate frontmatter key {key!r} "
+                f"(PyYAML keeps the last value; strict parsers reject it)")

--- a/luria/frontmatter_shape.py
+++ b/luria/frontmatter_shape.py
@@ -29,7 +29,10 @@ def check(errors: list[str], rel: str, text: str) -> None:
     seen: dict[str, int] = {}
     for line in block.splitlines():
         stripped = line.lstrip()
-        if stripped.startswith("<!--"):
+        # Column 0 is what makes PyYAML treat `<!--` as a mapping key.
+        # An indented `<!--` inside a folded scalar (e.g. `summary: >-`)
+        # is legal content and must stay silent.
+        if line.startswith("<!--"):
             errors.append(
                 f"{rel}: HTML comment in YAML frontmatter — use a `#` "
                 f"comment (PyYAML treats `<!--` as a mapping key)")

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -50,7 +50,8 @@ import re
 import sys
 
 from . import adr_index as builder
-from . import (adr_pending, badges, chains, ci, contract, doc_refs, journal, referents,
+from . import (adr_pending, badges, chains, ci, contract, doc_refs, frontmatter_shape,
+               journal, referents,
                link_targets, narrow_titles, pins, ref_status, remotes,
                relations, sources, statuses, templates)
 from . import aliases as aliases_mod
@@ -103,7 +104,9 @@ def check_frontmatter(errors: list[str]) -> None:
         for path in [*scheme.documents().values(),
                      *scheme.temp_documents().values()]:
             rel = cfg.rel(path)
-            meta, body = builder.parse_frontmatter(path.read_text(encoding="utf-8"))
+            text = path.read_text(encoding="utf-8")
+            frontmatter_shape.check(errors, rel, text)
+            meta, body = builder.parse_frontmatter(text)
             if not meta:
                 errors.append(f"{rel}: no YAML frontmatter (see _template.md)")
                 continue

--- a/record/changelog.d/20260911-043500.md
+++ b/record/changelog.d/20260911-043500.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `luria lint` now rejects HTML comments (`<!-- ... -->`) and duplicate
+  mapping keys in YAML frontmatter. PyYAML accepts both (treating `<!--`
+  as a key and keeping the last of two identical keys); Quartz and other
+  strict parsers reject the file, so a document that looked clean locally
+  could fail the downstream Pages build ([#164](https://github.com/dmarx/luria/issues/164)).
+  Use a `#` comment instead.

--- a/record/devlog.d/2026/09/11/054100.md
+++ b/record/devlog.d/2026/09/11/054100.md
@@ -1,0 +1,20 @@
+---
+title: 'Lint only column-0 HTML comments in YAML frontmatter'
+created: '2026-09-11T05:41:00'
+tags: []
+---
+
+[#164](https://github.com/dmarx/luria/issues/164) is the Pages-build miss:
+PyYAML treats a frontmatter line that *opens* with `<!--` as a mapping key
+and keeps the last of two identical keys, while Quartz rejects both. The
+first cut of the lint check stripped leading whitespace before looking for
+`<!--`, which would also flag an indented comment inside a folded scalar
+such as `summary: >-`.
+
+That spelling is legal YAML content. Column 0 is what makes PyYAML invent a
+key; an indented `<!--` is just text. No live vault entry used that shape
+when the check landed, but the first one that does is likely to be the
+entry that explains this bug.
+
+The check now uses `line.startswith("<!--")`. A `#` comment still stays
+silent. Duplicate unindented keys are unchanged.

--- a/tests/test_frontmatter_shape.py
+++ b/tests/test_frontmatter_shape.py
@@ -43,3 +43,16 @@ def test_duplicate_frontmatter_key_is_reported(project):
         "title: 'A decision'\nsource: LIT-141\nsource: LIT-142\n"))
     errors = errors_for(project)
     assert any("duplicate frontmatter key 'source'" in e for e in errors), errors
+
+
+def test_indented_html_comment_in_folded_scalar_is_clean(project):
+    """An indented `<!--` is content, not a mapping key."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\n"
+        "summary: >-\n"
+        "  An entry explaining this bug may itself contain\n"
+        "  <!-- a comment that is not a key -->\n"))
+    assert errors_for(project) == []

--- a/tests/test_frontmatter_shape.py
+++ b/tests/test_frontmatter_shape.py
@@ -1,0 +1,45 @@
+"""HTML comments and duplicate keys in YAML frontmatter (#164).
+
+PyYAML's default loader accepts both; Quartz rejects them. The check has
+to look at the raw fence, not the parsed dict.
+"""
+from luria import lint
+from tests import _scheme
+
+
+def errors_for(project) -> list[str]:
+    found: list[str] = []
+    lint.check_frontmatter(found)
+    return found
+
+
+def test_html_comment_in_frontmatter_is_reported(project):
+    """PyYAML accepts `<!-- ... -->` as a mapping key; Quartz does not."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\n<!-- inactive-ok: LIT-141 — predecessor -->\n"))
+    errors = errors_for(project)
+    assert any("HTML comment in YAML frontmatter" in e for e in errors), errors
+
+
+def test_hash_comment_in_frontmatter_is_clean(project):
+    """The intended spelling after #163: a YAML `#` comment is not a key."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\n# inactive-ok: LIT-141 — predecessor\n"))
+    assert errors_for(project) == []
+
+
+def test_duplicate_frontmatter_key_is_reported(project):
+    """PyYAML keeps the last value; a strict loader rejects the file."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\nsource: LIT-141\nsource: LIT-142\n"))
+    errors = errors_for(project)
+    assert any("duplicate frontmatter key 'source'" in e for e in errors), errors


### PR DESCRIPTION
## Summary

`luria lint` now rejects two frontmatter shapes that PyYAML accepts and Quartz rejects:

1. A frontmatter line that opens with `<!--` (treated as a mapping key by PyYAML).
2. Duplicate top-level mapping keys (PyYAML keeps the last value).

A YAML `#` comment is still allowed. List items and nested keys are not treated as top-level keys.

## Motivation

Fixes #164. A practice in anthology-of-the-sota had `<!-- inactive-ok: … -->` written into YAML frontmatter. `luria lint` reported the file clean; Quartz failed the Pages build with `duplicated mapping key`.

## Implementation

- New helper `luria/frontmatter_shape.py` inspects the raw `---` block before `yaml.safe_load`.
- `check_frontmatter` runs that helper on every scheme document (including temp documents).
- Changelog fragment under `record/changelog.d/`.

Repair of `<!-- inactive-ok -->` to `# inactive-ok` is not included; the issue listed that as optional.

## Testing

```
pip install -e ".[dev]"
python -m pytest tests/test_frontmatter_shape.py tests/test_lint.py tests/test_examples.py tests/test_statuses.py -q
```

Result: 138 passed (after the list-item false-positive on `- version:` was fixed).

Also ran the three new tests in isolation: all passed.
