### PR TITLE
lint: reject duplicate frontmatter keys structurally

### DIFF
--- a/luria/frontmatter_shape.py
+++ b/luria/frontmatter_shape.py
@@ -8,6 +8,41 @@ Pages build went red (#164).
 
 from __future__ import annotations
 
+import yaml
+
+
+class DuplicateKeyError(yaml.YAMLError):
+    """A YAML mapping repeats a key that SafeLoader would overwrite."""
+
+    def __init__(self, key) -> None:
+        self.key = key
+        super().__init__(f"duplicate key {key!r}")
+
+
+class StrictLoader(yaml.SafeLoader):
+    """SafeLoader with a duplicate-mapping-key check at every depth."""
+
+
+def no_duplicates(loader, node, deep=False):
+    """Raise before SafeLoader silently collapses a duplicate mapping key."""
+    seen = set()
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            hash(key)
+        except TypeError:
+            # Preserve SafeLoader's existing ConstructorError for a mapping
+            # key that YAML cannot make hashable.
+            return yaml.SafeLoader.construct_mapping(loader, node, deep)
+        if key in seen:
+            raise DuplicateKeyError(key)
+        seen.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+
+StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicates)
+
 
 def frontmatter_raw(text: str) -> str | None:
     """The YAML block between the opening and closing `---` fences, or None
@@ -26,9 +61,7 @@ def check(errors: list[str], rel: str, text: str) -> None:
     block = frontmatter_raw(text)
     if block is None:
         return
-    seen: dict[str, int] = {}
     for line in block.splitlines():
-        stripped = line.lstrip()
         # Column 0 is what makes PyYAML treat `<!--` as a mapping key.
         # An indented `<!--` inside a folded scalar (e.g. `summary: >-`)
         # is legal content and must stay silent.
@@ -36,19 +69,13 @@ def check(errors: list[str], rel: str, text: str) -> None:
             errors.append(
                 f"{rel}: HTML comment in YAML frontmatter — use a `#` "
                 f"comment (PyYAML treats `<!--` as a mapping key)")
-        # Top-level mapping keys only: unindented, not a YAML `#` comment
-        # or a list item, and carrying a colon. Nested keys are indented.
-        if (not line or line[0].isspace() or stripped.startswith("#")
-                or stripped.startswith("-")):
-            continue
-        if ":" not in line:
-            continue
-        key = line.split(":", 1)[0].rstrip()
-        if not key:
-            continue
-        seen[key] = seen.get(key, 0) + 1
-    for key, count in seen.items():
-        if count > 1:
-            errors.append(
-                f"{rel}: duplicate frontmatter key {key!r} "
-                f"(PyYAML keeps the last value; strict parsers reject it)")
+    try:
+        yaml.load(block, Loader=StrictLoader)
+    except DuplicateKeyError as error:
+        errors.append(
+            f"{rel}: duplicate frontmatter key {error.key!r} "
+            f"(PyYAML keeps the last value; strict parsers reject it)")
+    except yaml.YAMLError:
+        # Let the existing SafeLoader call report or preserve all other YAML
+        # behavior. This check only widens it for silent duplicate keys.
+        pass

--- a/luria/lint.py
+++ b/luria/lint.py
@@ -322,7 +322,9 @@ def check_journals(errors: list[str]) -> None:
             if path.name == "_template.md":
                 continue
             rel = cfg.rel(path)
-            meta, _ = builder.parse_frontmatter(path.read_text(encoding="utf-8"))
+            text = path.read_text(encoding="utf-8")
+            frontmatter_shape.check(errors, rel, text)
+            meta, _ = builder.parse_frontmatter(text)
             created = journal.parse_created(meta.get("created"))
             if created is None:
                 # An inferrable field names its own remedy (#33); one with no

--- a/record/changelog.d/20260911-175601.md
+++ b/record/changelog.d/20260911-175601.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `luria lint` now detects duplicate YAML frontmatter keys at every mapping
+  depth, including quoted and unquoted spellings of the same key. The check
+  now also covers journal entries, so they cannot pass locally and fail in a
+  strict downstream parser ([#240](https://github.com/dmarx/luria/issues/240)).

--- a/record/devlog.d/2026/09/11/175602.md
+++ b/record/devlog.d/2026/09/11/175602.md
@@ -1,0 +1,24 @@
+---
+title: 'Detect duplicate frontmatter keys structurally'
+created: '2026-09-11T17:56:02'
+tags: []
+---
+
+[#240](https://github.com/dmarx/luria/issues/240) follows the first
+frontmatter-shape check from [#239](https://github.com/dmarx/luria/issues/239).
+Its raw line scan could see only literal, unindented duplicate spellings.
+PyYAML therefore still silently collapsed both a plain `title:` followed by a
+quoted `"title":`, and a repeated key in a nested mapping. A strict downstream
+parser rejects either document.
+
+The duplicate check now uses a `SafeLoader` subclass that raises while it
+constructs any mapping. This keeps the HTML-comment check textual — PyYAML
+still treats that line as a valid key — while comparing duplicate keys through
+the parser's own construction rules. A loader error other than the new
+duplicate-key finding is left for the existing normal loader, so this check
+does not change its behavior for unrelated malformed or recursive YAML.
+
+Journal entries had been parsed directly in `check_journals`, skipping this
+shape check entirely. They now pass through the same raw-text check before
+their normal frontmatter parse. Tests cover the two missed duplicate forms and
+a journal entry, alongside the prior HTML-comment coverage.

--- a/tests/test_frontmatter_shape.py
+++ b/tests/test_frontmatter_shape.py
@@ -4,6 +4,7 @@ PyYAML's default loader accepts both; Quartz rejects them. The check has
 to look at the raw fence, not the parsed dict.
 """
 from luria import lint
+from luria import frontmatter_shape
 from tests import _scheme
 
 
@@ -43,6 +44,35 @@ def test_duplicate_frontmatter_key_is_reported(project):
         "title: 'A decision'\nsource: LIT-141\nsource: LIT-142\n"))
     errors = errors_for(project)
     assert any("duplicate frontmatter key 'source'" in e for e in errors), errors
+
+
+def test_quoted_duplicate_frontmatter_key_is_reported(project):
+    """Quoted and plain spellings construct the same YAML key."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\n\"title\": 'A replacement'\n"))
+    errors = errors_for(project)
+    assert any("duplicate frontmatter key 'title'" in e for e in errors), errors
+
+
+def test_nested_duplicate_frontmatter_key_is_reported(project):
+    """A duplicate inside a mapping is as lossy as a top-level one."""
+    path = _scheme.decision(project, 1, "Active", title="A decision")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'A decision'\n",
+        "title: 'A decision'\nmeta:\n  name: first\n  name: second\n"))
+    errors = errors_for(project)
+    assert any("duplicate frontmatter key 'name'" in e for e in errors), errors
+
+
+def test_nonhashable_mapping_key_is_left_to_the_normal_loader():
+    """The duplicate check must not replace SafeLoader's YAML error."""
+    errors: list[str] = []
+    frontmatter_shape.check(errors, "invalid.md", "---\n? [a]\n: value\n---\n")
+    assert errors == []
 
 
 def test_indented_html_comment_in_folded_scalar_is_clean(project):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -171,6 +171,17 @@ def test_the_template_is_exempt(project):
     assert journal_errors(project) == []
 
 
+def test_a_journal_entry_with_a_duplicate_frontmatter_key_is_reported(project):
+    """Journals use frontmatter too, so they share the shape check (#240)."""
+    path = entry(journal_project(project), "2026/08/03/211926")
+    text = path.read_text()
+    path.write_text(text.replace(
+        "title: 'An entry'\n",
+        "title: 'An entry'\n\"title\": 'A replacement'\n"))
+    errors = journal_errors(project)
+    assert any("duplicate frontmatter key 'title'" in e for e in errors), errors
+
+
 # ── `version:` agrees with `history:` (ADR-019) ──────────────────────────
 
 


### PR DESCRIPTION
Closes #240

## Summary

- Replace the top-level line heuristic with a SafeLoader-based check that detects duplicate mapping keys at every depth, including quoted and unquoted equivalents.
- Preserve the raw-text HTML-comment check, because PyYAML accepts that shape as a key.
- Apply the same shape check to journal entries before their normal frontmatter parse.
- Preserve SafeLoader handling for non-duplicate malformed YAML, including unhashable mapping keys.
- Add the required changelog and devlog source entries without modifying generated views.

## Testing

- .venv/bin/python -m pytest tests -q: 1082 passed, 33 skipped
- .venv/bin/luria lint: docs lint clean
- .venv/bin/python -m compileall -q luria tests
- git diff --check

The duplicate loader raises on the first duplicate key, matching the issue proposal; all other YAML parse errors continue through the existing normal parser.