### PR TITLE
Take the graph keys back out, and test that a setting is read

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -322,18 +322,6 @@ logo_dark = "assets/brand/lockup-inverted.svg"   # optional
 light = "#f4f1e8"                      # any of Quartz's colour names
 ```
 
-A project that would rather show a graph it designed than the page-link
-one Quartz draws points at the export:
-
-```toml
-graph        = "docs/graphs/architecture.json"   # strata-g graph data
-graph_height = "320px"                           # optional
-```
-
-Set, that graph replaces `Component.Graph` on every page — one curated map
-of the project, the same everywhere, rather than a neighbourhood computed
-per page. Unset, Quartz's local graph is what the site keeps.
-
 `logo_dark` is only needed when the artwork can't invert itself. A logo
 whose SVG exposes a `--luria-ink` custom property — the convention this
 project's own kit uses — is re-inked to the theme automatically, and one
@@ -350,9 +338,6 @@ that doesn't is used as it is in both modes.
 | `logo` | `Path \| None` | *unset* |
 | `logo_dark` | `Path \| None` | *unset* |
 | `theme` | `dict` | *unset* |
-| `graph` | `Path \| None` | *unset* |
-| `graph_height` | `str` | `"320px"` |
-| `graph_depth` | `int` | `1` |
 
 ## Environment variables
 

--- a/luria/config.py
+++ b/luria/config.py
@@ -155,12 +155,6 @@ DEFAULTS: dict = {
         "logo": "",
         "logo_dark": "",
         "theme": {},
-        # A graph the project designed itself, shown in place of Quartz's.
-        # Empty means Quartz's local graph, which is the default.
-        "graph": "",
-        "graph_height": "320px",
-        # Hops from the page's own node. 0 shows the whole graph on every page.
-        "graph_depth": 1,
     },
 }
 
@@ -1504,16 +1498,6 @@ class Site:
         [luria.site.theme.light]
         light = "#f4f1e8"                      # any of Quartz's colour names
 
-    A project that would rather show a graph it designed than the page-link
-    one Quartz draws points at the export:
-
-        graph        = "docs/graphs/architecture.json"   # strata-g graph data
-        graph_height = "320px"                           # optional
-
-    Set, that graph replaces `Component.Graph` on every page — one curated map
-    of the project, the same everywhere, rather than a neighbourhood computed
-    per page. Unset, Quartz's local graph is what the site keeps.
-
     `logo_dark` is only needed when the artwork can't invert itself. A logo
     whose SVG exposes a `--luria-ink` custom property — the convention this
     project's own kit uses — is re-inked to the theme automatically, and one
@@ -1530,15 +1514,6 @@ class Site:
     logo: Path | None = None
     logo_dark: Path | None = None
     theme: dict = field(default_factory=dict)
-    # A graph the project laid out itself, exported from strata-g as
-    # `Canvas — graph data (JSON)`. Set, it is shown on every page IN PLACE OF
-    # Quartz's local graph; unset, Quartz's is what the site keeps.
-    graph: Path | None = None
-    graph_height: str = "320px"
-    # How much of the configured graph each page shows: hops from that page's
-    # own node. 1 is its immediate neighbourhood; 0 is the whole graph, which
-    # is the same picture everywhere.
-    graph_depth: int = 1
 
 
 @dataclass(frozen=True)
@@ -2233,9 +2208,6 @@ def _site(raw: dict, root: Path) -> Site:
         logo=root / spec["logo"] if spec.get("logo") else None,
         logo_dark=root / spec["logo_dark"] if spec.get("logo_dark") else None,
         theme=spec.get("theme", {}) or {},
-        graph=root / spec["graph"] if spec.get("graph") else None,
-        graph_height=spec.get("graph_height") or "320px",
-        graph_depth=int(spec.get("graph_depth", 1)),
     )
 
 

--- a/record/changelog.d/claude-drop-unused-graph-keys.md
+++ b/record/changelog.d/claude-drop-unused-graph-keys.md
@@ -1,0 +1,14 @@
+### Removed
+
+- **`[luria.site] graph`, `graph_height` and `graph_depth` are gone**, having
+  never done anything. They reached `main` as schema without an implementation:
+  documented in the configuration reference, accepted in `luria.toml`, parsed
+  into a `Path`, and read by nothing. A project that set `graph` got its
+  Quartz local graph and no explanation. They return with the code that
+  implements them.
+
+### Added
+
+- A test that a `[luria.site]` setting is read by something. A key in the
+  schema publishes itself into the generated reference, so an unimplemented
+  one looks exactly like a working feature from the outside.

--- a/tests/test_config_consumers.py
+++ b/tests/test_config_consumers.py
@@ -1,0 +1,66 @@
+"""A key in the schema is a promise; something has to keep it.
+
+`docs/configuration.md` is generated from the dataclasses, so adding a field
+to `Site` publishes a documented, defaulted, parsed setting with no further
+work — including, if nobody notices, one that nothing reads. That is worse
+than an undocumented feature: the reference tells a reader to set `graph`,
+`luria.toml` accepts it, `config.load` parses it into a `Path`, and the site
+comes out exactly as it would have without it. Nothing fails, so nothing
+says so.
+
+It happened here. #245's branch carried `graph`, `graph_height` and
+`graph_depth` across from the stack that implements them, and main shipped
+the whole surface — DEFAULTS entry, dataclass field, docstring, `_site()`
+reader, reference row — with no `luria/site_graph.py` behind it.
+
+The check is deliberately crude: a field is *consumed* if some module other
+than `config.py` mentions it on a receiver named `site`, which is how every
+real reader spells it (`site.icon`, `cfg.site.publish`,
+`current().site.base_url`). Crude is the point — it is the cheapest thing
+that would have caught the mistake, and a reader sophisticated enough to
+follow a dynamic lookup would also be sophisticated enough to miss this.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+
+from luria.config import Site
+
+LURIA = Path(__file__).resolve().parent.parent / "luria"
+
+
+def _consumers() -> dict[str, list[str]]:
+    """Each `Site` field → the modules that read it off a `site` receiver."""
+    sources = {p.name: p.read_text(encoding="utf-8")
+               for p in LURIA.rglob("*.py") if p.name != "config.py"}
+    return {f.name: sorted(name for name, text in sources.items()
+                           if re.search(rf"\bsite\.{f.name}\b", text))
+            for f in dataclasses.fields(Site)}
+
+
+def test_every_site_setting_is_read_by_something():
+    found = _consumers()
+    unread = sorted(name for name, mods in found.items() if not mods)
+    assert not unread, (
+        f"[luria.site] {', '.join(unread)} appear(s) in the schema and the "
+        "generated reference, but no module reads it. Either wire the "
+        "setting up or take it out — a documented key that does nothing is "
+        "a promise the tool does not keep.")
+
+
+def test_the_check_can_tell_a_read_field_from_an_unread_one():
+    """The positive control. `_consumers()` returning "everything is fine"
+    because its pattern matches nothing is the failure mode that would make
+    the test above worthless, so prove the instrument moves: a field that is
+    genuinely read is found, and an invented one is not."""
+    found = _consumers()
+    assert found["base_url"], "base_url is read all over the tree and was not found"
+    assert "site.py" in found["icon"], found["icon"]
+
+    sources = {p.name: p.read_text(encoding="utf-8")
+               for p in LURIA.rglob("*.py") if p.name != "config.py"}
+    invented = [name for name, text in sources.items()
+                if re.search(r"\bsite\.nothing_reads_this\b", text)]
+    assert invented == [], "the pattern matched a field that does not exist"


### PR DESCRIPTION
`main` currently documents three `[luria.site]` settings that do nothing.

## What is wrong

`graph`, `graph_height` and `graph_depth` are on `main` as a complete config surface with no implementation behind it: a `DEFAULTS` entry, a `Site` dataclass field, a docstring paragraph, a `_site()` reader, and a row each in the configuration reference. There is no `luria/site_graph.py` here and `site.py` imports none, so a project that sets

```toml
[luria.site]
graph = "docs/graphs/architecture.json"
```

gets its Quartz local graph and no explanation. Nothing errors, nothing warns — the key is parsed into a `Path` and then never looked at.

**They arrived by accident.** [#245](https://github.com/dmarx/luria/pull/245) was lifted out of the [#242](https://github.com/dmarx/luria/pull/242) → [#243](https://github.com/dmarx/luria/pull/243) → [#244](https://github.com/dmarx/luria/pull/244) stack as an isolated change, and its branch carried this hunk across with the `cite` work it was actually for. `git log -S graph_depth -- luria/config.py` names `bd5448d` and nothing else.

## Why nothing caught it

`docs/configuration.md` is generated from these dataclasses, which is the right design and is also what hid this: **a field publishes its own reference row whether or not any code reads it.** From outside, an unimplemented setting and a working one are the same thing — documented, defaulted, accepted — until somebody tries it.

So the check is the interesting half of this PR. A `Site` field counts as consumed if some module other than `config.py` names it on a receiver called `site`:

| | |
|---|---|
| `site.icon`, `cfg.site.publish`, `current().site.base_url` | how all nine real readers spell it |
| `graph`, `graph_height`, `graph_depth` | no match anywhere |

Crude on purpose. It is the cheapest rule that separates the nine from these three, and on `main` it fails naming exactly the three. A cleverer check that followed dynamic lookups would also be a check nobody trusts the output of.

**Its positive control sits next to it**, because the way this test becomes worthless is a pattern that matches nothing and reports the tree clean: one assertion that a field which *is* read (`base_url`, `icon`) is found, one that an invented field is not. An earlier draft used a bare `\.<field>\b` and "found" a consumer for `graph` — it had matched `edges.graph()`, which is a different thing entirely.

## This is now the bottom of the stack

The keys come back with the code that implements them, and the stack has been rebased onto this branch so that happens in the right place:

| | reintroduces | alongside |
|---|---|---|
| [#243](https://github.com/dmarx/luria/pull/243) | `graph`, `graph_height` | `luria/site_graph.py` and the layout swap that read them |
| [#244](https://github.com/dmarx/luria/pull/244) | `graph_depth` | the ego-neighbourhood slicing that reads it |

Each key is now introduced by the commit that consumes it, which is where it should have been all along — and the guard test rides along underneath, passing at every step, which is the evidence that it permits a key with an implementation while refusing one without.

Nothing else on this record mentions them, and `docs/configuration.md` loses its rows without being edited, from the schema.

## Verification

Per branch, `python -m pytest -q` and `luria lint`:

| branch | tests | lint |
|---|---|---|
| this one | 1118 passed, 33 skipped | docs clean |
| [#242](https://github.com/dmarx/luria/pull/242) | 1141 passed, 33 skipped | docs clean |
| [#243](https://github.com/dmarx/luria/pull/243) | 1152 passed, 33 skipped | docs clean |
| [#244](https://github.com/dmarx/luria/pull/244) | 1155 passed, 33 skipped | docs clean |

The new test fails on `main` as it stands, with the message it would have shown in September:

```
[luria.site] graph, graph_depth, graph_height appear(s) in the schema and the
generated reference, but no module reads it. Either wire the setting up or take
it out — a documented key that does nothing is a promise the tool does not keep.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSRQzpm4kAWQSaKWD6V9x2